### PR TITLE
Add WPP tracing to the samples.

### DIFF
--- a/DmfSamples/SwitchBar/trace.h
+++ b/DmfSamples/SwitchBar/trace.h
@@ -18,51 +18,31 @@ Environment:
 
 #pragma once
 
-//
 // Define the tracing flags.
-// Tracing GUID - {BAE674B7-AB79-4320-B120-06D2C25916BA}
+// Tracing GUIDs:
+//
+// Client Driver - {296D475F-89B6-4470-B943-023A0BEAFD04}
+//
+// NOTE: Every driver must define a unique GUID otherwise tracing from multiple drivers
+//       that use the same GUID will appear.
+//
+// DMF           - {83029B7A-5AE6-4672-A171-32C6695B8735}
 //
 
 #define WPP_CONTROL_GUIDS                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                            \
-        SwitchBarTraceGuid, (BAE674B7,AB79,4320,B120,06D2C25916BA),                     \
-        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
-        WPP_DEFINE_BIT(TRACE_DRIVER)                                                    \
-        )                                                                               \
    WPP_DEFINE_CONTROL_GUID(                                                             \
-        SurfaceLibraryTraceGuid, (5C357B96,1DC8,4DB3,A4BB,7CB7E4434728),                \
-        WPP_DEFINE_BIT(DMF_TRACE_DeviceInterfaceTarget)                                 \
+        DmfTraceGuid, (83029B7A,5AE6,4672,A171,32C6695B8735),                           \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
+        )                                                                               \
+    WPP_DEFINE_CONTROL_GUID(                                                            \
+        SwitchBarTraceGuid, (296D475F,89B6,4470,B943,023A0BEAFD04),                     \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
+        WPP_DEFINE_BIT(TRACE_DEVICE)                                                    \
+        WPP_DEFINE_BIT(TRACE_CALLBACK)                                                  \
         )                                                                               \
 
-//
-// This comment block is scanned by the trace preprocessor to define our
-// Trace function.
-//
-// USEPREFIX and USESUFFIX strip all trailing whitespace, so we need to surround
-// FuncExit messages with brackets 
-//
-// begin_wpp config
-// FUNC Trace{FLAG=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
-// FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
-// FUNC FuncEntry{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC FuncEntryArguments{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExit{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitVoid{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC TraceError{LEVEL=TRACE_LEVEL_ERROR}(FLAGS, MSG, ...);
-// FUNC TraceInformation{LEVEL=TRACE_LEVEL_INFORMATION}(FLAGS, MSG, ...);
-// FUNC TraceVerbose{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitNoReturn{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// USEPREFIX(FuncEntry, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncEntryArguments, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncExit, "%!STDPREFIX! [%!FUNC!] <-- Exit <");
-// USESUFFIX(FuncExit, ">");
-// USEPREFIX(FuncExitVoid, "%!STDPREFIX! [%!FUNC!] <-- Exit");
-// USEPREFIX(TraceError, "%!STDPREFIX! [%!FUNC!] ERROR:");
-// USEPREFIX(TraceEvents, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceInformation, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceVerbose, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(FuncExitNoReturn, "%!STDPREFIX! [%!FUNC!] <--");
-// end_wpp
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) WPP_LEVEL_LOGGER(flags)
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level  >= lvl)
 
 // eof: Trace.h
 //

