### PR TITLE
Child Module of Dynamic Module.

### DIFF
--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -1042,7 +1042,11 @@ Exit:
     else if (dmfObject != NULL)
     {
         ASSERT(! dmfObject->DynamicModule);
-        if (DmfModuleAttributes->DynamicModule)
+        // If this Module is a Dynamic Module or it is an immediate or non-immediate Child
+        // of a Dynamic Module, open it now if it it should be opened during Create.
+        //
+        if ((DmfModuleAttributes->DynamicModule) ||
+            (DMF_IsTopParentDynamicModule(dmfObject)))
         {
             // Remember it is Dynamic Module so it can be automatically closed prior to destruction.
             // (Client no longer has access to Open/Close API.)

--- a/Dmf/Framework/DmfHelpers.c
+++ b/Dmf/Framework/DmfHelpers.c
@@ -291,6 +291,51 @@ Return Value:
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
+BOOLEAN
+DMF_IsTopParentDynamicModule(
+    _In_ DMF_OBJECT* DmfObject
+    )
+/*++
+
+Routine Description:
+
+    Given a DMF_OBJECT determine if its root parent DMF_OBJECT refers to a Dynamic Module.
+    (Determines if the given Module a child, either immediate or not, of a Dynamic Module.)
+
+Arguments:
+
+    DmfObject - The given DMF_OBJECT.
+
+Return Value:
+
+    TRUE - The given Module is a child of a Dynamic Module, immediate or not.
+    FALSE - The given Module is not a child of a Dynamic Module, immediate or not.
+
+--*/
+{
+    BOOLEAN returnValue;
+
+    // Find the root Parent Module. (Its DmfObjectParent is NULL.)
+    //
+    while (DmfObject->DmfObjectParent != NULL)
+    {
+        DmfObject = DmfObject->DmfObjectParent;
+    }
+
+    // Determine if this root Parent Module is a Dynamic Module.
+    //
+    if (DmfObject->DynamicModule)
+    {
+        returnValue = TRUE;
+    }
+    else
+    {
+        returnValue = FALSE;
+    }
+
+    return returnValue;
+}
+
 #pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -442,8 +442,11 @@ DMF_ModuleLiveKernelDump_ModuleCollectionInitialize(
 // DmfHelpers.h
 //
 
-// TODO: This should not be here.
-//
+BOOLEAN
+DMF_IsTopParentDynamicModule(
+    _In_ DMF_OBJECT* DmfObject
+    );
+
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_SynchronizationCreate(


### PR DESCRIPTION
Correct issue where Child Modules that are ancestors of Dynamic Modules were not opened.