### PR TITLE
Merge20190516

### DIFF
--- a/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
+++ b/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
@@ -662,6 +662,10 @@ Return:
             timerExpirationCallback = bufferPoolEntryTimer->TimerExpirationCallback;
             BufferPool_TimerFieldsClear(dmfModule,
                                         bufferPoolEntryTimer);
+            
+            // The only matching buffer has been found.
+            //
+            break;
         }
 
         // Keep searching.
@@ -2045,8 +2049,10 @@ Return Value:
 
     FuncEntry(DMF_TRACE);
 
-    DMF_HandleValidate_ModuleMethod(DmfModule,
-                                    &DmfModuleDescriptor_BufferPool);
+    // This function is called while the Module is closing as it is flushing its buffers.
+    //
+    DMF_HandleValidate_ClosingOk(DmfModule,
+                                 &DmfModuleDescriptor_BufferPool);
 
     bufferPoolEntry = BufferPool_BufferPoolEntryGetFromClientBuffer(ClientBuffer);
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferPool.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferPool.c
@@ -33,7 +33,7 @@ Environment:
 #define BUFFER_SIZE                 (32)
 #define BUFFER_COUNT_PREALLOCATED   (16)
 #define BUFFER_COUNT_MAX            (24)
-#define THREAD_COUNT                (4)
+#define THREAD_COUNT                (2)
 
 #define CLIENT_CONTEXT_SIGNATURE    'GISB'
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
@@ -41,7 +41,7 @@ Environment:
 #define BUFFER_COUNT_MAX            (24)
 // Number of working threads
 //
