### PR TITLE
Merge20190528:

### DIFF
--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -2992,9 +2992,9 @@ Return Value:
 #endif
         // Sometimes the Thread ID of the current thread is zero. In that case, use DMF_INVALID_HANDLE_VALUE.
         //
-        if (dmfObject->Synchronizations[DMF_DEFAULT_LOCK_INDEX].LockHeldByThread == 0)
+        if (dmfObject->Synchronizations[AuxiliaryLockIndex + DMF_NUMBER_OF_DEFAULT_LOCKS].LockHeldByThread == 0)
         {
-            dmfObject->Synchronizations[DMF_DEFAULT_LOCK_INDEX].LockHeldByThread = DMF_INVALID_HANDLE_VALUE;
+            dmfObject->Synchronizations[AuxiliaryLockIndex + DMF_NUMBER_OF_DEFAULT_LOCKS].LockHeldByThread = DMF_INVALID_HANDLE_VALUE;
         }
     }
     else

--- a/Dmf/Framework/DmfFilter.c
+++ b/Dmf/Framework/DmfFilter.c
@@ -95,8 +95,6 @@ Return Value:
 
     dmfDeviceInit = DMF_DmfControlDeviceInitAllocate(deviceInit);
 
-    DMF_DmfDeviceInitHookFileObjectConfig(dmfDeviceInit,
-                                          NULL);
     DMF_DmfControlDeviceInitSetClientDriverDevice(dmfDeviceInit,
                                                   Device);
 

--- a/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
+++ b/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
@@ -2120,8 +2120,8 @@ Return Value:
 
     FuncEntry(DMF_TRACE);
 
-    DMF_HandleValidate_ModuleMethod(DmfModule,
-                                    &DmfModuleDescriptor_BufferPool);
+    DMF_HandleValidate_ClosingOk(DmfModule,
+                                 &DmfModuleDescriptor_BufferPool);
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -778,12 +778,6 @@ Return Value:
     moduleContext = DMF_CONTEXT_GET(*dmfModuleAddress);
     moduleConfig = DMF_CONFIG_GET(*dmfModuleAddress);
 
-    if (moduleConfig->EvtDeviceInterfaceTargetOnStateChange)
-    {
-        moduleConfig->EvtDeviceInterfaceTargetOnStateChange(*dmfModuleAddress,
-                                                            DeviceInterfaceTarget_StateType_QueryRemoveCancelled);
-    }
-
     WDF_IO_TARGET_OPEN_PARAMS_INIT_REOPEN(&openParams);
 
     ntStatus = WdfIoTargetOpen(IoTarget,
@@ -802,6 +796,12 @@ Return Value:
         {
             TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_DeviceInterfaceTarget_StreamStart fails: ntStatus=%!STATUS!", ntStatus);
         }
+    }
+
+    if (moduleConfig->EvtDeviceInterfaceTargetOnStateChange)
+    {
+        moduleConfig->EvtDeviceInterfaceTargetOnStateChange(*dmfModuleAddress,
+                                                            DeviceInterfaceTarget_StateType_QueryRemoveCancelled);
     }
 
 Exit:


### PR DESCRIPTION
1. Correct incorrect assert in DMF_BufferPool.
2. Correct issue causing assertion in some filter drivers.
3. Correct bug in User Mode related to auxiliary locks.
4. Correct issue where "remove cancel" callback happens before underlying target is open.