### PR TITLE
Merge20192801

### DIFF
--- a/Dmf/Framework/DmfContainer.c
+++ b/Dmf/Framework/DmfContainer.c
@@ -1372,7 +1372,7 @@ DMF_ContainerFileObjectConfigInit(
     // For filter/miniport drivers we don't know the policy on FileObject usage.
     // Make sure we don't use FsContexts by default, and allow FileObject to be optional.
     //
-    FileObjectConfig->FileObjectClass = WDF_FILEOBJECT_CLASS(WdfFileObjectWdfCannotUseFsContexts | WdfFileObjectCanBeOptional);
+    FileObjectConfig->FileObjectClass = (WDF_FILEOBJECT_CLASS)(WdfFileObjectWdfCannotUseFsContexts | WdfFileObjectCanBeOptional);
 }
 #pragma code_seg()
 

--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -987,21 +987,24 @@ Return Value:
     ASSERT(ModuleState_Invalid == dmfObject->ModuleState);
     dmfObject->ModuleState = ModuleState_Created;
 
-    // Add the Child Module to the list of the Parent Module's children
-    // if its not a Dynamic Module. The lifetime of the Dynamic Module is
-    // managed by the Client. 
-    //
-    if ((childModuleCreate) &&
-        (! DmfModuleAttributes->DynamicModule))
+    if (childModuleCreate)
     {
         ASSERT(dmfObjectParent != NULL);
         ASSERT(dmfModuleParent != NULL);
-        InsertTailList(&dmfObjectParent->ChildObjectList,
-                       &dmfObject->ChildListEntry);
 
-        // Increment the Number of Child Modules.
+        // Add the Child Module to the list of the Parent Module's children
+        // if its not a Dynamic Module. The lifetime of the Dynamic Module is
+        // managed by the Client. 
         //
-        dmfObjectParent->NumberOfChildModules += 1;
+        if (!DmfModuleAttributes->DynamicModule)
+        {
+            InsertTailList(&dmfObjectParent->ChildObjectList,
+                           &dmfObject->ChildListEntry);
+
+            // Increment the Number of Child Modules.
+            //
+            dmfObjectParent->NumberOfChildModules += 1;
+        }
 
         // Save the Parent in the Child.
         //

--- a/Dmf/Framework/DmfDeviceInit.c
+++ b/Dmf/Framework/DmfDeviceInit.c
@@ -92,7 +92,7 @@ typedef struct DMFDEVICE_INIT
 // This is a sentinel for failed allocations. In this way, callers call to allocate always succeeds. It
 // eliminates an if() in all Client drivers.
 //
-DMFDEVICE_INIT g_DmfDefaultDeviceInit = {};
+struct DMFDEVICE_INIT g_DmfDefaultDeviceInit = { 0 };
 
 #pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Framework/DmfHelpers.c
+++ b/Dmf/Framework/DmfHelpers.c
@@ -325,51 +325,6 @@ Return Value:
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-BOOLEAN
-DMF_IsTopParentDynamicModule(
-    _In_ DMF_OBJECT* DmfObject
-    )
-/*++
-
-Routine Description:
-
-    Given a DMF_OBJECT determine if its root parent DMF_OBJECT refers to a Dynamic Module.
-    (Determines if the given Module a child, either immediate or not, of a Dynamic Module.)
-
-Arguments:
-
-    DmfObject - The given DMF_OBJECT.
-
-Return Value:
-
-    TRUE - The given Module is a child of a Dynamic Module, immediate or not.
-    FALSE - The given Module is not a child of a Dynamic Module, immediate or not.
-
---*/
-{
-    BOOLEAN returnValue;
-
-    // Find the root Parent Module. (Its DmfObjectParent is NULL.)
-    //
-    while (DmfObject->DmfObjectParent != NULL)
-    {
-        DmfObject = DmfObject->DmfObjectParent;
-    }
-
-    // Determine if this root Parent Module is a Dynamic Module.
-    //
-    if (DmfObject->DynamicModule)
-    {
-        returnValue = TRUE;
-    }
-    else
-    {
-        returnValue = FALSE;
-    }
-
-    return returnValue;
-}
-
 #pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -493,11 +493,6 @@ DMF_ModuleLiveKernelDump_ModuleCollectionInitialize(
 // DmfHelpers.h
 //
 
-BOOLEAN
-DMF_IsTopParentDynamicModule(
-    _In_ DMF_OBJECT* DmfObject
-    );
-
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_SynchronizationCreate(

--- a/Dmf/Framework/Modules.Core/DmfModules.Core.Trace.h
+++ b/Dmf/Framework/Modules.Core/DmfModules.Core.Trace.h
@@ -19,6 +19,8 @@ Environment:
 
 #pragma once
 
+#include "..\Framework\DmfTrace.h"
+
 // WPP Tracing Support
 //
 #define WPP_CONTROL_GUIDS                                                                                      \

--- a/Dmf/Modules.Library/Dmf_HidTarget.h
+++ b/Dmf/Modules.Library/Dmf_HidTarget.h
@@ -89,7 +89,7 @@ typedef struct
 
 // This macro declares the following functions:
 // DMF_HidTarget_ATTRIBUTES_INIT()
-// DMF_CONFIG_Hid_AND_ATTRIBUTES_INIT()
+// DMF_CONFIG_HidTarget_AND_ATTRIBUTES_INIT()
 // DMF_HidTarget_Create()
 //
 DECLARE_DMF_MODULE(HidTarget)
@@ -158,6 +158,15 @@ _Must_inspect_result_
 NTSTATUS
 DMF_HidTarget_InputRead(
     _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_HidTarget_InputReportGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFMEMORY InputReportMemory,
+    _Out_ ULONG* InputReportLength
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library/Dmf_HidTarget.md
+++ b/Dmf/Modules.Library/Dmf_HidTarget.md
@@ -330,6 +330,9 @@ DMF_HidTarget_InputRead(
 
 Allows the Client to send a "Input Report Read" command to the HID device connected the instance of this Module.
 
+NOTE: This call is asynchronous. Please see comments for DMF_HidTarget_InputReportRead() for
+      more information.
+
 ##### Returns
 
 NTSTATUS
@@ -338,6 +341,40 @@ NTSTATUS
 Parameter | Description
 ----|----
 DmfModule | An open DMF_HidTarget Module handle.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_HidTarget_InputReportGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_HidTarget_InputReportGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFMEMORY InputReportMemory,
+    _Out_ ULONG* InputReportLength
+    )
+````
+
+Synchronously reads an Input Report.
+
+NOTE: This function is not normally used to read Input Reports. Use it only if 
+        the underlying device is known to not asynchronously respond reliably. If 
+        there is no data available within 5 seconds, this call will complete
+        regardless whereas the normally used Method (DMF_HidTarget_InputRead)
+        will continue to wait.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_HidTarget Module handle.
+InputReportMemory | InputReportMemory is the WDFMEMORY returned by DMF_HidTarget_ReportCreate(). (First, call DMF_HidTarget_ReportCreate() to get the handle, then call this function.)
+InputReportLength | Amount of data read from the device.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
1. Correct bug in Dmf_NotifyUserWithRequest where decrement of held Requests happens after Request is returned instead of before. If Client immediately attempts to enqueue a Request in completion routine, it can fail improperly.

2. Correct issue with Dynamic Modules when they are Child Modules so that callbacks can access the Parent Module.
3. Add Method to Dmf_HidTarget to allow Client to read input reports synchronously. This is necessary for some kinds of devices.
4. Minor fixes to make compilation work with more compilers and environments.

NOTE: It is not clear to me why diffs seem to think whole file has changed.