### PR TITLE
Merge20190531

### DIFF
--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1234,6 +1234,15 @@ DMF_ModulesCreate(
     _In_ PDMFDEVICE_INIT* DmfDeviceInit
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_ModuleConfigRetrieve(
+    _In_ DMFMODULE DmfModule,
+    _Out_writes_(ModuleConfigSize) PVOID ModuleConfigPointer,
+    _In_ size_t ModuleConfigSize
+    );
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Filter Driver Support (FilterControl API)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Dmf/Framework/DmfGeneric.c
+++ b/Dmf/Framework/DmfGeneric.c
@@ -2016,29 +2016,9 @@ Return Value:
 
     dmfObject = DMF_ModuleToObject(DmfModule);
 
-    // NeedtoCallPreClose is set when the Module has not been closed.
-    // DMF does not use ModuleState for decision making purposes, only
-    // for debug and assertions. NeedToCallPreClose used to make a check
-    // to determine if the Module has been closed instead. This flag is
-    // cleared when the Module is closed.
-    // TODO: Perhaps rename this variable to "HasModuleBeenClosed".
-    //
-    if (dmfObject->NeedToCallPreClose)
-    {
-        // The Module was successfully opened and now we are closing it.
-        // No asynchronous notification will close the Module, so close it now
-        // (as if this was the asynchronous notification).
-        //
-        // This eliminates the need to for the Module to handle this callback just
-        // to close the Module in cases where OPEN_NOTIFY_* is used and the Client
-        // does not need to actually register for a notification.
-        //
-        DMF_ModuleClose(DmfModule);
-    }
-
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s]", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrClosed(dmfObject);
+    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s]", dmfObject, dmfObject->ClientModuleInstanceName);
 }

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -273,6 +273,9 @@ typedef struct
     // This is the Child Module to be returned at the next iteration.
     //
     LIST_ENTRY* NextChildObjectListEntry;
+    // This is the Child Module to be returned at the next iteration.
+    //
+    LIST_ENTRY* PreviousChildObjectListEntry;
 } CHILD_OBJECT_INTERATION_CONTEXT;
 
 // The DMF Module Collection contains information about all the instantiated

--- a/Dmf/Modules.Library/Dmf_ScheduledTask.c
+++ b/Dmf/Modules.Library/Dmf_ScheduledTask.c
@@ -926,13 +926,12 @@ Return Value:
     DmfCallbacksDmf_ScheduledTask.DeviceOpen = DMF_ScheduledTask_Open;
     DmfCallbacksDmf_ScheduledTask.DeviceClose = DMF_ScheduledTask_Close;
 
-    DMF_CALLBACKS_WDF_INIT(&DmfCallbacksWdf_ScheduledTask);
-
     // Allow Module to be created Dynamically when possible.
     //
     if ((moduleConfig->ExecuteWhen == ScheduledTask_ExecuteWhen_PrepareHardware) ||
         (moduleConfig->ExecuteWhen == ScheduledTask_ExecuteWhen_D0Entry))
     {
+        DMF_CALLBACKS_WDF_INIT(&DmfCallbacksWdf_ScheduledTask);
         DmfCallbacksWdf_ScheduledTask.ModulePrepareHardware = DMF_ScheduledTask_ModulePrepareHardware;
         DmfCallbacksWdf_ScheduledTask.ModuleReleaseHardware = DMF_ScheduledTask_ModuleReleaseHardware;
         DmfCallbacksWdf_ScheduledTask.ModuleD0Entry = DMF_ScheduledTask_ModuleD0Entry;
@@ -946,7 +945,13 @@ Return Value:
                                             DMF_MODULE_OPEN_OPTION_OPEN_Create);
 
     DmfModuleDescriptor_ScheduledTask.CallbacksDmf = &DmfCallbacksDmf_ScheduledTask;