-#define THREAD_COUNT                (4)
+#define THREAD_COUNT                (2)
 
 #define CLIENT_CONTEXT_SIGNATURE    'GISB'
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
@@ -30,8 +30,16 @@ Environment:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#define THREAD_COUNT                (2)
-#define MAXIMUM_SLEEP_TIME_MS       (15000)
+#define THREAD_COUNT                            (2)
+#define MAXIMUM_SLEEP_TIME_MS                   (15000)
+// This timeout is necessary for causing asynchronous single requests to complete fast so that
+// driver disable works well (since it is not possible to cancel asynchronous requests at this time.
+// using DMF).
+//
+#define ASYNCHRONOUS_REQUEST_TIMEOUT_MS         (50)
+// Keep synchronous maximum time short to make driver disable faster.
+//
+#define MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS       (1000)
 
 typedef enum _TEST_ACTION
 {
@@ -165,7 +173,7 @@ Tests_DefaultTarget_ThreadAction_Synchronous(
                   sizeof(sleepIoctlBuffer));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 MAXIMUM_SLEEP_TIME_MS);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_DefaultTarget_SendSynchronously(moduleContext->DmfModuleDefaultTargetDispatchInput,
                                                    &sleepIoctlBuffer,
@@ -181,7 +189,7 @@ Tests_DefaultTarget_ThreadAction_Synchronous(
     //
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 MAXIMUM_SLEEP_TIME_MS);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_DefaultTarget_SendSynchronously(moduleContext->DmfModuleDefaultTargetPassiveInput,
                                                    &sleepIoctlBuffer,
@@ -255,7 +263,7 @@ Tests_DefaultTarget_ThreadAction_Asynchronous(
                                       NULL,
                                       ContinuousRequestTarget_RequestType_Ioctl,
                                       IOCTL_Tests_IoctlHandler_SLEEP,
-                                      0,
+                                      ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                       Tests_DefaultTarget_SendCompletion,
                                       NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -270,7 +278,7 @@ Tests_DefaultTarget_ThreadAction_Asynchronous(
                                       NULL,
                                       ContinuousRequestTarget_RequestType_Ioctl,
                                       IOCTL_Tests_IoctlHandler_SLEEP,
-                                      0,
+                                      ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                       Tests_DefaultTarget_SendCompletion,
                                       NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -309,7 +317,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                       NULL,
                                       ContinuousRequestTarget_RequestType_Ioctl,
                                       IOCTL_Tests_IoctlHandler_SLEEP,
-                                      0,
+                                      ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                       Tests_DefaultTarget_SendCompletion,
                                       NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -333,7 +341,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                       NULL,
                                       ContinuousRequestTarget_RequestType_Ioctl,
                                       IOCTL_Tests_IoctlHandler_SLEEP,
-                                      0,
+                                      ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                       Tests_DefaultTarget_SendCompletion,
                                       NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -714,7 +722,7 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
-    FuncExitVoid(DMF_TRACE);
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
 
     return ntStatus;
 }

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -30,8 +30,16 @@ Environment:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#define THREAD_COUNT                (2)
-#define MAXIMUM_SLEEP_TIME_MS       (15000)
+#define THREAD_COUNT                            (2)
+#define MAXIMUM_SLEEP_TIME_MS                   (15000)
+// This timeout is necessary for causing asynchronous single requests to complete fast so that
+// driver disable works well (since it is not possible to cancel asynchronous requests at this time.
+// using DMF).
+//
+#define ASYNCHRONOUS_REQUEST_TIMEOUT_MS         (50)
+// Keep synchronous maximum time short to make driver disable faster.
+//
+#define MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS       (1000)
 
 typedef enum _TEST_ACTION
 {
@@ -170,7 +178,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(
                   sizeof(sleepIoctlBuffer));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 MAXIMUM_SLEEP_TIME_MS);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_DeviceInterfaceTarget_SendSynchronously(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
                                                            &sleepIoctlBuffer,
@@ -186,7 +194,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(
     //
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 MAXIMUM_SLEEP_TIME_MS);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_DeviceInterfaceTarget_SendSynchronously(moduleContext->DmfModuleDeviceInterfaceTargetPassiveInput,
                                                            &sleepIoctlBuffer,
@@ -260,7 +268,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              0,
+                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -275,7 +283,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              0,
+                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -314,7 +322,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              0,
+                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -338,7 +346,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              0,
+                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -60,6 +60,10 @@ typedef struct
     //
     DMFMODULE DmfModuleThreadAuto[THREAD_COUNT + 1];
     DMFMODULE DmfModuleThreadManual[THREAD_COUNT + 1];
+    // Use alertable sleep to allow driver to unload faster.
+    //
+    DMFMODULE DmfModuleAlertableSleepAuto[THREAD_COUNT + 1];
+    DMFMODULE DmfModuleAlertableSleepManual[THREAD_COUNT + 1];
 } DMF_CONTEXT_Tests_DeviceInterfaceTarget;
 
 // This macro declares the following function:
@@ -80,6 +84,15 @@ DMF_MODULE_DECLARE_NO_CONFIG(Tests_DeviceInterfaceTarget)
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
+// Stores the Module threadIndex so that the corresponding alterable sleep
+// can be retrieved inside the thread's callback.
+//
+typedef struct
+{
+    DMFMODULE DmfModuleAlertableSleep;
+} THREAD_INDEX_CONTEXT;
+WDF_DECLARE_CONTEXT_TYPE(THREAD_INDEX_CONTEXT);
+
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
@@ -96,13 +109,12 @@ Tests_DeviceInterfaceTarget_BufferInput(
     UNREFERENCED_PARAMETER(InputBufferSize);
     UNREFERENCED_PARAMETER(ClientBuferContextInput);
 
-    PAGED_CODE();
-
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0,
                                                                                  MAXIMUM_SLEEP_TIME_MS);
     RtlCopyMemory(InputBuffer,
                   &sleepIoctlBuffer,
                   sizeof(sleepIoctlBuffer));
+    *InputBufferSize = sizeof(sleepIoctlBuffer);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -139,13 +151,16 @@ Tests_DeviceInterfaceTarget_BufferOutput(
 static
 void
 Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep
     )
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
 
     PAGED_CODE();
 
@@ -217,13 +232,16 @@ Tests_DeviceInterfaceTarget_SendCompletion(
 static
 void
 Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep
     )
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
 
     PAGED_CODE();
 
@@ -270,7 +288,8 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
 static
 void
 Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep
     )
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
@@ -299,7 +318,15 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
-    DMF_Utility_DelayMilliseconds(sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Driver is shutting down...get out.
+        //
+        goto Exit;
+    }
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
                                                                                  MAXIMUM_SLEEP_TIME_MS);
@@ -315,7 +342,14 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
-    DMF_Utility_DelayMilliseconds(sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    DMF_AlertableSleep_ResetForReuse(DmfModuleAlertableSleep,
+                                     0);
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+
+Exit:
+    ;
 }
 #pragma code_seg()
 
@@ -330,10 +364,12 @@ Tests_DeviceInterfaceTarget_WorkThread(
     DMFMODULE dmfModule;
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
     TEST_ACTION testAction;
+    THREAD_INDEX_CONTEXT* threadIndex;
 
     PAGED_CODE();
 
     dmfModule = DMF_ParentModuleGet(DmfModuleThread);
+    threadIndex = WdfObjectGet_THREAD_INDEX_CONTEXT(DmfModuleThread);
     moduleContext = DMF_CONTEXT_GET(dmfModule);
 
     // Generate a random test action Id for a current iteration.
@@ -346,13 +382,16 @@ Tests_DeviceInterfaceTarget_WorkThread(
     switch (testAction)
     {
         case TEST_ACTION_SYNCHRONOUS:
-            Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(dmfModule);
+            Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(dmfModule,
+                                                                 threadIndex->DmfModuleAlertableSleep);
             break;
         case TEST_ACTION_ASYNCHRONOUS:
-            Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(dmfModule);
+            Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(dmfModule,
+                                                                  threadIndex->DmfModuleAlertableSleep);
             break;
         case TEST_ACTION_ASYNCHRONOUSCANCEL:
-            Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(dmfModule);
+            Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(dmfModule,
+                                                                        threadIndex->DmfModuleAlertableSleep);
             break;
         default:
             ASSERT(FALSE);
@@ -370,7 +409,8 @@ Tests_DeviceInterfaceTarget_WorkThread(
 }
 #pragma code_seg()
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 Tests_DeviceInterfaceTarget_NonContinousStartAuto(
     _In_ DMFMODULE DmfModule
@@ -394,7 +434,7 @@ Return Value:
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
     NTSTATUS ntStatus;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -404,9 +444,9 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThreadAuto[index]);
+        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThreadAuto[threadIndex]);
         if (!NT_SUCCESS(ntStatus))
         {
             TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_Thread_Start fails: ntStatus=%!STATUS!", ntStatus);
@@ -414,9 +454,9 @@ Return Value:
         }
     }
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_WorkReady(moduleContext->DmfModuleThreadAuto[index]);
+        DMF_Thread_WorkReady(moduleContext->DmfModuleThreadAuto[threadIndex]);
     }
 
 Exit:
@@ -425,8 +465,10 @@ Exit:
 
     return ntStatus;
 }
+#pragma code_seg()
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_NonContinousStopAuto(
     _In_ DMFMODULE DmfModule
@@ -449,7 +491,7 @@ Return Value:
 --*/
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -457,15 +499,23 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_Stop(moduleContext->DmfModuleThreadAuto[index]);
+        // Interrupt any long sleeps.
+        //
+        DMF_AlertableSleep_Abort(moduleContext->DmfModuleAlertableSleepAuto[threadIndex],
+                                 0);
+        // Stop thread.
+        //
+        DMF_Thread_Stop(moduleContext->DmfModuleThreadAuto[threadIndex]);
     }
 
     FuncExitVoid(DMF_TRACE);
 }
