### PR TITLE
Merge20190521

### DIFF
--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
@@ -63,7 +63,7 @@ typedef struct
     DMFMODULE DmfModuleAlertableSleep[THREAD_COUNT + 1];
     // Serial number in use table.
     //
-    BOOLEAN SerialNumbersInUse[MAXIMUM_NUMBER_OF_PDO_SERIAL_NUMBERS];
+    BOOLEAN SerialNumbersInUse[MAXIMUM_NUMBER_OF_PDO_SERIAL_NUMBERS + 1];
 } DMF_CONTEXT_Tests_Pdo;
 
 // This macro declares the following function:

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
@@ -533,7 +533,7 @@ Return Value:
     // Thread
     // ------
     //
-    for (ULONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
+    for (LONG threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++)
     {
         DMF_CONFIG_Thread_AND_ATTRIBUTES_INIT(&moduleConfigThread,
                                               &moduleAttributes);

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
@@ -1364,7 +1364,8 @@ Exit:
         *BytesWritten = outputBufferSize;
     }
 
-    if (IsSynchronousRequest && request != NULL)
+    if (IsSynchronousRequest && 
+        request != NULL)
     {
         // Delete the request if its Synchronous.
         //
@@ -1840,14 +1841,10 @@ Return Value:
     moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
     moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = TRUE;
     moduleConfigBufferPool.Mode.SourceSettings.BufferCount = 1;
-    if (DmfParentModuleAttributes->PassiveLevel)
-    {
-        moduleConfigBufferPool.Mode.SourceSettings.PoolType = PagedPool;
-    }
-    else
-    {
-        moduleConfigBufferPool.Mode.SourceSettings.PoolType = NonPagedPoolNx;
-    }
+    // NOTE: BufferPool context must always be NonPagedPool because it is accessed in the
+    //       completion routine running at DISPATCH_LEVEL.
+    //
+    moduleConfigBufferPool.Mode.SourceSettings.PoolType = NonPagedPoolNx;
     moduleConfigBufferPool.Mode.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_SingleAsynchronousRequestContext);
     moduleAttributes.ClientModuleInstanceName = "BufferPoolContext";
     moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;


### PR DESCRIPTION
1. Fix issue where DMF_ContinousRequestTarget incorrectly allows Client to create PASSIVE_LEVEL context buffers. This does not work because the completion routine that uses them always runs in DISPATCH_LEVEL.

2. Fix issues with cancellation due to WDF verifier rules in DMF_Tests_IoctlHandler.