-    DmfModuleDescriptor_ScheduledTask.CallbacksWdf = &DmfCallbacksWdf_ScheduledTask;
+    // Allow Module to be created Dynamically when possible.
+    //
+    if ((moduleConfig->ExecuteWhen == ScheduledTask_ExecuteWhen_PrepareHardware) ||
+        (moduleConfig->ExecuteWhen == ScheduledTask_ExecuteWhen_D0Entry))
+    {
+        DmfModuleDescriptor_ScheduledTask.CallbacksWdf = &DmfCallbacksWdf_ScheduledTask;
+    }
 
     ntStatus = DMF_ModuleCreate(Device,
                                 DmfModuleAttributes,

--- a/Dmf/Modules.Library/Dmf_String.c
+++ b/Dmf/Modules.Library/Dmf_String.c
@@ -391,6 +391,53 @@ Return Value:
 }
 
 LONG
+DMF_String_FindInListExactGuid(
+    _In_ GUID* GuidList,
+    _In_ ULONG NumberOfGuidsInGuidList,
+    _In_ GUID* LookFor
+    )
+/*++
+
+Routine Description:
+
+    Given a list of GUIDs, find the index of a given GUID.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    GuidList - List of strings to search.
+    NumberOfGuidsInGuidList - Number of GUIDs in GuidList.
+    LookFor - GUID to look for.
+
+Return Value:
+
+    -1 - LookFor is not found in GuidList.
+    non-negative: Index of GUID in GuidList that matches LookFor.
+
+--*/
+{
+    LONG returnValue;
+
+    ASSERT(GuidList != NULL);
+
+    // -1 indicates "not found int list".
+    //
+    returnValue = -1;
+
+    for (ULONG guidIndex = 0; guidIndex < NumberOfGuidsInGuidList; guidIndex++)
+    {
+        if (DMF_Utility_IsEqualGUID((LPGUID)&GuidList[guidIndex],
+                                    (LPGUID)LookFor))
+        {
+            returnValue = guidIndex;
+            break;
+        }
+    }
+
+    return returnValue;
+}
+
+LONG
 DMF_String_FindInListLookForLeftMatchChar(
     _In_ DMFMODULE DmfModule,
     _In_ CHAR** StringList,

--- a/Dmf/Modules.Library/Dmf_String.h
+++ b/Dmf/Modules.Library/Dmf_String.h
@@ -57,6 +57,13 @@ DMF_String_FindInListExactChar(
     );
 
 LONG
+DMF_String_FindInListExactGuid(
+    _In_ GUID* GuidList,
+    _In_ ULONG NumberOfGuidsInGuidList,
+    _In_ GUID* LookFor
+    );
+
+LONG
 DMF_String_FindInListLookForLeftMatchChar(
     _In_ DMFMODULE DmfModule,
     _In_ CHAR** StringList,

--- a/Dmf/Modules.Library/Dmf_String.md
+++ b/Dmf/Modules.Library/Dmf_String.md
@@ -127,7 +127,34 @@ LookFor | The given string to search for in the list.
 * None
 
 -----------------------------------------------------------------------------------------------------------------------------------
+````
+LONG
+DMF_String_FindInListExactGuid(
+    _In_ GUID* GuidList,
+    _In_ ULONG NumberOfGuidsInGuidList,
+    _In_ GUID* LookFor
+    );
+````
+Given a list of GUIDs and a GUID to find, find the GUID in the list.
+The comparison made is: Full GUID, exact match.
 
+##### Returns
+
+-1 indicates the GUID to look for was not found.
+Otherwise the index of the matching GUID in the list of strings is returned.
+
+##### Parameters
+Parameter | Description
+----|----
+GuidList | The given list of GUIDs to search.
+NumberOfGuidsInGuidList | The number of GUIDs in GuidList.
+LookFor | The given GUID to search for in the list.
+
+##### Remarks
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_String_FindInListLookForLeftMatchChar
 ````
 LONG


### PR DESCRIPTION
1. Module Child List iteration is changed to to match the WDF callback iteration for the DMF tree. In some cases this allows for the Client to close down Modules more gracefully when Child Modules callback into the Parent Module during shutdown.
2. Add a Method for GUID comparison to DMF_String.
3. Make it possible to instantiate DMF_ScheduledTask dynamically.
4. Give access to a Module's Config data to a Client. This is useful in cases where the Client has instantiated multiple instances of the same Module and receives callbacks from those instances. Client can now access the caller's Config to know which instance is calling back.