+#pragma code_seg()
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 Tests_DeviceInterfaceTarget_NonContinousStartManual(
     _In_ DMFMODULE DmfModule
@@ -489,7 +539,7 @@ Return Value:
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
     NTSTATUS ntStatus;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -499,9 +549,9 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThreadManual[index]);
+        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThreadManual[threadIndex]);
         if (!NT_SUCCESS(ntStatus))
         {
             TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_Thread_Start fails: ntStatus=%!STATUS!", ntStatus);
@@ -509,9 +559,9 @@ Return Value:
         }
     }
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_WorkReady(moduleContext->DmfModuleThreadManual[index]);
+        DMF_Thread_WorkReady(moduleContext->DmfModuleThreadManual[threadIndex]);
     }
 
 Exit:
@@ -520,8 +570,10 @@ Exit:
 
     return ntStatus;
 }
+#pragma code_seg()
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_NonContinousStopManual(
     _In_ DMFMODULE DmfModule
@@ -544,7 +596,7 @@ Return Value:
 --*/
 {
     DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -552,14 +604,23 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_Stop(moduleContext->DmfModuleThreadManual[index]);
+        // Interrupt any long sleeps.
+        //
+        DMF_AlertableSleep_Abort(moduleContext->DmfModuleAlertableSleepManual[threadIndex],
+                                 0);
+        // Stop thread.
+        //
+        DMF_Thread_Stop(moduleContext->DmfModuleThreadManual[threadIndex]);
     }
 
     FuncExitVoid(DMF_TRACE);
 }
