### PR TITLE
Fix issues related to non-PnP drivers.

### DIFF
--- a/Dmf/Framework/DmfContainer.c
+++ b/Dmf/Framework/DmfContainer.c
@@ -1467,6 +1467,12 @@ Return Value:
         goto Exit;
     }
 
+    // Remember that DMF_Invoke_DeviceCallbacksDestroy() needs to be called before the Module
+    // Collection is destroyed.
+    //
+    DMF_MODULE_COLLECTION* moduleCollection = DMF_CollectionToHandle(dmfDeviceContext->DmfCollection);
+    moduleCollection->ManualDestroyCallbackIsPending = TRUE;
+
     // Dispatch Device Prepare Hardware.
     //
     ntStatus = DmfContainerEvtDevicePrepareHardware(Device,

--- a/Dmf/Framework/DmfContainer.c
+++ b/Dmf/Framework/DmfContainer.c
@@ -1571,6 +1571,12 @@ Return Value:
         goto Exit;
     }
 
+    // Remember that DMF_Invoke_DeviceCallbacksDestroy() has been called before the Module
+    // Collection is destroyed.
+    //
+    DMF_MODULE_COLLECTION* moduleCollection = DMF_CollectionToHandle(dmfDeviceContext->DmfCollection);
+    moduleCollection->ManualDestroyCallbackIsPending = FALSE;
+
 Exit:
 
     FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);

--- a/Dmf/Framework/DmfGeneric.c
+++ b/Dmf/Framework/DmfGeneric.c
@@ -266,7 +266,9 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpened(dmfObject);
+    // This is needed for cases where Module Opens, Close and Opens again.
+    //
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
@@ -405,6 +407,9 @@ Return Value:
         if (dmfObject->ModuleOpenedDuring == ModuleOpenedDuringType_PrepareHardware)
         {
             DMF_Internal_Close(DmfModule);
+            // This is needed for cases where Module Opens, Close and Opens again.
+            //
+            dmfObject->ModuleOpenedDuring = ModuleOpenedDuringType_Invalid;
         }
     }
     else if (DMF_MODULE_OPEN_OPTION_NOTIFY_PrepareHardware == dmfObject->ModuleDescriptor.OpenOption)
@@ -412,6 +417,9 @@ Return Value:
         // This Module's Notification Registration is automatically closed in PrepareHardware.
         //
         DMF_Internal_NotificationUnregister(DmfModule);
+        // This is needed for cases where Module Opens, Close and Opens again.
+        //
+        dmfObject->ModuleNotificationRegisteredDuring = ModuleOpenedDuringType_Invalid;
     }
     else if (dmfObject->ModuleDescriptor.OpenOption < DMF_MODULE_OPEN_OPTION_LAST)
     {
@@ -1783,7 +1791,9 @@ Return Value:
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
 
-    DMF_HandleValidate_IsCreatedOrIsNotify(dmfObject);
+    // This is needed for cases where Module Opens, Close and Opens again.
+    //
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     // This is called during PrepareHardware when the flag is used.
     //

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -292,6 +292,16 @@ struct _DMF_MODULE_COLLECTION_
     // Flags indicating if modules implement WDF callbacks.
     //
     DMF_CALLBACKS_WDF_CHECK DmfCallbacksWdfCheck;
+
+    // Indicates that Client invoked Create callbacks manually.
+    // It is necessary for the case where Module Collection Cleanup callback
+    // is called, but the Client has not had a chance to call the corresponding
+    // Destroy callback. (The Client cannot do so in its parent object Cleanup
+    // callback as that happens after the Module Collection is destroyed since
+    // the Module Collection's Cleanup callback is called first by WDF.
+    //
+    BOOLEAN ManualDestroyCallbackIsPending;
+    WDFDEVICE ClientDevice;
 };
 
 typedef struct _DMF_DEVICE_CONTEXT

--- a/Dmf/Framework/DmfInternal.c
+++ b/Dmf/Framework/DmfInternal.c
@@ -1421,9 +1421,10 @@ Return Value:
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
     TraceInformation(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    // NOTE: In the case where there is no handler, we have to allow "Opened".
+    // NOTE: In the case where there is no handler, allow "Opened".
+    // NOTE: In the cases where Modules are Opened, Closed and Opened again, allow "Closed" state.
     //
-    DMF_HandleValidate_IsCreatedOrOpened(dmfObject);
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     ASSERT(dmfObject->ModuleDescriptor.CallbacksDmf->DeviceResourcesAssign != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksDmf->DeviceResourcesAssign)(DmfModule,
@@ -1469,7 +1470,9 @@ Return Value:
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
     TraceInformation(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpened(dmfObject);
+    // NOTE: In the cases where Modules are Opened, Closed and Opened again, allow "Closed" state.
+    //
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     ASSERT(dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationRegister != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationRegister)(DmfModule);


### PR DESCRIPTION
Fix asserts that happen with calls to DMF_Invoke_DeviceCallbacksCreate/DMF_Invoke_DeviceCallbacksDestroy/DMF_Invoke_DeviceCallbacksCreate.
Automatically call DMF_Invoke_DeviceCallbacksDestroy() when the Client is unable to.