--- a/DmfSamples/SwitchBar2/DmfInterface.c
+++ b/DmfSamples/SwitchBar2/DmfInterface.c
@@ -118,6 +118,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     // Switches have changed. Read them. (Wait until the switch is read.)
     //
     ntStatus = DMF_DeviceInterfaceTarget_SendSynchronously(DmfModuleDeviceInterfaceTarget,
@@ -155,11 +157,11 @@ Return Value:
 
 Exit:
     ;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 
 #pragma code_seg("PAGE")
-_Function_class_(EVT_WDF_WORKITEM)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -187,6 +189,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
+
     // Get the address where the DMFMODULE is located.
     //
     dmfModuleAddressDeviceInterfaceTarget = WdfObjectGet_DMFMODULE(Workitem);
@@ -196,6 +200,8 @@ Return Value:
     SwitchBarReadSwitchesAndUpdateLightBar(*dmfModuleAddressDeviceInterfaceTarget);
 
     WdfObjectDelete(Workitem);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 
@@ -243,11 +249,14 @@ Return Value:
     UNREFERENCED_PARAMETER(OutputBufferSize);
     UNREFERENCED_PARAMETER(ClientBufferContextOutput);
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC! CompletionStatus=%!STATUS!", CompletionStatus);
+
     if (!NT_SUCCESS(CompletionStatus))
     {
         // This will happen when OSR FX2 board is unplugged.
         //
         returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: stop");
         goto Exit;
     }
 
@@ -276,13 +285,13 @@ Return Value:
     // Continue streaming this IOCTL.
     //
     returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndContinueStreaming;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: continue");
 
 Exit:
 
     return returnValue;
 }
 
-static
 VOID
 SwitchBar_OnDeviceArrivalNotification(
     _In_ DMFMODULE DmfModule
@@ -303,6 +312,8 @@ Return Value:
 
 --*/
 {
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     // Dmf_ContinousRequestTarget has been set to start automatically, so it is not started here.
     // Also, the PreClose callback is not necessary.
     //
@@ -311,6 +322,8 @@ Return Value:
     // any switches have been changed.
     //
     SwitchBarReadSwitchesAndUpdateLightBar(DmfModule);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 
 #pragma code_seg("PAGED")
@@ -324,7 +337,7 @@ DmfDeviceModulesAdd(
 
 Routine Description:
 
-    Add all the Dmf Modules used by this driver.
+    Add all the DMF Modules used by this driver.
 
 Arguments:
 
@@ -345,15 +358,17 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "-->%!FUNC!");
+
     // DeviceInterfaceTarget
     // ---------------------
     //
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_OSRUSBFX2;
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 4;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 1;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(SWITCH_STATE);
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 4;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPoolNx;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_OSRUSBFX2_GET_INTERRUPT_MESSAGE;
@@ -378,5 +393,7 @@ Return Value:
                      &moduleAttributes,
                      WDF_NO_OBJECT_ATTRIBUTES,
                      NULL);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "<--%!FUNC!");
 }
 

--- a/DmfSamples/SwitchBar2/trace.h
+++ b/DmfSamples/SwitchBar2/trace.h
@@ -18,51 +18,31 @@ Environment:
 
 #pragma once
 
-//
 // Define the tracing flags.
-// Tracing GUID - {BAE674B7-AB79-4320-B120-06D2C25916BA}
+// Tracing GUIDs:
+//
+// Client Driver - {E72837CC-1F19-4B2F-86AF-5CB7D0B768F4}
+//
+// NOTE: Every driver must define a unique GUID otherwise tracing from multiple drivers
+//       that use the same GUID will appear.
+//
+// DMF           - {433274DE-89F9-459D-A89B-E81B4AE2FAEE}
 //
 
 #define WPP_CONTROL_GUIDS                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                            \
-        SwitchBarTraceGuid, (BAE674B7,AB79,4320,B120,06D2C25916BA),                     \
-        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
-        WPP_DEFINE_BIT(TRACE_DRIVER)                                                    \
-        )                                                                               \
    WPP_DEFINE_CONTROL_GUID(                                                             \
-        SurfaceLibraryTraceGuid, (5C357B96,1DC8,4DB3,A4BB,7CB7E4434728),                \
-        WPP_DEFINE_BIT(DMF_TRACE_DeviceInterfaceTarget)                                 \
+        DmfTraceGuid, (433274DE,89F9,459D,A89B,E81B4AE2FAEE),                           \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
+        )                                                                               \
+    WPP_DEFINE_CONTROL_GUID(                                                            \
+        SwitchBarTraceGuid, (E72837CC,1F19,4B2F,86AF,5CB7D0B768F4),                     \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
+        WPP_DEFINE_BIT(TRACE_DEVICE)                                                    \
+        WPP_DEFINE_BIT(TRACE_CALLBACK)                                                  \
         )                                                                               \
 
