### PR TITLE
Merge20190429:

### DIFF
--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1574,11 +1574,12 @@ DMF_Utility_EventLogEntryWriteUserMode(
 // LIST_ENTRY functions for User-Mode. (These are copied as-is from Wdm.h.
 // Some Modules use LIST_ENTRY. To make those Modules work with both Kernel-mode and User-mode, these
 // definitions are included here.)
+// LIST_ENTRY functions are defined in UMDF starting from v23
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#if defined DMF_USER_MODE
+#if defined(DMF_USER_MODE) && UMDF_VERSION_MINOR < 23
 
 FORCEINLINE
 VOID

--- a/Dmf/Framework/DmfGeneric.c
+++ b/Dmf/Framework/DmfGeneric.c
@@ -1953,8 +1953,12 @@ DMF_Generic_NotificationRegister(
 Routine Description:
 
     Generic callback for NotificationRegister for a given DMF Module. This call can happen if the
-    Client has not set the NotificationRegister callback. (Client may decide to open the Module
-    for any reason, possibly unrelated to PnP, and may not need to support that call.)
+    Client has not set the NotificationRegister callback. NotificationRegister callback is optional
+    only for DMF_MODULE_OPEN_OPTION_NOTIFY_Create. (Client may decide to open the Module
+    for any reason, possibly unrelated to PnP, and may not need to support that call.).
+
+    If Client decides to open the Module in post open callback of a child Module, then the Module will 
+    already be open before this call. 
 
 Arguments:
 
@@ -1974,7 +1978,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s]", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrClosed(dmfObject);
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     FuncExit(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s] ntStatus=%!STATUS!", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName, STATUS_SUCCESS);
 
@@ -1993,8 +1997,8 @@ DMF_Generic_NotificationUnregister(
 Routine Description:
 
     Generic callback for NotificationUnregister for a given DMF Module. This call can happen if the
-    Client has not set the NotificationUnregister callback. (Client may decide to close the Module
-    for any reason, possibly unrelated to PnP, and may not need to support this call.)
+    Client has not set the NotificationUnregister callback. NotificationUnregister is optional. 
+    (Client may decide to close the Module for any reason, possibly unrelated to PnP, and may not need to support this call.)
 
 Arguments:
 

--- a/Dmf/Framework/DmfHelpers.c
+++ b/Dmf/Framework/DmfHelpers.c
@@ -502,16 +502,21 @@ Return Value:
 --*/
 {
     DMF_OBJECT* dmfObjectFeature;
-    DMF_OBJECT* DmfObject;
+    DMF_OBJECT* dmfObject;
     DMFMODULE dmfModuleFeature;
 
-    DmfObject = DMF_ModuleToObject(DmfModule);
-    ASSERT(DmfObject != NULL);
+    dmfObject = DMF_ModuleToObject(DmfModule);
+    ASSERT(dmfObject != NULL);
+    dmfObjectFeature = NULL;
 
-    DMFCOLLECTION dmfCollection = DMF_ObjectToCollection(DmfObject->ModuleCollection);
+    if (dmfObject->ModuleCollection != NULL)
+    {
+        DMFCOLLECTION dmfCollection = DMF_ObjectToCollection(dmfObject->ModuleCollection);
 
-    dmfObjectFeature = DMF_FeatureHandleGetFromModuleCollection(dmfCollection,
-                                                                DmfFeature);
+        dmfObjectFeature = DMF_FeatureHandleGetFromModuleCollection(dmfCollection,
+                                                                    DmfFeature);
+    }
+
     if (dmfObjectFeature != NULL)
     {
         dmfModuleFeature = DMF_ObjectToModule(dmfObjectFeature);
@@ -520,6 +525,7 @@ Return Value:
     else
     {
         // The Client Driver has not enabled this DMF Feature.
+        // Dynamic Modules do not support DMF Features.
         //
         dmfModuleFeature = NULL;
     }

--- a/Dmf/Modules.Library/Dmf_SerialTarget.c
+++ b/Dmf/Modules.Library/Dmf_SerialTarget.c
@@ -993,13 +993,24 @@ Return Value:
     DmfCallbacksDmf_SerialTarget.DeviceResourcesAssign = DMF_SerialTarget_ResourcesAssign;
     DmfCallbacksDmf_SerialTarget.ChildModulesAdd = DMF_SerialTarget_ChildModulesAdd;
 
-    if (moduleConfig->CloseOnHibernate == TRUE)
+    // SerialTarget support multiple open option configurations. 
+    // Choose the open option based on Module config. 
+    //
+    switch (moduleConfig->ModuleOpenOption)
     {
-        openOption = DMF_MODULE_OPEN_OPTION_OPEN_D0EntrySystemPowerUp;
-    }
-    else
-    {
+    case SerialTarget_OpenOption_PrepareHardware:
         openOption = DMF_MODULE_OPEN_OPTION_OPEN_PrepareHardware;
+        break;
+    case SerialTarget_OpenOption_D0EntrySystemPowerUp:
+        openOption = DMF_MODULE_OPEN_OPTION_OPEN_D0EntrySystemPowerUp;
+        break;
+    case SerialTarget_OpenOption_D0Entry:
+        openOption = DMF_MODULE_OPEN_OPTION_OPEN_D0Entry;
+        break;
+    default:
+        ASSERT(FALSE);
+        openOption = DMF_MODULE_OPEN_OPTION_Invalid;
+        break;
     }
 
     DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(DmfModuleDescriptor_SerialTarget,

--- a/Dmf/Modules.Library/Dmf_SerialTarget.h
+++ b/Dmf/Modules.Library/Dmf_SerialTarget.h
@@ -59,6 +59,19 @@ typedef struct
     ULONG SerialWaitMask;
 } SerialTarget_Configuration;
 
+typedef enum
+{
+    // Module is opened in PrepareHardware and closed in ReleaseHardware.
+    //
+    SerialTarget_OpenOption_PrepareHardware = 0,
+    // Module is opened in D0Entry when system transitions from SX to S0.
+    //
+    SerialTarget_OpenOption_D0EntrySystemPowerUp,
+    // Module is opened in D0Entry and closed in D0Exit.
+    //
+    SerialTarget_OpenOption_D0Entry
+} SerialTarget_OpenOption;
+
 // Client Driver callback function to get Configuration parameters.
 //
 typedef
@@ -82,10 +95,9 @@ typedef struct
     // Share Access.
     //
     ULONG ShareAccess;
-    // Module is opened when system power state transitions from SX to S0.
-    // Module is closed when system power state transitions from S0 to SX.
+    // Module's Open option.
     //
-    BOOLEAN CloseOnHibernate;
+    SerialTarget_OpenOption ModuleOpenOption;
     // Child Request Stream Module.
     //
     DMF_CONFIG_ContinuousRequestTarget ContinuousRequestTargetModuleConfig;


### PR DESCRIPTION
Fix ModuleOpen and ModuleClose to not open Child Modules. (This code was not in use and should have been removed during a previous refactoring.)
Fix crash for Dynamic Modules using DMF features. (Using DMF Features from Dynamic Modules will be supported later.)
Update NotificationRegister validation.
Fix ContinuousRequestTarget invalid buffer access when no output buffers are used.