+#pragma code_seg()
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_AutoContinous(
     _In_ DMFMODULE DmfModule
@@ -584,16 +645,41 @@ Return Value:
 {
     NTSTATUS ntStatus;
     DMFMODULE dmfModuleParent;
+    DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
+    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
+
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
+    moduleContext = DMF_CONTEXT_GET(dmfModuleParent);
+
+    for (LONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
+    {
+        THREAD_INDEX_CONTEXT* threadIndexContext;
+        WDF_OBJECT_ATTRIBUTES objectAttributes;
+
+        WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+        WDF_OBJECT_ATTRIBUTES_SET_CONTEXT_TYPE(&objectAttributes,
+                                               THREAD_INDEX_CONTEXT);
+        WdfObjectAllocateContext(moduleContext->DmfModuleThreadAuto[threadIndex],
+                                 &objectAttributes,
+                                 (PVOID*)&threadIndexContext);
+        threadIndexContext->DmfModuleAlertableSleep = moduleContext->DmfModuleAlertableSleepAuto[threadIndex];
+        // Reset in case target comes and goes and comes back.
+        //
+        DMF_AlertableSleep_ResetForReuse(threadIndexContext->DmfModuleAlertableSleep,
+                                         0);
+    }
 
     ntStatus = Tests_DeviceInterfaceTarget_NonContinousStartAuto(dmfModuleParent);
     ASSERT(NT_SUCCESS(ntStatus));
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "<--%!FUNC!");
 }
+#pragma code_seg()
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_AutoContinous(
     _In_ DMFMODULE DmfModule
@@ -618,13 +704,20 @@ Return Value:
 {
     DMFMODULE dmfModuleParent;
 
+    PAGED_CODE();
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
+
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
 
     Tests_DeviceInterfaceTarget_NonContinousStopAuto(dmfModuleParent);
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "<--%!FUNC!");
 }
+#pragma code_seg()
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_ManualContinous(
     _In_ DMFMODULE DmfModule
@@ -650,10 +743,31 @@ Return Value:
 {
     NTSTATUS ntStatus;
     DMFMODULE dmfModuleParent;
+    DMF_CONTEXT_Tests_DeviceInterfaceTarget* moduleContext;
+    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
 
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
+    moduleContext = DMF_CONTEXT_GET(dmfModuleParent);
+
+    for (LONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
+    {
+        THREAD_INDEX_CONTEXT* threadIndexContext;
+        WDF_OBJECT_ATTRIBUTES objectAttributes;
+
+        WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+        WDF_OBJECT_ATTRIBUTES_SET_CONTEXT_TYPE(&objectAttributes,
+                                               THREAD_INDEX_CONTEXT);
+        WdfObjectAllocateContext(moduleContext->DmfModuleThreadManual[threadIndex],
+                                 &objectAttributes,
+                                 (PVOID*)&threadIndexContext);
+        threadIndexContext->DmfModuleAlertableSleep = moduleContext->DmfModuleAlertableSleepManual[threadIndex];
+        // Reset in case target comes and goes and comes back.
+        //
+        DMF_AlertableSleep_ResetForReuse(threadIndexContext->DmfModuleAlertableSleep,
+                                         0);
+    }
 
     ntStatus = DMF_DeviceInterfaceTarget_StreamStart(DmfModule);
     if (NT_SUCCESS(ntStatus))
@@ -664,7 +778,10 @@ Return Value:
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "<--%!FUNC!");
 }
+#pragma code_seg()
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_ManualContinous(
     _In_ DMFMODULE DmfModule
@@ -690,13 +807,18 @@ Return Value:
 {
     DMFMODULE dmfModuleParent;
 
+    PAGED_CODE();
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
+
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
 
     DMF_DeviceInterfaceTarget_StreamStop(DmfModule);
     Tests_DeviceInterfaceTarget_NonContinousStopManual(dmfModuleParent);
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "<--%!FUNC!");
 }
+#pragma code_seg()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // WDF Module Callbacks
@@ -739,6 +861,7 @@ Return Value:
     DMF_CONFIG_Thread moduleConfigThread;
     DMF_CONFIG_DeviceInterfaceTarget moduleConfigDeviceInterfaceTarget;
     DMF_MODULE_EVENT_CALLBACKS moduleEventCallbacks;
+    DMF_CONFIG_AlertableSleep moduleConfigAlertableSleep;
 
     UNREFERENCED_PARAMETER(DmfParentModuleAttributes);
 
@@ -821,7 +944,7 @@ Return Value:
     // Thread
     // ------
     //
-    for (ULONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
+    for (LONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
         DMF_CONFIG_Thread_AND_ATTRIBUTES_INIT(&moduleConfigThread,
                                               &moduleAttributes);
@@ -840,6 +963,30 @@ Return Value:
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          &moduleContext->DmfModuleThreadManual[threadIndex]);
+
+        // AlertableSleep Auto
+        // -------------------
+        //
+        DMF_CONFIG_AlertableSleep_AND_ATTRIBUTES_INIT(&moduleConfigAlertableSleep,
+                                                      &moduleAttributes);
+        moduleConfigAlertableSleep.EventCount = 1;
+        moduleAttributes.ClientModuleInstanceName = "AlertableSleep.Auto";
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            &moduleContext->DmfModuleAlertableSleepAuto[threadIndex]);
+
+        // AlertableSleep Manual
+        // ---------------------
+        //
+        DMF_CONFIG_AlertableSleep_AND_ATTRIBUTES_INIT(&moduleConfigAlertableSleep,
+                                                      &moduleAttributes);
+        moduleConfigAlertableSleep.EventCount = 1;
+        moduleAttributes.ClientModuleInstanceName = "AlertableSleep.Manual";
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            &moduleContext->DmfModuleAlertableSleepManual[threadIndex]);
     }
 
     FuncExitVoid(DMF_TRACE);

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
@@ -34,7 +34,7 @@ Environment:
 // Don't use an ever increasing serial number because those serial numbers will be remembered
 // by Windows and will slow down the test computer eventually.
 //