-//
-// This comment block is scanned by the trace preprocessor to define our
-// Trace function.
-//
-// USEPREFIX and USESUFFIX strip all trailing whitespace, so we need to surround
-// FuncExit messages with brackets 
-//
-// begin_wpp config
-// FUNC Trace{FLAG=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
-// FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
-// FUNC FuncEntry{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC FuncEntryArguments{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExit{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitVoid{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC TraceError{LEVEL=TRACE_LEVEL_ERROR}(FLAGS, MSG, ...);
-// FUNC TraceInformation{LEVEL=TRACE_LEVEL_INFORMATION}(FLAGS, MSG, ...);
-// FUNC TraceVerbose{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitNoReturn{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// USEPREFIX(FuncEntry, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncEntryArguments, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncExit, "%!STDPREFIX! [%!FUNC!] <-- Exit <");
-// USESUFFIX(FuncExit, ">");
-// USEPREFIX(FuncExitVoid, "%!STDPREFIX! [%!FUNC!] <-- Exit");
-// USEPREFIX(TraceError, "%!STDPREFIX! [%!FUNC!] ERROR:");
-// USEPREFIX(TraceEvents, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceInformation, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceVerbose, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(FuncExitNoReturn, "%!STDPREFIX! [%!FUNC!] <--");
-// end_wpp
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) WPP_LEVEL_LOGGER(flags)
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level  >= lvl)
 
 // eof: Trace.h
 //

--- a/DmfSamples/SwitchBar3/README.md
+++ b/DmfSamples/SwitchBar3/README.md
@@ -44,8 +44,10 @@ Module Name:
 
 Abstract:
 
-    Loads as a filter driver on OSRFX2 driver. When it does, reads changes to switch state and sets
-    lightbar on the board to match switch settings.
+    SwitchBar3 Sample: Loads as a filter driver on OSRFX2 driver. When it does, reads changes to 
+                       switch state and sets lightbar on the board to match switch settings. This 
+                       sample sets up a default WDFIOQUEUE so it can examine all the IOCTLs from
+                       the application.
 
 Environment:
 
@@ -67,7 +69,7 @@ Environment:
 #include "Trace.h"
 #include "DmfInterface.tmh"
 
-// DMF: These lines provide default DriverEntry/DeviceAdd/DriverCleanup functions.
+// DMF: These lines provide default DriverEntry/AddDevice/DriverCleanup functions.
 //
 DRIVER_INITIALIZE DriverEntry;
 EVT_WDF_DRIVER_DEVICE_ADD SwitchBarEvtDeviceAdd;
@@ -85,9 +87,15 @@ DMF_DEFAULT_DRIVERENTRY(DriverEntry,
 
 typedef struct
 {
+    // Handle to DMF_DefaultTarget:
+    // It supports communication to the next driver down the stack.
+    //_
     DMFMODULE DmfModuleDefaultTarget;
 } DEVICE_CONTEXT, *PDEVICE_CONTEXT;
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, DeviceContextGet)
+
+#pragma code_seg("PAGED")
+DMF_DEFAULT_DRIVERCLEANUP(SwitchBarEvtDriverContextCleanup)
 
 _Use_decl_annotations_
 NTSTATUS
@@ -108,6 +116,8 @@ SwitchBarEvtDeviceAdd(
     UNREFERENCED_PARAMETER(Driver);
 
     PAGED_CODE();
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "-->%!FUNC!");
 
     dmfDeviceInit = DMF_DmfDeviceInitAllocate(DeviceInit);
 
@@ -203,6 +213,8 @@ Exit:
         DMF_DmfDeviceInitFree(&dmfDeviceInit);
     }
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC! ntStatus=%!STATUS!", ntStatus);
+
     return ntStatus;
 }
 #pragma code_seg()
@@ -268,6 +280,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     // Switches have changed. Read them. (Wait until the switch is read.)
     //
     ntStatus = DMF_DefaultTarget_SendSynchronously(DmfModuleDefaultTarget,
@@ -305,11 +319,11 @@ Return Value:
 
 Exit:
     ;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 
 #pragma code_seg("PAGE")
-_Function_class_(EVT_WDF_WORKITEM)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -337,6 +351,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
+
     // Get the address where the DMFMODULE is located.
     //
     dmfModuleAddressDefaultTarget = WdfObjectGet_DMFMODULE(Workitem);
@@ -346,6 +362,8 @@ Return Value:
     SwitchBarReadSwitchesAndUpdateLightBar(*dmfModuleAddressDefaultTarget);
 
     WdfObjectDelete(Workitem);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 
@@ -393,11 +411,14 @@ Return Value:
     UNREFERENCED_PARAMETER(OutputBufferSize);
     UNREFERENCED_PARAMETER(ClientBufferContextOutput);
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC! CompletionStatus=%!STATUS!", CompletionStatus);
+
     if (!NT_SUCCESS(CompletionStatus))
     {
         // This will happen when OSR FX2 board is unplugged: Stop streaming.
         // 
         returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: stop");
         goto Exit;
     }
 
@@ -426,6 +447,7 @@ Return Value:
     // Continue streaming this IOCTL.
     //
     returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndContinueStreaming;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: continue");
 
 Exit:
 
@@ -443,7 +465,7 @@ DmfDeviceModulesAdd(
 
 Routine Description:
 
-    Add all the Dmf Modules used by this driver.
+    Add all the DMF Modules used by this driver.
 
 Arguments:
 
@@ -464,6 +486,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     deviceContext = DeviceContextGet(Device);
 
     // Dmf_DefaultTarget allows the driver to talk to the next driver in the stack. In this case, it is the driver that
@@ -475,9 +499,9 @@ Return Value:
     //
     DMF_CONFIG_DefaultTarget_AND_ATTRIBUTES_INIT(&moduleConfigDefaultTarget,
                                                  &moduleAttributes);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 4;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 1;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(SWITCH_STATE);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 4;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPoolNx;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_OSRUSBFX2_GET_INTERRUPT_MESSAGE;
@@ -497,6 +521,8 @@ Return Value:
                      &moduleAttributes,
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &deviceContext->DmfModuleDefaultTarget);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 
 NTSTATUS
@@ -508,7 +534,7 @@ SwitchBarEvtDeviceD0Entry(
 
 Routine Description:
 
-    When the device powers up, read the switches and set the lightbar appropriatetely.
+    When the device powers up, read the switches and set the lightbar appropriately.
  
 Arguments:
 
@@ -528,6 +554,8 @@ Return Value:
 
     UNREFERENCED_PARAMETER(PreviousState);
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "-->%!FUNC!");
+
     deviceContext = DeviceContextGet(Device);
 
     // Read the state of switches and initialize lightbar.
@@ -536,9 +564,12 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "<--%!FUNC!");
+
     return ntStatus;
 }
 