-#define MAXIMUM_NUMBER_OF_PDO_SERIAL_NUMBERS    (16)
+#define MAXIMUM_NUMBER_OF_PDO_SERIAL_NUMBERS    (THREAD_COUNT)
 
 typedef enum _TEST_ACTION
 {
@@ -275,7 +275,7 @@ Tests_Pdo_WorkThread(
     //
     testAction = (TEST_ACTION)TestsUtility_GenerateRandomNumber(TEST_ACTION_MINIUM,
                                                                 TEST_ACTION_MAXIMUM);
-testAction = TEST_ACTION_SLOW;
+
     // Execute the test action.
     //
     switch (testAction)

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
@@ -30,7 +30,16 @@ Environment:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#define THREAD_COUNT                (2)
+#define THREAD_COUNT                            (2)
+#define MAXIMUM_SLEEP_TIME_MS                   (15000)
+// This timeout is necessary for causing asynchronous single requests to complete fast so that
+// driver disable works well (since it is not possible to cancel asynchronous requests at this time.
+// using DMF).
+//
+#define ASYNCHRONOUS_REQUEST_TIMEOUT_MS         (50)
+// Keep synchronous maximum time short to make driver disable faster.
+//
+#define MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS       (1000)
 
 typedef enum _TEST_ACTION
 {
@@ -111,7 +120,7 @@ Tests_SelfTarget_ThreadAction_Synchronous(
                   sizeof(sleepIoctlBuffer));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_SendSynchronously(moduleContext->DmfModuleSelfTargetDispatch,
                                                 &sleepIoctlBuffer,
@@ -127,7 +136,7 @@ Tests_SelfTarget_ThreadAction_Synchronous(
     //
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_SendSynchronously(moduleContext->DmfModuleSelfTargetPassive,
                                                 &sleepIoctlBuffer,
@@ -192,7 +201,7 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
                   sizeof(sleepIoctlBuffer));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_Send(moduleContext->DmfModuleSelfTargetDispatch,
                                    &sleepIoctlBuffer,
@@ -201,13 +210,13 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
                                    NULL,
                                    ContinuousRequestTarget_RequestType_Ioctl,
                                    IOCTL_Tests_IoctlHandler_SLEEP,
-                                   0,
+                                   ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_Send(moduleContext->DmfModuleSelfTargetPassive,
                                    &sleepIoctlBuffer,
@@ -216,7 +225,7 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
                                    NULL,
                                    ContinuousRequestTarget_RequestType_Ioctl,
                                    IOCTL_Tests_IoctlHandler_SLEEP,
-                                   0,
+                                   ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -246,7 +255,7 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                   sizeof(sleepIoctlBuffer));
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_Send(moduleContext->DmfModuleSelfTargetDispatch,
                                    &sleepIoctlBuffer,
@@ -255,7 +264,7 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    NULL,
                                    ContinuousRequestTarget_RequestType_Ioctl,
                                    IOCTL_Tests_IoctlHandler_SLEEP,
-                                   0,
+                                   ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -270,7 +279,7 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
     }
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                                 15000);
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
     ntStatus = DMF_SelfTarget_Send(moduleContext->DmfModuleSelfTargetPassive,
                                    &sleepIoctlBuffer,
@@ -279,7 +288,7 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    NULL,
                                    ContinuousRequestTarget_RequestType_Ioctl,
                                    IOCTL_Tests_IoctlHandler_SLEEP,
-                                   0,
+                                   ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
@@ -55,7 +55,10 @@ typedef struct
     DMFMODULE DmfModuleSelfTargetPassive;
     // Work threads that perform actions on the SelfTarget Module.
     //
-    DMFMODULE DmfModuleThread[THREAD_COUNT];
+    DMFMODULE DmfModuleThread[THREAD_COUNT + 1];
+    // Use alertable sleep to allow driver to unload faster.
+    //
+    DMFMODULE DmfModuleAlertableSleep[THREAD_COUNT + 1];
 } DMF_CONTEXT_Tests_SelfTarget;
 
 // This macro declares the following function:
@@ -76,17 +79,29 @@ DMF_MODULE_DECLARE_NO_CONFIG(Tests_SelfTarget)
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
+// Stores the Module threadIndex so that the corresponding alterable sleep
+// can be retrieved inside the thread's callback.
+//
+typedef struct
+{
+    ULONG ThreadIndex;
+} THREAD_INDEX_CONTEXT;
+WDF_DECLARE_CONTEXT_TYPE(THREAD_INDEX_CONTEXT);
+
 #pragma code_seg("PAGE")
 static
 void
 Tests_SelfTarget_ThreadAction_Synchronous(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ ULONG ThreadIndex
     )
 {
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+
+    UNREFERENCED_PARAMETER(ThreadIndex);
 
     PAGED_CODE();
 
@@ -158,13 +173,16 @@ Tests_SelfTarget_SendCompletion(
 static
 void
 Tests_SelfTarget_ThreadAction_Asynchronous(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ ULONG ThreadIndex
     )
 {
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+
+    UNREFERENCED_PARAMETER(ThreadIndex);
 
     PAGED_CODE();
 
@@ -211,7 +229,8 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
 static
 void
 Tests_SelfTarget_ThreadAction_AsynchronousCancel(
-    _In_ DMFMODULE DmfModule
+    _In_ DMFMODULE DmfModule,
+    _In_ ULONG ThreadIndex
     )
 {
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
@@ -240,7 +259,15 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
-    DMF_Utility_DelayMilliseconds(sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    ntStatus = DMF_AlertableSleep_Sleep(moduleContext->DmfModuleAlertableSleep[ThreadIndex],
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Driver is shutting down...get out.
+        //
+        goto Exit;
+    }
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
                                                                                  15000);
@@ -256,7 +283,14 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    Tests_SelfTarget_SendCompletion,
                                    NULL);
     ASSERT(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
-    DMF_Utility_DelayMilliseconds(sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    DMF_AlertableSleep_ResetForReuse(moduleContext->DmfModuleAlertableSleep[ThreadIndex],
+                                     0);
+    ntStatus = DMF_AlertableSleep_Sleep(moduleContext->DmfModuleAlertableSleep[ThreadIndex],
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+
+Exit:
+    ;
 }
 #pragma code_seg()
 
@@ -271,10 +305,12 @@ Tests_SelfTarget_WorkThread(
     DMFMODULE dmfModule;
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
     TEST_ACTION testAction;
+    THREAD_INDEX_CONTEXT* threadIndex;
 
     PAGED_CODE();
 
     dmfModule = DMF_ParentModuleGet(DmfModuleThread);
+    threadIndex = WdfObjectGet_THREAD_INDEX_CONTEXT(DmfModuleThread);
     moduleContext = DMF_CONTEXT_GET(dmfModule);
 
     // Generate a random test action Id for a current iteration.
@@ -287,13 +323,16 @@ Tests_SelfTarget_WorkThread(
     switch (testAction)
     {
         case TEST_ACTION_SYNCHRONOUS:
-            Tests_SelfTarget_ThreadAction_Synchronous(dmfModule);
+            Tests_SelfTarget_ThreadAction_Synchronous(dmfModule,
+                                                      threadIndex->ThreadIndex);
             break;
         case TEST_ACTION_ASYNCHRONOUS:
-            Tests_SelfTarget_ThreadAction_Asynchronous(dmfModule);
+            Tests_SelfTarget_ThreadAction_Asynchronous(dmfModule,
+                                                       threadIndex->ThreadIndex);
             break;
         case TEST_ACTION_ASYNCHRONOUSCANCEL:
-            Tests_SelfTarget_ThreadAction_AsynchronousCancel(dmfModule);
+            Tests_SelfTarget_ThreadAction_AsynchronousCancel(dmfModule,
+                                                             threadIndex->ThreadIndex);
             break;
         default:
             ASSERT(FALSE);
@@ -316,7 +355,8 @@ Tests_SelfTarget_WorkThread(
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_Tests_SelfTarget_SelfManagedIoInit(
     _In_ DMFMODULE DmfModule
@@ -339,7 +379,7 @@ Return Value:
 {
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
     NTSTATUS ntStatus;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -352,9 +392,9 @@ Return Value:
     // Create threads that read with expected success, read with expected failure
     // and enumerate.
     //
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThread[index]);
+        ntStatus = DMF_Thread_Start(moduleContext->DmfModuleThread[threadIndex]);
         if (!NT_SUCCESS(ntStatus))
         {
             TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_Thread_Start fails: ntStatus=%!STATUS!", ntStatus);
@@ -362,9 +402,9 @@ Return Value:
         }
     }
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_WorkReady(moduleContext->DmfModuleThread[index]);
+        DMF_Thread_WorkReady(moduleContext->DmfModuleThread[threadIndex]);
     }
 
 Exit:
@@ -373,8 +413,10 @@ Exit:
 
     return ntStatus;
 }
+#pragma code_seg()
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 DMF_Tests_SelfTarget_SelfManagedIoCleanup(
     _In_ DMFMODULE DmfModule
@@ -396,7 +438,7 @@ Return Value:
 --*/
 {
     DMF_CONTEXT_Tests_SelfTarget* moduleContext;
-    LONG index;
+    LONG threadIndex;
 
     PAGED_CODE();
 
@@ -404,13 +446,20 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
-    for (index = 0; index < THREAD_COUNT; index++)
+    for (threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
-        DMF_Thread_Stop(moduleContext->DmfModuleThread[index]);
+        // Interrupt any long sleeps.
+        //
+        DMF_AlertableSleep_Abort(moduleContext->DmfModuleAlertableSleep[threadIndex],
+                                 0);
+        // Stop thread.
+        //
+        DMF_Thread_Stop(moduleContext->DmfModuleThread[threadIndex]);
     }
 
     FuncExitVoid(DMF_TRACE);
 }
+#pragma code_seg()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // DMF Module Callbacks
@@ -485,9 +534,76 @@ Return Value:
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          &moduleContext->DmfModuleThread[threadIndex]);
+
+        // AlertableSleep
+        // --------------
+        //
+        DMF_CONFIG_AlertableSleep moduleConfigAlertableSleep;
+        DMF_CONFIG_AlertableSleep_AND_ATTRIBUTES_INIT(&moduleConfigAlertableSleep,
+                                                      &moduleAttributes);
+        moduleConfigAlertableSleep.EventCount = 1;
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            &moduleContext->DmfModuleAlertableSleep[threadIndex]);
     }
 
     FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+static
+NTSTATUS
+DMF_Tests_SelfTarget_Open(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Initialize an instance of a DMF Module of type Test_SelfTarget.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    STATUS_SUCCESS
+
+--*/
+{
+    DMF_CONTEXT_Tests_SelfTarget* moduleContext;
+    NTSTATUS ntStatus;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    ntStatus = STATUS_SUCCESS;
+
+    for (LONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
+    {
+        THREAD_INDEX_CONTEXT* threadIndexContext;
+        WDF_OBJECT_ATTRIBUTES objectAttributes;
+
+        WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+        WDF_OBJECT_ATTRIBUTES_SET_CONTEXT_TYPE(&objectAttributes,
+                                               THREAD_INDEX_CONTEXT);
+        WdfObjectAllocateContext(moduleContext->DmfModuleThread[threadIndex],
+                                 &objectAttributes,
+                                 (PVOID*)&threadIndexContext);
+        threadIndexContext->ThreadIndex = threadIndex;
+    }
+    
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
 }
 #pragma code_seg()
 
@@ -540,6 +656,7 @@ Return Value:
 
     DMF_CALLBACKS_DMF_INIT(&DmfCallbacksDmf_Tests_SelfTarget);
     DmfCallbacksDmf_Tests_SelfTarget.ChildModulesAdd = DMF_Tests_SelfTarget_ChildModulesAdd;
+    DmfCallbacksDmf_Tests_SelfTarget.DeviceOpen = DMF_Tests_SelfTarget_Open;
 
     DMF_CALLBACKS_WDF_INIT(&DmfCallbacksWdf_Tests_SelfTarget);
     DmfCallbacksWdf_Tests_SelfTarget.ModuleSelfManagedIoInit = DMF_Tests_SelfTarget_SelfManagedIoInit;

--- a/Dmf/Modules.Library.Tests/TestsUtility.c
+++ b/Dmf/Modules.Library.Tests/TestsUtility.c
@@ -46,10 +46,8 @@ Environment:
 
 #if !defined(DMF_USER_MODE)
 
-#pragma code_seg("PAGE")
 _Must_inspect_result_
 _IRQL_requires_same_
-_IRQL_requires_max_(APC_LEVEL)
 ULONG
 TestsUtility_GenerateRandomNumber(
     _In_ ULONG Min,
@@ -76,8 +74,6 @@ Return Value:
     ULONG random;
     ULONG range;
 
-    PAGED_CODE();
-
     ASSERT(Max >= Min);
 
     range = Max - Min + 1;
@@ -86,14 +82,11 @@ Return Value:
 
     return random;
 }
-#pragma code_seg()
 
-#pragma code_seg("PAGE")
 _IRQL_requires_same_
-_IRQL_requires_max_(APC_LEVEL)
 VOID
 TestsUtility_FillWithSequentialData(
-    _In_ PUINT8 Buffer,
+    _Out_writes_(Size) UINT8* Buffer,
     _In_ ULONG Size
     )
 /*++
@@ -117,9 +110,8 @@ Return Value:
     UINT8 currentValue;
     ULONG index;
 
-    PAGED_CODE();
-    
-    currentValue = (UINT8)TestsUtility_GenerateRandomNumber(0, BYTE_MAX);
+    currentValue = (UINT8)TestsUtility_GenerateRandomNumber(0,
+                                                            BYTE_MAX);
     
     for (index = 0; index < Size; ++ index)
     {
@@ -129,7 +121,6 @@ Return Value:
         ++ currentValue;
     }
 }
-#pragma code_seg()
 
 #pragma code_seg("PAGE")
 _IRQL_requires_same_

--- a/Dmf/Modules.Library.Tests/TestsUtility.h
+++ b/Dmf/Modules.Library.Tests/TestsUtility.h
@@ -25,7 +25,6 @@ Environment:
 
 _Must_inspect_result_
 _IRQL_requires_same_
-_IRQL_requires_max_(APC_LEVEL)
 ULONG
 TestsUtility_GenerateRandomNumber(
     _In_ ULONG Min,
@@ -33,10 +32,9 @@ TestsUtility_GenerateRandomNumber(
     );
 
 _IRQL_requires_same_
-_IRQL_requires_max_(APC_LEVEL)
 VOID
 TestsUtility_FillWithSequentialData(
-    _In_ PUINT8 Buffer,
+    _Out_writes_(Size) UINT8* Buffer,
     _In_ ULONG Size
     );
 

--- a/Dmf/Modules.Library/Dmf_Pdo.md
+++ b/Dmf/Modules.Library/Dmf_Pdo.md
@@ -352,6 +352,43 @@ Device | The newly created PDO (optional).
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_Pdo_DevicePlugEx
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Pdo_DevicePlugEx(
+    _In_ DMFMODULE DmfModule,
+    _In_ PDO_RECORD* PdoRecord,
+    _Out_opt_ WDFDEVICE* Device
+    );
+
+````
+
+Create and attach a static PDO to the Client Driver's FDO. This version of the API allows the Client to create a
+PDO that can instantiate DMF Modules.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Pdo Module handle.
+PdoRecord | Contains the parameters that define the characteristic of the PDO.
+Device | The newly created PDO (optional).
+
+##### Remarks
+
+* This version allows the Client to create PDO that is able to instantiate Modules.
+* This API is a superset of the non-Ex version.
+* In addition to specifying the characteristics of the PDO, set the `EnableDmf` flag and the name of the callback
+function that tells DMF what Modules to instantiate (if Modules are required).
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
 ##### DMF_Pdo_DeviceUnplug
 
 ````

--- a/DmfTest/DmfKTest/sys/DmfInterface.c
+++ b/DmfTest/DmfKTest/sys/DmfInterface.c
@@ -166,51 +166,6 @@ Return Value:
 
     isFunctionDriver = DriverModeGet(Device);
 
-    // Tests_BufferPool
-    // ----------------
-    //
-    DMF_Tests_BufferPool_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
-    // Tests_BufferQueue
-    // ----------------
-    //
-    DMF_Tests_BufferQueue_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
-    // Tests_RingBuffer
-    // ----------------
-    //
-    DMF_Tests_RingBuffer_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
-    // Tests_PingPongBuffer
-    // --------------------
-    //
-    DMF_Tests_PingPongBuffer_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
-    // Tests_HashTable
-    // ---------------
-    //
-    DMF_Tests_HashTable_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
     if (isFunctionDriver)
     {
         // Tests_DefaultTarget
@@ -240,9 +195,9 @@ Return Value:
         //
         DMF_Tests_Registry_ATTRIBUTES_INIT(&moduleAttributes);
         DMF_DmfModuleAdd(DmfModuleInit,
-                         &moduleAttributes,
-                         WDF_NO_OBJECT_ATTRIBUTES,
-                         NULL);
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
 
         // Tests_ScheduledTask
         // --------------------
@@ -251,9 +206,9 @@ Return Value:
         //
         DMF_Tests_ScheduledTask_ATTRIBUTES_INIT(&moduleAttributes);
         DMF_DmfModuleAdd(DmfModuleInit,
-                         &moduleAttributes,
-                         WDF_NO_OBJECT_ATTRIBUTES,
-                         NULL);
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
 
         // Tests_IoctlHandler
         // ------------------
@@ -286,6 +241,57 @@ Return Value:
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          NULL);
+
+        /////////////////////////////////////////////////////////////////////////////////
+        // These tests can be in both bus and function drivers. To reduce CPU usage, just
+        // place them in the bus driver.
+        /////////////////////////////////////////////////////////////////////////////////
+        //
+
+        // Tests_BufferPool
+        // ----------------
+        //
+        DMF_Tests_BufferPool_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
+
+        // Tests_BufferQueue
+        // ----------------
+        //
+        DMF_Tests_BufferQueue_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
+
+        // Tests_RingBuffer
+        // ----------------
+        //
+        DMF_Tests_RingBuffer_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
+
+        // Tests_PingPongBuffer
+        // --------------------
+        //
+        DMF_Tests_PingPongBuffer_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
+
+        // Tests_HashTable
+        // ---------------
+        //
+        DMF_Tests_HashTable_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                            &moduleAttributes,
+                            WDF_NO_OBJECT_ATTRIBUTES,
+                            NULL);
     }
 }
 #pragma code_seg()

--- a/DmfTest/DmfKTest/sys/DmfInterface.c
+++ b/DmfTest/DmfKTest/sys/DmfInterface.c
@@ -202,15 +202,6 @@ Return Value:
                      WDF_NO_OBJECT_ATTRIBUTES,
                      NULL);
 
-    // Tests_ScheduledTask
-    // --------------------
-    //
-    DMF_Tests_ScheduledTask_ATTRIBUTES_INIT(&moduleAttributes);
-    DMF_DmfModuleAdd(DmfModuleInit,
-                     &moduleAttributes,
-                     WDF_NO_OBJECT_ATTRIBUTES,
-                     NULL);
-
     // Tests_HashTable
     // ---------------
     //
@@ -248,6 +239,17 @@ Return Value:
         // (the registry). Running from multiple drivers will cause sporadic errors.
         //
         DMF_Tests_Registry_ATTRIBUTES_INIT(&moduleAttributes);
+        DMF_DmfModuleAdd(DmfModuleInit,
+                         &moduleAttributes,
+                         WDF_NO_OBJECT_ATTRIBUTES,
+                         NULL);
+
+        // Tests_ScheduledTask
+        // --------------------
+        // Only run these in a single driver since they add/delete from a single resource
+        // (the registry). Running from multiple drivers will cause sporadic errors.
+        //
+        DMF_Tests_ScheduledTask_ATTRIBUTES_INIT(&moduleAttributes);
         DMF_DmfModuleAdd(DmfModuleInit,
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,

--- a/DmfTest/DmfKTest/sys/Trace.h
+++ b/DmfTest/DmfKTest/sys/Trace.h
@@ -21,24 +21,20 @@ Environment:
 // Define the tracing flags.
 //
 // DmfKTest Tracing GUID - {61C379CE-3A6B-4E34-B8B1-BEF18A0F6209}
-// SurfaceLibrary Tracing GUID - {4DA41ED6-B8E6-473E-A7DF-E9C958B86167}
+// DMF Tracing GUID - {48F112EC-38AC-417B-935D-2250A46BDC89}
 //
 
 #define WPP_CONTROL_GUIDS                                                                                                               \
+    WPP_DEFINE_CONTROL_GUID(                                                                                                            \
+        DmfTraceGuid, (48F112EC,38AC,417B,935D,2250A46BDC89),                                                                           \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                                                                       \
+        )                                                                                                                               \
     WPP_DEFINE_CONTROL_GUID(                                                                                                            \
         DmfKTestDriverTraceGuid, (61C379CE,3A6B,4E34,B8B1,BEF18A0F6209),                                                                \
         WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                                                                               \
         WPP_DEFINE_BIT(TRACE_DRIVER)                                                                                                    \
         )                                                                                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                                                                            \
-        SurfaceLibraryTraceGuid, (4DA41ED6,B8E6,473E,A7DF,E9C958B86167),                                                                \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_BufferPool)                                                                                      \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_BufferQueue)                                                                                     \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_PingPongBuffer)                                                                                  \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_Registry)                                                                                        \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_RingBuffer)                                                                                      \
-        WPP_DEFINE_BIT(DMF_TRACE_Tests_ScheduledTask)                                                                                   \
-        )                                                                                                                               \
+
 //
 // This comment block is scanned by the trace preprocessor to define our
 // Trace function.


### PR DESCRIPTION
Merge20190516: 

1. Fix issue in DMF_ContinuousRequestTarget that could cause BSOD during Close due to race condition while deleting Requests that may be in use. (Close will not begin to execute until all asynchronous requests have been processed.)
2. Correct issue with Test Driver that caused many hidden PDOs to be left on test machine.
3. Several updates to Test Driver Modules to make it more robust and faster during disable of bus driver.
4. Correct issue in DMF_BufferPool where it incorrectly kept searching for a buffer in the list that was already found.
5. Correct issue in Hash Table tests because it was possible that duplicate keys could be randomly created (for different records).
6. Make cancellation logic more robust in Tests_IoctlHandler.
7. Correct some SAL issues in Test Modules.
8. Fix tracing GUIDs definition in the Test Driver. It was using the old method incorrectly.
9. Fix issue with DMF_Tests_ScheduledTask. Only one instance should execute at a time since it uses a common resource in the machine (the Registry).

This PR also shows techniques that can be used to solve various programming tasks using DMF.