+#pragma code_seg("PAGE")
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
@@ -553,7 +584,8 @@ SwitchBarModuleDeviceIoControl(
 
 Routine Description:
 
-    Template callback for ModuleDeviceIoControl for a given DMF Module.
+    Filters IOCTLs that come through the stack. All IOCTLs are passed through except for the IOCTL
+    that sets the lightbar.
 
 Arguments:
 
@@ -566,8 +598,7 @@ Arguments:
 
 Return Value:
 
-    If this Module handles the IOCTL (it recognizes it), returns TRUE.
-    If this Module does not recognize the IOCTL, returns FALSE.
+    None
 
 --*/
 {
@@ -578,8 +609,20 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     switch (IoControlCode)
     {
+        case IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY:
+        {
+            // Filter out setting the Bar Graph Display.
+            // Don't let application know or the application will end.
+            //
+            WdfRequestComplete(Request,
+                               STATUS_SUCCESS);
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY filtered out");
+            break;
+        }
         case IOCTL_OSRUSBFX2_GET_CONFIG_DESCRIPTOR:
         case IOCTL_OSRUSBFX2_RESET_DEVICE:
         case IOCTL_OSRUSBFX2_REENUMERATE_DEVICE:
@@ -588,6 +631,7 @@ Return Value:
         case IOCTL_OSRUSBFX2_SET_7_SEGMENT_DISPLAY:
         case IOCTL_OSRUSBFX2_READ_SWITCHES:
         case IOCTL_OSRUSBFX2_GET_INTERRUPT_MESSAGE:
+        default:
         {
             WDFDEVICE device;
             WDFIOTARGET ioTarget;
@@ -616,25 +660,10 @@ Return Value:
             }
             break;
         }
-        case IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY:
-        {
-            // Filter out setting the Bar Graph Display.
-            // Don't let application know or the application will error out.
-            //
-            WdfRequestComplete(Request,
-                               STATUS_SUCCESS);
-            break;
-        }
-        default:
-        {
-            // We don't know this IOCTL. Complete the Request with an error.
-            //
-            WdfRequestComplete(Request,
-                               STATUS_NOT_SUPPORTED);
-            break;
-        }
     }
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
+#pragma code_seg()
 ```
 Annotated Code Tour
 ===================
@@ -707,38 +736,53 @@ SwitchBarEvtDeviceAdd(
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "-->%!FUNC!");
+
     dmfDeviceInit = DMF_DmfDeviceInitAllocate(DeviceInit);
 
     // Tell WDF this callback should be called.
     //
     WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&pnpPowerCallbacks);
     pnpPowerCallbacks.EvtDeviceD0Entry = SwitchBarEvtDeviceD0Entry;
-    // Tell DMF to intercept PnP callback, then route them to this driver.
+
+    // All DMF drivers must call this function even if they do not support PnP Power callbacks.
+    // (In this case, this driver does support a PnP Power callback.)
     //
     DMF_DmfDeviceInitHookPnpPowerEventCallbacks(dmfDeviceInit,
                                                 &pnpPowerCallbacks);
     WdfDeviceInitSetPnpPowerEventCallbacks(DeviceInit,
                                            &pnpPowerCallbacks);
 
+    // All DMF drivers must call this function even if they do not support File Object callbacks.
+    //
     DMF_DmfDeviceInitHookFileObjectConfig(dmfDeviceInit,
                                           NULL);
-
+    // All DMF drivers must call this function even if they do not support Power Policy callbacks.
+    //
     DMF_DmfDeviceInitHookPowerPolicyEventCallbacks(dmfDeviceInit,
                                                    NULL);
 
+    // Set any device attributes needed.
+    //
     WdfDeviceInitSetDeviceType(DeviceInit,
                                FILE_DEVICE_UNKNOWN);
     WdfDeviceInitSetExclusive(DeviceInit,
                               FALSE);
-    // This is a filter driver that loads on OSRFX2 driver.
-    // Only use this driver of the DMF version of the OSR driver.
+
+    // This is a filter driver that loads on OSRUSBFX2 driver.
     //
     WdfFdoInitSetFilter(DeviceInit);
+    // DMF Client drivers that are filter drivers must also make this call.
+    //
     DMF_DmfFdoSetFilter(dmfDeviceInit);
 
+    // Define a device context type.
+    //
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&objectAttributes, 
                                             DEVICE_CONTEXT);
 
+    // Create the Client driver's WDFDEVICE.
+    //
     ntStatus = WdfDeviceCreate(&DeviceInit,
                                &objectAttributes,
                                &device);
@@ -747,9 +791,15 @@ SwitchBarEvtDeviceAdd(
         goto Exit;
     }
 
+    // This driver will filter IOCTLS, so set up a default queue.
+    //
     WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig,
                                            WdfIoQueueDispatchSequential);
     queueConfig.EvtIoDeviceControl = SwitchBarModuleDeviceIoControl;
+
+    // When a DMF Client driver creates a default queue, it must also make this call.
+    // This call is not needed if the Client driver does not create a default queue.
+    //
     DMF_DmfDeviceInitHookQueueConfig(dmfDeviceInit,
                                      &queueConfig);
 
@@ -762,6 +812,8 @@ SwitchBarEvtDeviceAdd(
         goto Exit;
     }
 
+    // Create the DMF Modules this Client driver will use.
+    //
     dmfCallbacks.EvtDmfDeviceModulesAdd = DmfDeviceModulesAdd;
     DMF_DmfDeviceInitSetEventCallbacks(dmfDeviceInit,
                                        &dmfCallbacks);
@@ -780,8 +832,11 @@ Exit:
         DMF_DmfDeviceInitFree(&dmfDeviceInit);
     }
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC! ntStatus=%!STATUS!", ntStatus);
+
     return ntStatus;
 }
+#pragma code_seg()
 ```
 In the above function note these important calls:
 ```
@@ -896,6 +951,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     // Switches have changed. Read them. (Wait until the switch is read.)
     //
     ntStatus = DMF_DefaultTarget_SendSynchronously(DmfModuleDefaultTarget,
@@ -933,6 +990,7 @@ Return Value:
 
 Exit:
     ;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 ```
@@ -942,7 +1000,6 @@ function to read switches and set the lightbar, then it deletes the associated W
 
 ```
 #pragma code_seg("PAGE")
-_Function_class_(EVT_WDF_WORKITEM)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -970,6 +1027,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
+
     // Get the address where the DMFMODULE is located.
     //
     dmfModuleAddressDefaultTarget = WdfObjectGet_DMFMODULE(Workitem);
@@ -979,6 +1038,8 @@ Return Value:
     SwitchBarReadSwitchesAndUpdateLightBar(*dmfModuleAddressDefaultTarget);
 
     WdfObjectDelete(Workitem);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
 #pragma code_seg()
 ```
@@ -1043,11 +1104,14 @@ Return Value:
     UNREFERENCED_PARAMETER(OutputBufferSize);
     UNREFERENCED_PARAMETER(ClientBufferContextOutput);
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC! CompletionStatus=%!STATUS!", CompletionStatus);
+
     if (!NT_SUCCESS(CompletionStatus))
     {
         // This will happen when OSR FX2 board is unplugged: Stop streaming.
         // 
         returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: stop");
         goto Exit;
     }
 
@@ -1076,6 +1140,7 @@ Return Value:
     // Continue streaming this IOCTL.
     //
     returnValue = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndContinueStreaming;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! Streaming: continue");
 
 Exit:
 
@@ -1108,7 +1173,7 @@ DmfDeviceModulesAdd(
 
 Routine Description:
 
-    Add all the Dmf Modules used by this driver.
+    Add all the DMF Modules used by this driver.
 
 Arguments:
 
@@ -1129,6 +1194,8 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     deviceContext = DeviceContextGet(Device);
 
     // Dmf_DefaultTarget allows the driver to talk to the next driver in the stack. In this case, it is the driver that
@@ -1140,9 +1207,9 @@ Return Value:
     //
     DMF_CONFIG_DefaultTarget_AND_ATTRIBUTES_INIT(&moduleConfigDefaultTarget,
                                                  &moduleAttributes);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 4;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 1;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(SWITCH_STATE);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 4;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPoolNx;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_OSRUSBFX2_GET_INTERRUPT_MESSAGE;
@@ -1162,8 +1229,9 @@ Return Value:
                      &moduleAttributes,
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &deviceContext->DmfModuleDefaultTarget);
-}
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
+}
 ```
 Next, is the Client driver's `EvtDeviceD0Entry()` callback. The Client driver needs to support this callback in order to set the state of the lightbar
 correctly when the driver starts (and before the user has changed a switch).
@@ -1201,6 +1269,8 @@ Return Value:
 
     UNREFERENCED_PARAMETER(PreviousState);
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "-->%!FUNC!");
+
     deviceContext = DeviceContextGet(Device);
 
     // Read the state of switches and initialize lightbar.
@@ -1209,6 +1279,8 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "<--%!FUNC!");
+
     return ntStatus;
 }
 ```
@@ -1216,6 +1288,7 @@ The final function in this driver is the function that filters IOCTLs. All the I
 for the IOCTL that sets the lightbar (because the lightbar should only be set based on the state of the switches).
 
 ```
+#pragma code_seg("PAGE")
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
@@ -1255,8 +1328,20 @@ Return Value:
 
     PAGED_CODE();
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "-->%!FUNC!");
+
     switch (IoControlCode)
     {
+        case IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY:
+        {
+            // Filter out setting the Bar Graph Display.
+            // Don't let application know or the application will end.
+            //
+            WdfRequestComplete(Request,
+                               STATUS_SUCCESS);
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "%!FUNC! IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY filtered out");
+            break;
+        }
         case IOCTL_OSRUSBFX2_GET_CONFIG_DESCRIPTOR:
         case IOCTL_OSRUSBFX2_RESET_DEVICE:
         case IOCTL_OSRUSBFX2_REENUMERATE_DEVICE:
@@ -1265,6 +1350,7 @@ Return Value:
         case IOCTL_OSRUSBFX2_SET_7_SEGMENT_DISPLAY:
         case IOCTL_OSRUSBFX2_READ_SWITCHES:
         case IOCTL_OSRUSBFX2_GET_INTERRUPT_MESSAGE:
+        default:
         {
             WDFDEVICE device;
             WDFIOTARGET ioTarget;
@@ -1293,25 +1379,10 @@ Return Value:
             }
             break;
         }
-        case IOCTL_OSRUSBFX2_SET_BAR_GRAPH_DISPLAY:
-        {
-            // Filter out setting the Bar Graph Display.
-            // Don't let application know or the application will error out.
-            //
-            WdfRequestComplete(Request,
-                               STATUS_SUCCESS);
-            break;
-        }
-        default:
-        {
-            // We don't know this IOCTL. Complete the Request with an error.
-            //
-            WdfRequestComplete(Request,
-                               STATUS_NOT_SUPPORTED);
-            break;
-        }
     }
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CALLBACK, "<--%!FUNC!");
 }
+#pragma code_seg()
 ```
 
 Testing the driver

--- a/DmfSamples/SwitchBar3/trace.h
+++ b/DmfSamples/SwitchBar3/trace.h
@@ -18,51 +18,31 @@ Environment:
 
 #pragma once
 
-//
 // Define the tracing flags.
-// Tracing GUID - {BAE674B7-AB79-4320-B120-06D2C25916BA}
+// Tracing GUIDs:
+//
+// Client Driver - {0A41377B-C973-4943-89D8-8253D0BE7CED}
+//
+// NOTE: Every driver must define a unique GUID otherwise tracing from multiple drivers
+//       that use the same GUID will appear.
+//
+// DMF           - {89084538-C6AE-448A-8ADC-55B4B1A0E495}
 //
 
 #define WPP_CONTROL_GUIDS                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                            \
-        SwitchBarTraceGuid, (BAE674B7,AB79,4320,B120,06D2C25916BA),                     \
-        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
-        WPP_DEFINE_BIT(TRACE_DRIVER)                                                    \
-        )                                                                               \
    WPP_DEFINE_CONTROL_GUID(                                                             \
-        SurfaceLibraryTraceGuid, (5C357B96,1DC8,4DB3,A4BB,7CB7E4434728),                \
-        WPP_DEFINE_BIT(DMF_TRACE_DeviceInterfaceTarget)                                 \
+        DmfTraceGuid, (89084538,C6AE,448A,8ADC,55B4B1A0E495),                           \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
+        )                                                                               \
+    WPP_DEFINE_CONTROL_GUID(                                                            \
+        SwitchBarTraceGuid, (0A41377B,C973,4943,89D8,8253D0BE7CED),                     \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
+        WPP_DEFINE_BIT(TRACE_DEVICE)                                                    \
+        WPP_DEFINE_BIT(TRACE_CALLBACK)                                                  \
         )                                                                               \
 
-//
-// This comment block is scanned by the trace preprocessor to define our
-// Trace function.
-//
-// USEPREFIX and USESUFFIX strip all trailing whitespace, so we need to surround
-// FuncExit messages with brackets 
-//
-// begin_wpp config
-// FUNC Trace{FLAG=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
-// FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
-// FUNC FuncEntry{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC FuncEntryArguments{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExit{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitVoid{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC TraceError{LEVEL=TRACE_LEVEL_ERROR}(FLAGS, MSG, ...);
-// FUNC TraceInformation{LEVEL=TRACE_LEVEL_INFORMATION}(FLAGS, MSG, ...);
-// FUNC TraceVerbose{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitNoReturn{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// USEPREFIX(FuncEntry, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncEntryArguments, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncExit, "%!STDPREFIX! [%!FUNC!] <-- Exit <");
-// USESUFFIX(FuncExit, ">");
-// USEPREFIX(FuncExitVoid, "%!STDPREFIX! [%!FUNC!] <-- Exit");
-// USEPREFIX(TraceError, "%!STDPREFIX! [%!FUNC!] ERROR:");
-// USEPREFIX(TraceEvents, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceInformation, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceVerbose, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(FuncExitNoReturn, "%!STDPREFIX! [%!FUNC!] <--");
-// end_wpp
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) WPP_LEVEL_LOGGER(flags)
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level  >= lvl)
 
 // eof: Trace.h
 //

--- a/DmfSamples/SwitchBar4/trace.h
+++ b/DmfSamples/SwitchBar4/trace.h
@@ -18,51 +18,31 @@ Environment:
 
 #pragma once
 
-//
 // Define the tracing flags.
-// Tracing GUID - {BAE674B7-AB79-4320-B120-06D2C25916BA}
+// Tracing GUIDs:
+//
+// Client Driver - {9DE29693-B70E-4028-BA97-42DA7224522E}
+//
+// NOTE: Every driver must define a unique GUID otherwise tracing from multiple drivers
+//       that use the same GUID will appear.
+//
+// DMF           - {94A46978-C450-45B9-8790-5070DA9002F7}
 //
 
 #define WPP_CONTROL_GUIDS                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                            \
-        SwitchBarTraceGuid, (BAE674B7,AB79,4320,B120,06D2C25916BA),                     \
-        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
-        WPP_DEFINE_BIT(TRACE_DRIVER)                                                    \
-        )                                                                               \
    WPP_DEFINE_CONTROL_GUID(                                                             \
-        SurfaceLibraryTraceGuid, (5C357B96,1DC8,4DB3,A4BB,7CB7E4434728),                \
-        WPP_DEFINE_BIT(DMF_TRACE_DeviceInterfaceTarget)                                 \
+        DmfTraceGuid, (94A46978,C450,45B9,8790,5070DA9002F7),                           \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
+        )                                                                               \
+    WPP_DEFINE_CONTROL_GUID(                                                            \
+        SwitchBarTraceGuid, (9DE29693,B70E,4028,BA97,42DA7224522E),                     \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
+        WPP_DEFINE_BIT(TRACE_DEVICE)                                                    \
+        WPP_DEFINE_BIT(TRACE_CALLBACK)                                                  \
         )                                                                               \
 
-//
-// This comment block is scanned by the trace preprocessor to define our
-// Trace function.
-//
-// USEPREFIX and USESUFFIX strip all trailing whitespace, so we need to surround
-// FuncExit messages with brackets 
-//
-// begin_wpp config
-// FUNC Trace{FLAG=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
-// FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
-// FUNC FuncEntry{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC FuncEntryArguments{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExit{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitVoid{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// FUNC TraceError{LEVEL=TRACE_LEVEL_ERROR}(FLAGS, MSG, ...);
-// FUNC TraceInformation{LEVEL=TRACE_LEVEL_INFORMATION}(FLAGS, MSG, ...);
-// FUNC TraceVerbose{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, MSG, ...);
-// FUNC FuncExitNoReturn{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS);
-// USEPREFIX(FuncEntry, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncEntryArguments, "%!STDPREFIX! [%!FUNC!] --> Entry");
-// USEPREFIX(FuncExit, "%!STDPREFIX! [%!FUNC!] <-- Exit <");
-// USESUFFIX(FuncExit, ">");
-// USEPREFIX(FuncExitVoid, "%!STDPREFIX! [%!FUNC!] <-- Exit");
-// USEPREFIX(TraceError, "%!STDPREFIX! [%!FUNC!] ERROR:");
-// USEPREFIX(TraceEvents, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceInformation, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(TraceVerbose, "%!STDPREFIX! [%!FUNC!]");
-// USEPREFIX(FuncExitNoReturn, "%!STDPREFIX! [%!FUNC!] <--");
-// end_wpp
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) WPP_LEVEL_LOGGER(flags)
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level  >= lvl)
 
 // eof: Trace.h
 //


### PR DESCRIPTION
Add WPP tracing to the samples. This shows how to emit WPP tracing from Modules as well as the Client driver.