### PR TITLE
Merge20190730

### DIFF
--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -6391,6 +6391,32 @@ None
     **DMF_ModuleNotificationClose()** is used by the Module from the
     Module's notification callback.
 
+
+### DMF_ModuleIsDynamic
+```
+VOID
+DMF_ModuleIsDynamic(
+    _In_ DMFMODULE DmfModule
+    )
+```
+This function allows the caller to determine if the given Module has been instantiated as a Dynamic Module.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
+  **DMFMODULE DmfModule** |  The handle of the given Module.
+
+#### Returns
+
+TRUE indicates the given Module has been instantiated as a Dynamic Module.
+
+FALSE indicates the given Module has not been instantiated as a Dynamic Module.
+
+#### Remarks
+
+-  Dynamic Modules cannot use WDF callbacks. So, Modules that can be instantiated as Dynamic use this function to determine if WDF callbacks should be set.
+
 ### DMF_ModuleIsInFilterDriver
 ```
 VOID
@@ -6427,6 +6453,31 @@ FALSE indicates the Module is not executing in a filter driver.
 
 -   DMF knows the Client driver is a filter driver because such drivers
     must call **DMF_DmfFdoSetFilter()**.
+
+### DMF_ModuleIsPassivelevel
+```
+VOID
+DMF_ModuleIsPassiveLevel(
+    _In_ DMFMODULE DmfModule
+    )
+```
+This function allows the caller to determine if the given Module has been instantiated with the `PassiveLevel = TRUE` setting.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
+  **DMFMODULE DmfModule** |  The handle of the given Module.
+
+#### Returns
+
+TRUE indicates the given Module has been instantiated with `PassiveLevel = TRUE`.
+
+FALSE indicates the given Module has been instantiated with `PassiveLevel = FALSE`.
+
+#### Remarks
+
+-   In some cases, a Module will execute different paths depending on its `PassiveLevel` setting.
 
 ### DMF_ModuleRequestCompleteOrForward
 ```

--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -497,7 +497,7 @@ Return Value:
     dmfObject = DMF_ModuleToObject(DmfModule);
     ASSERT(dmfObject != NULL);
 
-    ASSERT(! dmfObject->DynamicModule);
+    ASSERT(! dmfObject->DynamicModuleImmediate);
 
     // Dispatch callback to Child DMF Modules first.
     //
@@ -563,7 +563,7 @@ Return Value:
     // Since  it is a Dynamic Module automatically close it before it is destroyed.
     // (Client has no access to the Close API.)
     //
-    ASSERT(dmfObject->DynamicModule);
+    ASSERT(dmfObject->DynamicModuleImmediate);
     DMF_Module_CloseOrUnregisterNotificationOnDestroy(dmfModule);
 
     // Dispatch callback to Child DMF Modules first.

--- a/Dmf/Framework/DmfHelpers.c
+++ b/Dmf/Framework/DmfHelpers.c
@@ -247,7 +247,7 @@ Return Value:
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
-DMF_IsModulePassive(
+DMF_IsModulePassiveLevel(
     _In_ DMFMODULE DmfModule
     )
 /*++

--- a/Dmf/Framework/DmfHelpers.c
+++ b/Dmf/Framework/DmfHelpers.c
@@ -205,6 +205,82 @@ Return Value:
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_IsModuleDynamic(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Returns TRUE if 
+        - the given DMF Module was created dynamically. or
+        - the given DMF Module is part of a dynamic Module tree.
+    FALSE if the given DMF Module is part of Module Collection. 
+
+Arguments:
+
+    DmfModule: The given DMF Module.
+
+Return Value:
+
+    TRUE if 
+        - the given DMF Module was created dynamically. or
+        - the given DMF Module is part of a dynamic Module tree.
+    FALSE if the given DMF Module is part of Module Collection.
+
+--*/
+{
+    // NOTE: No FuncEntry/Exit logging. It is too much and it is not necessary for this
+    // simple function.
+    //
+    DMF_OBJECT* DmfObject;
+
+    DmfObject = DMF_ModuleToObject(DmfModule);
+
+    DMF_HandleValidate_IsAvailable(DmfObject);
+
+    ASSERT(DmfObject != NULL);
+
+    return DmfObject->ModuleAttributes.DynamicModule;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_IsModulePassive(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Allows caller to access PassiveLevel field of a given Module's Attributes.
+
+Arguments:
+
+    DmfModule: The given DMF Module.
+
+Return Value:
+
+    Returns TRUE if the given DMF Module was created with PassiveLevel = TRUE; otherwise returns FALSE.
+
+--*/
+{
+    // NOTE: No FuncEntry/Exit logging. It is too much and it is not necessary for this
+    // simple function.
+    //
+    DMF_OBJECT* DmfObject;
+
+    DmfObject = DMF_ModuleToObject(DmfModule);
+
+    DMF_HandleValidate_IsAvailable(DmfObject);
+
+    ASSERT(DmfObject != NULL);
+
+    return DmfObject->ModuleAttributes.PassiveLevel;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_ModuleConfigRetrieve(
@@ -405,8 +481,6 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_SynchronizationCreate(
     _In_ DMF_OBJECT* DmfObject,
-    _In_ WDFDEVICE ParentDevice,
-    _In_ DMF_MODULE_DESCRIPTOR* ModuleDescriptor,
     _In_ BOOLEAN PassiveLevel
     )
 /*++
@@ -414,14 +488,12 @@ DMF_SynchronizationCreate(
 Routine Description:
 
     Create a set of Locks for a given DMF Module.
+    PassiveLevel - TRUE if Client wants the Module options to be set to MODULE_OPTIONS_PASSIVE.
+                   NOTE: Module Options must be set to MODULE_OPTIONS_DISPATCH_MAXIMUM. 
 
 Arguments:
 
     DmfModule - The given DMF Module.
-    ParentDevice - The Parent Device for the Module
-    ModuleDescriptor - The given DMF Module's descriptor.
-    PassiveLevel - TRUE if Client wants the Module options to be set to MODULE_OPTIONS_PASSIVE.
-                   NOTE: Module Options must be set to MODULE_OPTIONS_DISPATCH_MAXIMUM. 
 
 Return Value:
 
@@ -433,48 +505,57 @@ Return Value:
     NTSTATUS ntStatus;
     WDF_OBJECT_ATTRIBUTES attributes;
     ULONG lockIndex;
+    DMF_MODULE_DESCRIPTOR* moduleDescriptor;
 
     PAGED_CODE();
 
     FuncEntryArguments(DMF_TRACE, "DmfObject=0x%p [%s]", DmfObject, DmfObject->ClientModuleInstanceName);
 
-    ASSERT(ModuleDescriptor->NumberOfAuxiliaryLocks <= DMF_MAXIMUM_AUXILIARY_LOCKS);
+    moduleDescriptor = &DmfObject->ModuleDescriptor;
 
-    if (ModuleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_DISPATCH_MAXIMUM)
+    ASSERT(moduleDescriptor->NumberOfAuxiliaryLocks <= DMF_MAXIMUM_AUXILIARY_LOCKS);
+
+    if (moduleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_DISPATCH_MAXIMUM)
     {
         if (PassiveLevel)
         {
-            ModuleDescriptor->ModuleOptions |= DMF_MODULE_OPTIONS_PASSIVE;
+            moduleDescriptor->ModuleOptions |= DMF_MODULE_OPTIONS_PASSIVE;
         }
         else
         {
-            ModuleDescriptor->ModuleOptions |= DMF_MODULE_OPTIONS_DISPATCH;
+            moduleDescriptor->ModuleOptions |= DMF_MODULE_OPTIONS_DISPATCH;
         }
     }
     else
     {
-        ASSERT(FALSE == PassiveLevel);
+        if ((moduleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_DISPATCH) &&
+            PassiveLevel)
+        {
+            ASSERT(FALSE);
+            ntStatus = STATUS_INVALID_DEVICE_REQUEST;
+            goto Exit;
+        }
     }
 
     // Create the locking mechanism based on Module Options.
     //
-    if (ModuleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_PASSIVE)
+    if (moduleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_PASSIVE)
     {
         TraceInformation(DMF_TRACE, "DMF_MODULE_OPTIONS_PASSIVE");
 
-        ASSERT(! (ModuleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_DISPATCH));
+        ASSERT(! (moduleDescriptor->ModuleOptions & DMF_MODULE_OPTIONS_DISPATCH));
 
         // Create the Generic PASSIVE_LEVEL Lock for the Auxiliary Synchronization and one device lock.
         //
-        for (lockIndex = 0; lockIndex < ModuleDescriptor->NumberOfAuxiliaryLocks + DMF_NUMBER_OF_DEFAULT_LOCKS; lockIndex++)
+        for (lockIndex = 0; lockIndex < moduleDescriptor->NumberOfAuxiliaryLocks + DMF_NUMBER_OF_DEFAULT_LOCKS; lockIndex++)
         {
             WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
-            attributes.ParentObject = ParentDevice;
+            attributes.ParentObject = DmfObject->ParentDevice;
             ntStatus = WdfWaitLockCreate(&attributes,
                                          &DmfObject->Synchronizations[lockIndex].SynchronizationPassiveWaitLock);
             if (! NT_SUCCESS(ntStatus))
             {
-                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Unable to create locks");
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfSpinLockCreate fails: ntStatus=%!STATUS!", ntStatus);
                 goto Exit;
             }
         }
@@ -485,15 +566,15 @@ Return Value:
 
         // Create the Generic DISPATCH_LEVEL Lock for the Auxiliary Synchronization and one device lock.
         //
-        for (lockIndex = 0; lockIndex < ModuleDescriptor->NumberOfAuxiliaryLocks + DMF_NUMBER_OF_DEFAULT_LOCKS; lockIndex++)
+        for (lockIndex = 0; lockIndex < moduleDescriptor->NumberOfAuxiliaryLocks + DMF_NUMBER_OF_DEFAULT_LOCKS; lockIndex++)
         {
             WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
-            attributes.ParentObject = ParentDevice;
+            attributes.ParentObject = DmfObject->ParentDevice;
             ntStatus = WdfSpinLockCreate(&attributes,
                                          &DmfObject->Synchronizations[lockIndex].SynchronizationDispatchSpinLock);
             if (! NT_SUCCESS(ntStatus))
             {
-                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Unable to create locks");
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfSpinLockCreate fails: ntStatus=%!STATUS!", ntStatus);
                 goto Exit;
             }
         }

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -197,6 +197,9 @@ struct _DMF_OBJECT_
     // DMF Module Descriptor.
     //
     DMF_MODULE_DESCRIPTOR ModuleDescriptor;
+    // DMF Module Attributes.
+    //
+    DMF_MODULE_ATTRIBUTES ModuleAttributes;
     // DMF Module Callbacks (optional, set by Client).
     //
     DMF_MODULE_EVENT_CALLBACKS Callbacks;
@@ -212,7 +215,7 @@ struct _DMF_OBJECT_
     // Remember this Module is created directly by the Client, not part of a Collection.
     // It is important because it needs to be automatically closed prior to being destroyed.
     //
-    BOOLEAN DynamicModule;
+    BOOLEAN DynamicModuleImmediate;
     // List of this Module's Child Modules.
     //
     LIST_ENTRY ChildObjectList;
@@ -221,7 +224,7 @@ struct _DMF_OBJECT_
     ULONG NumberOfChildModules;
     // Collection of Interface Bindings where this Module is either the Transport or the Protocol.
     //
-    // sweana: do we need a lock to protect this?
+    // TODO: Check if a lock is needed to protect this?
     //
     WDFCOLLECTION InterfaceBindings;
     // Spin Lock to protect access to InterfaceBindings.
@@ -247,7 +250,7 @@ struct _DMF_OBJECT_
     // Client Cleanup Callback (chained).
     //
     PFN_WDF_OBJECT_CONTEXT_CLEANUP ClientEvtCleanupCallback;
-    // indicates this Module is a Transport.
+    // Indicates this Module is a Transport.
     //
     BOOLEAN IsTransport;
     // Transport Interface GUID for validation.
@@ -541,8 +544,6 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_SynchronizationCreate(
     _In_ DMF_OBJECT* DmfObject,
-    _In_ WDFDEVICE ParentDevice,
-    _In_ DMF_MODULE_DESCRIPTOR* ModuleDescriptor,
     _In_ BOOLEAN PassiveLevel
     );
 

--- a/Dmf/Framework/DmfModule.h
+++ b/Dmf/Framework/DmfModule.h
@@ -793,6 +793,18 @@ DMF_ModuleConfigGet(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_IsModuleDynamic(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_IsModulePassive(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_ModuleReference(

--- a/Dmf/Framework/DmfModule.h
+++ b/Dmf/Framework/DmfModule.h
@@ -800,7 +800,7 @@ DMF_IsModuleDynamic(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
-DMF_IsModulePassive(
+DMF_IsModulePassiveLevel(
     _In_ DMFMODULE DmfModule
     );
 

--- a/Dmf/Framework/DmfModuleCollection.c
+++ b/Dmf/Framework/DmfModuleCollection.c
@@ -2787,7 +2787,7 @@ Return Value:
 
     // Module is created as part of a collection. It is not a DynamicModule.
     //
-    ModuleAttributes->DynamicModule = FALSE;
+    ModuleAttributes->DynamicModuleImmediate = FALSE;
 
     WDFMEMORY memoryConfigAndAttributes;
     VOID* memoryConfigAndAttributesBuffer;
@@ -3465,10 +3465,12 @@ Return Value:
         if (ModuleCollectionConfig->DmfPrivate.ParentDmfModule != NULL)
         {
             moduleObjectAttributesPointer->ParentObject = ModuleCollectionConfig->DmfPrivate.ParentDmfModule;
+            moduleAttributesPointer->DynamicModule = DMF_IsModuleDynamic(ModuleCollectionConfig->DmfPrivate.ParentDmfModule);
         }
         else
         {
             moduleObjectAttributesPointer->ParentObject = ModuleCollectionConfig->DmfPrivate.ClientDriverWdfDevice;
+            moduleAttributesPointer->DynamicModule = FALSE;
         }
         ntStatus = moduleAttributesPointer->InstanceCreator(ModuleCollectionConfig->DmfPrivate.ClientDriverWdfDevice,
                                                             moduleAttributesPointer,

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Registry.h
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Registry.h
@@ -13,7 +13,6 @@ Abstract:
 Environment:
 
     Kernel-mode Driver Framework
-    User-mode Driver Framework
 
 --*/
 

--- a/Dmf/Modules.Library/Dmf_CmApi.h
+++ b/Dmf/Modules.Library/Dmf_CmApi.h
@@ -107,6 +107,16 @@ DMF_CmApi_ParentTargetInterfacesEnumerate(
     _Inout_ VOID* ClientContext
     );
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_CmApi_PropertyUint32Get(
+    _In_ DMFMODULE DmfModule,
+    _In_ GUID* PropertyInterfaceGuid,
+    _In_ PDEVPROPKEY PropertyKey,
+    _Out_ UINT32* Value
+    );
+
+
 #endif // defined(DMF_USER_MODE)
 
 // eof: Dmf_CmApi.h

--- a/Dmf/Modules.Library/Dmf_CmApi.md
+++ b/Dmf/Modules.Library/Dmf_CmApi.md
@@ -283,6 +283,41 @@ ClientContext | Client context passed to ParentTargetCallback.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_CmApi_PropertyUint32Get
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_CmApi_PropertyUint32Get(
+    _In_ DMFMODULE DmfModule,
+    _In_ GUID* PropertyInterfaceGuid,
+    _In_ PDEVPROPKEY PropertyKey,
+    _Out_ UINT32* Value
+    );
+````
+
+Given a device interface GUID, return the UINT32 value of the specified device property key.
+
+##### Returns
+
+* STATUS_SUCCESS - on a successfull query, and a CONFIGRET error converted to an NTSTATUS code on failure.
+
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_CmApi Module handle.
+PropertyInterfaceGuid | The GUID specifying the device interface to query.
+PropertyKey | The property key to query the value of.
+Value | The UINT32 value of this property if found.
+
+##### Remarks
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+
 #### Module Children
 
 * None

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
@@ -59,9 +59,6 @@ typedef struct
     // Completion routine for stream asynchronous requests.
     //
     EVT_WDF_REQUEST_COMPLETION_ROUTINE* CompletionRoutineStream;
-    // Completion routine for single asynchronous requests.
-    //
-    EVT_WDF_REQUEST_COMPLETION_ROUTINE* CompletionRoutineSingle;
     // IO Target to Send Requests to.
     //
     WDFIOTARGET IoTarget;
@@ -164,6 +161,36 @@ Return Value:
     }
     TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "BufferEnd");
 #endif // defined(DEBUG)
+}
+
+static
+VOID
+ContinuousRequestTarget_DeleteStreamRequestsFromCollection(
+    _In_ DMF_CONTEXT_ContinuousRequestTarget* ModuleContext
+)
+/*++
+
+Routine Description:
+
+    Remove and delete requests collected in CreatedStreamRequestsCollection.
+
+Arguments:
+
+    ModuleContext - This Module's context.
+
+Return Value:
+
+    None
+
+--*/
+{
+    WDFREQUEST request;
+    while ((request = (WDFREQUEST)WdfCollectionGetFirstItem(ModuleContext->CreatedStreamRequestsCollection)) != NULL)
+    {
+        WdfCollectionRemoveItem(ModuleContext->CreatedStreamRequestsCollection,
+                                0);
+        WdfObjectDelete(request);
+    }
 }
 
 #if !defined(DMF_USER_MODE)
@@ -1174,6 +1201,7 @@ ContinuousRequestTarget_RequestCreateAndSend(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _Out_opt_ size_t* BytesWritten,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
@@ -1193,7 +1221,10 @@ Arguments:
     ResponseLength - Size of Response Buffer in bytes.
     RequestIoctl - The given IOCTL.
     RequestTimeoutMilliseconds - Timeout value in milliseconds of the transfer or zero for no timeout.
+    CompletionOption - Completion option associated with the completion routine. 
     BytesWritten - Bytes returned by the transaction.
+    EvtContinuousRequestTargetSingleAsynchronousRequest - Completion routine. 
+    SingleAsynchronousRequestClientContext - Client context returned in completion routine. 
 
 Return Value:
 
@@ -1214,6 +1245,7 @@ Return Value:
     DMF_CONTEXT_ContinuousRequestTarget* moduleContext;
     DMF_CONFIG_ContinuousRequestTarget* moduleConfig;
     WDFDEVICE device;
+    EVT_WDF_REQUEST_COMPLETION_ROUTINE* completionRoutineSingle;
     ContinuousRequestTarget_SingleAsynchronousRequestContext* singleAsynchronousRequestContext;
     VOID* singleBufferContext;
 
@@ -1234,7 +1266,7 @@ Return Value:
     moduleConfig = DMF_CONFIG_GET(DmfModule);
 
     WDF_OBJECT_ATTRIBUTES_INIT(&requestAttributes);
-    requestAttributes.ParentObject = DmfModule;
+    requestAttributes.ParentObject = device;
     request = NULL;
     ntStatus = WdfRequestCreate(&requestAttributes,
                                 moduleContext->IoTarget,
@@ -1316,6 +1348,20 @@ Return Value:
             goto Exit;
         }
 
+        if (CompletionOption == ContinuousRequestTarget_CompletionOptions_Default)
+        {
+            completionRoutineSingle = ContinuousRequestTarget_CompletionRoutine;
+        }
+        else if (CompletionOption == ContinuousRequestTarget_CompletionOptions_Passive)
+        {
+            completionRoutineSingle = ContinuousRequestTarget_CompletionRoutinePassive;
+        }
+        else
+        {
+            completionRoutineSingle = ContinuousRequestTarget_CompletionRoutine;
+            ASSERT(FALSE);
+        }
+
         singleAsynchronousRequestContext->DmfModule = DmfModule;
         singleAsynchronousRequestContext->SingleAsynchronousCallbackClientContext = SingleAsynchronousRequestClientContext;
         singleAsynchronousRequestContext->EvtContinuousRequestTargetSingleAsynchronousRequest = EvtContinuousRequestTargetSingleAsynchronousRequest;
@@ -1324,7 +1370,7 @@ Return Value:
         // Set the completion routine to internal completion routine of this Module.
         //
         WdfRequestSetCompletionRoutine(request,
-                                       moduleContext->CompletionRoutineSingle,
+                                       completionRoutineSingle,
                                        singleAsynchronousRequestContext);
     }
 
@@ -1771,8 +1817,11 @@ Return Value:
     DMF_MODULE_ATTRIBUTES moduleAttributes;
     DMF_CONFIG_ContinuousRequestTarget* moduleConfig;
     DMF_CONTEXT_ContinuousRequestTarget* moduleContext;
-    DMF_CONFIG_BufferPool moduleConfigBufferPool;
-    DMF_CONFIG_QueuedWorkItem moduleConfigQueuedWorkItem;
+    DMF_CONFIG_BufferPool moduleConfigBufferPoolInput;
+    DMF_CONFIG_BufferPool moduleConfigBufferPoolOutput;
+    DMF_CONFIG_BufferPool moduleConfigBufferPoolContext;
+    DMF_CONFIG_QueuedWorkItem moduleConfigQueuedWorkItemStream;
+    DMF_CONFIG_QueuedWorkItem moduleConfigQueuedWorkItemSingle;
 
     PAGED_CODE();
 
@@ -1788,14 +1837,14 @@ Return Value:
         // BufferPoolInput
         // ---------------
         //
-        DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+        DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPoolInput,
                                                   &moduleAttributes);
-        moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
-        moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = FALSE;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferCount = moduleConfig->BufferCountInput;
-        moduleConfigBufferPool.Mode.SourceSettings.PoolType = moduleConfig->PoolTypeInput;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferSize = moduleConfig->BufferInputSize;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextInputSize;
+        moduleConfigBufferPoolInput.BufferPoolMode = BufferPool_Mode_Source;
+        moduleConfigBufferPoolInput.Mode.SourceSettings.EnableLookAside = FALSE;
+        moduleConfigBufferPoolInput.Mode.SourceSettings.BufferCount = moduleConfig->BufferCountInput;
+        moduleConfigBufferPoolInput.Mode.SourceSettings.PoolType = moduleConfig->PoolTypeInput;
+        moduleConfigBufferPoolInput.Mode.SourceSettings.BufferSize = moduleConfig->BufferInputSize;
+        moduleConfigBufferPoolInput.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextInputSize;
         moduleAttributes.ClientModuleInstanceName = "BufferPoolInput";
         moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
         DMF_DmfModuleAdd(DmfModuleInit,
@@ -1813,14 +1862,14 @@ Return Value:
         // BufferPoolOutput
         // ----------------
         //
-        DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+        DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPoolOutput,
                                                   &moduleAttributes);
-        moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
-        moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = moduleConfig->EnableLookAsideOutput;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferCount = moduleConfig->BufferCountOutput;
-        moduleConfigBufferPool.Mode.SourceSettings.PoolType = moduleConfig->PoolTypeOutput;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferSize = moduleConfig->BufferOutputSize;
-        moduleConfigBufferPool.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextOutputSize;
+        moduleConfigBufferPoolOutput.BufferPoolMode = BufferPool_Mode_Source;
+        moduleConfigBufferPoolOutput.Mode.SourceSettings.EnableLookAside = moduleConfig->EnableLookAsideOutput;
+        moduleConfigBufferPoolOutput.Mode.SourceSettings.BufferCount = moduleConfig->BufferCountOutput;
+        moduleConfigBufferPoolOutput.Mode.SourceSettings.PoolType = moduleConfig->PoolTypeOutput;
+        moduleConfigBufferPoolOutput.Mode.SourceSettings.BufferSize = moduleConfig->BufferOutputSize;
+        moduleConfigBufferPoolOutput.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextOutputSize;
         moduleAttributes.ClientModuleInstanceName = "BufferPoolOutput";
         moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
         DMF_DmfModuleAdd(DmfModuleInit,
@@ -1836,16 +1885,16 @@ Return Value:
     // BufferPoolContext
     // -----------------
     //
-    DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+    DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPoolContext,
                                               &moduleAttributes);
-    moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
-    moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = TRUE;
-    moduleConfigBufferPool.Mode.SourceSettings.BufferCount = 1;
+    moduleConfigBufferPoolContext.BufferPoolMode = BufferPool_Mode_Source;
+    moduleConfigBufferPoolContext.Mode.SourceSettings.EnableLookAside = TRUE;
+    moduleConfigBufferPoolContext.Mode.SourceSettings.BufferCount = 1;
     // NOTE: BufferPool context must always be NonPagedPool because it is accessed in the
     //       completion routine running at DISPATCH_LEVEL.
     //
-    moduleConfigBufferPool.Mode.SourceSettings.PoolType = NonPagedPoolNx;
-    moduleConfigBufferPool.Mode.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_SingleAsynchronousRequestContext);
+    moduleConfigBufferPoolContext.Mode.SourceSettings.PoolType = NonPagedPoolNx;
+    moduleConfigBufferPoolContext.Mode.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_SingleAsynchronousRequestContext);
     moduleAttributes.ClientModuleInstanceName = "BufferPoolContext";
     moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
     DMF_DmfModuleAdd(DmfModuleInit,
@@ -1853,47 +1902,45 @@ Return Value:
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &moduleContext->DmfModuleBufferPoolContext);
 
+    // QueuedWorkItemSingle
+    // --------------------
+    //
+    DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItemSingle,
+                                                  &moduleAttributes);
+    moduleConfigQueuedWorkItemSingle.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
+    moduleConfigQueuedWorkItemSingle.BufferQueueConfig.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_QueuedWorkitemContext);
+    // This has to be NonPagedPoolNx because completion routine runs at dispatch level.
+    //
+    moduleConfigQueuedWorkItemSingle.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
+    moduleConfigQueuedWorkItemSingle.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
+    moduleConfigQueuedWorkItemSingle.EvtQueuedWorkitemFunction = ContinuousRequestTarget_QueuedWorkitemCallbackSingle;
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleQueuedWorkitemSingle);
+
     if (DmfParentModuleAttributes->PassiveLevel)
     {
-        moduleContext->CompletionRoutineSingle = ContinuousRequestTarget_CompletionRoutinePassive;
         moduleContext->CompletionRoutineStream = ContinuousRequestTarget_StreamCompletionRoutinePassive;
         // QueuedWorkItemStream
         // --------------------
         //
-        DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItem,
+        DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItemStream,
                                                       &moduleAttributes);
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_QueuedWorkitemContext);
+        moduleConfigQueuedWorkItemStream.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
+        moduleConfigQueuedWorkItemStream.BufferQueueConfig.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_QueuedWorkitemContext);
         // This has to be NonPagedPoolNx because completion routine runs at dispatch level.
         //
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
-        moduleConfigQueuedWorkItem.EvtQueuedWorkitemFunction = ContinuousRequestTarget_QueuedWorkitemCallbackStream;
+        moduleConfigQueuedWorkItemStream.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
+        moduleConfigQueuedWorkItemStream.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
+        moduleConfigQueuedWorkItemStream.EvtQueuedWorkitemFunction = ContinuousRequestTarget_QueuedWorkitemCallbackStream;
         DMF_DmfModuleAdd(DmfModuleInit,
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          &moduleContext->DmfModuleQueuedWorkitemStream);
-
-        // QueuedWorkItemSingle
-        // --------------------
-        //
-        DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItem,
-                                                      &moduleAttributes);
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferSize = sizeof(ContinuousRequestTarget_QueuedWorkitemContext);
-        // This has to be NonPagedPoolNx because completion routine runs at dispatch level.
-        //
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
-        moduleConfigQueuedWorkItem.EvtQueuedWorkitemFunction = ContinuousRequestTarget_QueuedWorkitemCallbackSingle;
-        DMF_DmfModuleAdd(DmfModuleInit,
-                         &moduleAttributes,
-                         WDF_NO_OBJECT_ATTRIBUTES,
-                         &moduleContext->DmfModuleQueuedWorkitemSingle);
     }
     else
     {
-        moduleContext->CompletionRoutineSingle = ContinuousRequestTarget_CompletionRoutine;
         moduleContext->CompletionRoutineStream = ContinuousRequestTarget_StreamCompletionRoutine;
     }
 
@@ -1929,11 +1976,13 @@ Return Value:
     DMF_CONTEXT_ContinuousRequestTarget* moduleContext;
     DMF_CONFIG_ContinuousRequestTarget* moduleConfig;
     WDF_OBJECT_ATTRIBUTES objectAttributes;
+    WDFDEVICE device;
 
     PAGED_CODE();
 
     FuncEntry(DMF_TRACE);
 
+    device = DMF_ParentDeviceGet(DmfModule);
     moduleContext = DMF_CONTEXT_GET(DmfModule);
     moduleConfig = DMF_CONFIG_GET(DmfModule);
 
@@ -1981,7 +2030,14 @@ Return Value:
             WDFREQUEST request;
 
             WDF_OBJECT_ATTRIBUTES_INIT(&requestAttributes);
-            requestAttributes.ParentObject = DmfModule;
+            // The request is being parented to the device explicitly to handle deletion.
+            // When a dynamic module tree is deleted, the child objects are deleted first before the parent.
+            // So, if request is a child of this module and this module gets implicitly deleted, 
+            // the requests get the delete operation first. And if the reqeust is already sent to an IO Target, 
+            // WDF verifier complains about it.
+            // Thus request is parented to device, and are deleted when the collection is deleted in DMF close callback. 
+            //
+            requestAttributes.ParentObject = device;
 
             ntStatus = WdfRequestCreate(&requestAttributes,
                                         moduleContext->IoTarget,
@@ -2015,6 +2071,7 @@ Exit:
     {
         if(moduleContext->CreatedStreamRequestsCollection != NULL)
         {
+            ContinuousRequestTarget_DeleteStreamRequestsFromCollection(moduleContext);
             WdfObjectDelete(moduleContext->CreatedStreamRequestsCollection);
             moduleContext->CreatedStreamRequestsCollection = NULL;
         }
@@ -2083,6 +2140,7 @@ Return Value:
 
     if (moduleContext->CreatedStreamRequestsCollection != NULL)
     {
+        ContinuousRequestTarget_DeleteStreamRequestsFromCollection(moduleContext);
         WdfObjectDelete(moduleContext->CreatedStreamRequestsCollection);
         moduleContext->CreatedStreamRequestsCollection = NULL;
     }
@@ -2152,6 +2210,7 @@ Return Value:
 
     if (moduleConfig->PurgeAndStartTargetInD0Callbacks)
     {
+        ASSERT(DmfModuleAttributes->DynamicModule == FALSE);
         DMF_CALLBACKS_WDF_INIT(&dmfCallbacksWdf_ContinuousRequestTarget);
         dmfCallbacksWdf_ContinuousRequestTarget.ModuleD0Entry = DMF_ContinuousRequestTarget_ModuleD0Entry;
         dmfCallbacksWdf_ContinuousRequestTarget.ModuleD0Exit = DMF_ContinuousRequestTarget_ModuleD0Exit;
@@ -2337,6 +2396,98 @@ Return Value:
 
 --*/
 {
+    NTSTATUS ntStatus;
+    ContinuousRequestTarget_CompletionOptions completionOption;
+
+    FuncEntry(DMF_TRACE);
+
+    ntStatus = STATUS_SUCCESS;
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 ContinuousRequestTarget);
+
+    ntStatus = DMF_ModuleReference(DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    if (DMF_IsModulePassive(DmfModule))
+    {
+        completionOption = ContinuousRequestTarget_CompletionOptions_Passive;
+    }
+    else
+    {
+        completionOption = ContinuousRequestTarget_CompletionOptions_Dispatch;
+    }
+
+    ntStatus = ContinuousRequestTarget_RequestCreateAndSend(DmfModule,
+                                                            FALSE,
+                                                            RequestBuffer,
+                                                            RequestLength,
+                                                            ResponseBuffer,
+                                                            ResponseLength,
+                                                            RequestType,
+                                                            RequestIoctl,
+                                                            RequestTimeoutMilliseconds,
+                                                            completionOption,
+                                                            NULL,
+                                                            EvtContinuousRequestTargetSingleAsynchronousRequest,
+                                                            SingleAsynchronousRequestClientContext);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        DMF_ModuleDereference(DmfModule);
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "ContinuousRequestTarget_RequestCreateAndSend fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+Exit:
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_ContinuousRequestTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    )
+/*++
+
+Routine Description:
+
+    Creates and sends a Asynchronous request to the IoTarget given a buffer, IOCTL and other information.
+    Once the request is complete, EvtContinuousRequestTargetSingleAsynchronousRequest will be called at passive level. 
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    RequestBuffer - Buffer of data to attach to request to be sent.
+    RequestLength - Number of bytes to in RequestBuffer to send.
+    ResponseBuffer - Buffer of data that is returned by the request.
+    ResponseLength - Size of Response Buffer in bytes.
+    RequestType - Read or Write or Ioctl
+    RequestIoctl - The given IOCTL.
+    RequestTimeoutMilliseconds - Timeout value in milliseconds of the transfer or zero for no timeout.
+    EvtContinuousRequestTargetSingleAsynchronousRequest - Callback to be called in completion routine.
+    SingleAsynchronousRequestClientContext - Client context sent in callback
+
+Return Value:
+
+    STATUS_SUCCESS if a buffer is added to the list.
+    Other NTSTATUS if there is an error.
+
+--*/
+{
     NTSTATUS ntStatus = STATUS_SUCCESS;
 
     FuncEntry(DMF_TRACE);
@@ -2359,6 +2510,7 @@ Return Value:
                                                             RequestType,
                                                             RequestIoctl,
                                                             RequestTimeoutMilliseconds,
+                                                            CompletionOption,
                                                             NULL,
                                                             EvtContinuousRequestTargetSingleAsynchronousRequest,
                                                             SingleAsynchronousRequestClientContext);
@@ -2428,6 +2580,7 @@ Return Value:
                                                             RequestType,
                                                             RequestIoctl,
                                                             RequestTimeoutMilliseconds,
+                                                            ContinuousRequestTarget_CompletionOptions_Default,
                                                             BytesWritten,
                                                             NULL,
                                                             NULL);

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
@@ -2412,7 +2412,7 @@ Return Value:
         goto Exit;
     }
 
-    if (DMF_IsModulePassive(DmfModule))
+    if (DMF_IsModulePassiveLevel(DmfModule))
     {
         completionOption = ContinuousRequestTarget_CompletionOptions_Passive;
     }

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
@@ -92,6 +92,18 @@ EVT_DMF_ContinuousRequestTarget_SendCompletion(_In_ DMFMODULE DmfModule,
                                                _In_ size_t OutputBufferBytesRead,
                                                _In_ NTSTATUS CompletionStatus);
 
+typedef enum
+{
+    // EVT_DMF_ContinuousRequestTarget_SendCompletion will be called at dispatch level.
+    //
+    ContinuousRequestTarget_CompletionOptions_Dispatch = 0,
+    ContinuousRequestTarget_CompletionOptions_Default = 0,
+    // EVT_DMF_ContinuousRequestTarget_SendCompletion will be called at passive level.
+    //
+    ContinuousRequestTarget_CompletionOptions_Passive,
+    ContinuousRequestTarget_CompletionOptions_Maximum,
+} ContinuousRequestTarget_CompletionOptions;
+
 // These definitions indicate the mode of ContinuousRequestTarget.
 // Indicates how and when the Requests start and stop streaming.
 //
@@ -212,6 +224,22 @@ DMF_ContinuousRequestTarget_Send(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
+    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_ContinuousRequestTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
     );

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
@@ -158,6 +158,24 @@ ContinuousRequestTarget_Mode_Automatic | DMF_ContinuousRequestTarget_Start invok
 ContinuousRequestTarget_Mode_Manual | DMF_ContinuousRequestTarget_Start and DMF_ContinuousRequestTarget_Stop must be called explicitly by the Client when needed.
 
 -----------------------------------------------------------------------------------------------------------------------------------
+##### ContinuousRequestTarget_CompletionOptions
+These definitions indicate the completion options associated with Completion routine.
+Indicates how and when the completion routine should be called.
+
+````
+typedef enum
+{
+    ContinuousRequestTarget_CompletionOptions_Default = 0,
+    ContinuousRequestTarget_CompletionOptions_Passive,
+    ContinuousRequestTarget_CompletionOptions_Maximum,
+} ContinuousRequestTarget_CompletionOptions;
+````
+Member | Description
+----|----
+ContinuousRequestTarget_CompletionOptions_Default | EVT_DMF_ContinuousRequestTarget_SendCompletion will be called at dispatch level.
+ContinuousRequestTarget_Mode_Manual | EVT_DMF_ContinuousRequestTarget_SendCompletion will be called at passive level.
+
+-----------------------------------------------------------------------------------------------------------------------------------
 
 #### Module Structures
 
@@ -388,6 +406,51 @@ SingleAsynchronousRequestClientContext | The Client specific context that is sen
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_ContinuousRequestTarget_SendEx
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_ContinuousRequestTarget_SendEx(
+  _In_ DMFMODULE DmfModule,
+  _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+  _In_ size_t RequestLength,
+  _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+  _In_ size_t ResponseLength,
+  _In_ ContinuousRequestTarget_RequestType RequestType,
+  _In_ ULONG RequestIoctl,
+  _In_ ULONG RequestTimeoutMilliseconds,
+  _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+  _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+  _In_opt_ VOID* SingleAsynchronousRequestClientContext
+  );
+````
+
+This Method uses the given parameters to create a Request and send it asynchronously to the Module's underlying WDFIOTARGET.
+Ex version of DMF_RequestTarget_Send, allows the clients to specify ContinuousRequestTarget_CompletionOptions, which controls how completion routine will be called. 
+
+##### Returns
+
+NTSTATUS. Fails if the Request cannot be sent to the Modules internal WDFIOTARGET.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_ContinuousRequestTarget Module handle.
+RequestBuffer | The Client buffer that is sent to this Module's underlying WDFIOTARGET.
+RequestLength | The size in bytes of RequestBuffer.
+ResponseBuffer | The Client buffer that receives data from this Module's underlying WDFIOTARGET.
+ResponseLength | The size in bytes of ResponseBuffer.
+RequestType | The type of Request to send to this Module's underlying WDFIOTARGET.
+RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purpose of the associated Request that is sent.
+RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
+CompletionOption | Completion option associated with the completion routine.
+EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
+SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_ContinuousRequestTarget_SendSynchronously
 
 ````

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -63,6 +63,7 @@ RequestSink_Send_Type(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
     );
@@ -130,6 +131,7 @@ typedef struct
     RequestSink_Send_Type* RequestSink_Send;
     RequestSink_IoTargetSet_Type* RequestSink_IoTargetSet;
     RequestSink_IoTargetClear_Type* RequestSink_IoTargetClear;
+    ContinuousRequestTarget_CompletionOptions DefaultCompletionOption;
 } DMF_CONTEXT_DeviceInterfaceTarget;
 
 // This macro declares the following function:
@@ -421,6 +423,7 @@ DeviceInterfaceTarget_Stream_Send(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
     )
@@ -430,16 +433,17 @@ DeviceInterfaceTarget_Stream_Send(
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     ASSERT(moduleContext->OpenedInStreamMode);
-    return DMF_ContinuousRequestTarget_Send(moduleContext->DmfModuleContinuousRequestTarget,
-                                            RequestBuffer,
-                                            RequestLength,
-                                            ResponseBuffer,
-                                            ResponseLength,
-                                            RequestType,
-                                            RequestIoctl,
-                                            RequestTimeoutMilliseconds,
-                                            EvtRequestSinkSingleAsynchronousRequest,
-                                            SingleAsynchronousRequestClientContext);
+    return DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
+                                              RequestBuffer,
+                                              RequestLength,
+                                              ResponseBuffer,
+                                              ResponseLength,
+                                              RequestType,
+                                              RequestIoctl,
+                                              RequestTimeoutMilliseconds,
+                                              CompletionOption,
+                                              EvtRequestSinkSingleAsynchronousRequest,
+                                              SingleAsynchronousRequestClientContext);
 }
 
 VOID
@@ -516,28 +520,28 @@ DeviceInterfaceTarget_Target_Send(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
-    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
     )
 {
-    NTSTATUS ntStatus;
     DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     ASSERT(! moduleContext->OpenedInStreamMode);
-    ntStatus = DMF_RequestTarget_Send(moduleContext->DmfModuleRequestTarget,
-                                      RequestBuffer,
-                                      RequestLength,
-                                      ResponseBuffer,
-                                      ResponseLength,
-                                      RequestType,
-                                      RequestIoctl,
-                                      RequestTimeoutMilliseconds,
-                                      EvtRequestSinkSingleAsynchronousRequest,
-                                      SingleAsynchronousRequestClientContext);
 
-    return ntStatus;
+    return DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
+                                    RequestBuffer,
+                                    RequestLength,
+                                    ResponseBuffer,
+                                    ResponseLength,
+                                    RequestType,
+                                    RequestIoctl,
+                                    RequestTimeoutMilliseconds,
+                                    CompletionOption,
+                                    EvtRequestSinkSingleAsynchronousRequest,
+                                    SingleAsynchronousRequestClientContext);
 }
 
 VOID
@@ -1642,6 +1646,15 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
+    if (DMF_IsModulePassive(DmfModule))
+    {
+        moduleContext->DefaultCompletionOption = ContinuousRequestTarget_CompletionOptions_Passive;
+    }
+    else
+    {
+        moduleContext->DefaultCompletionOption = ContinuousRequestTarget_CompletionOptions_Dispatch;
+    }
+
     moduleContext->RequestSink_IoTargetSet(DmfModule,
                                            moduleContext->IoTarget);
 
@@ -1833,10 +1846,29 @@ Return Value:
     NTSTATUS ntStatus;
     DMF_MODULE_DESCRIPTOR dmfModuleDescriptor_DeviceInterfaceTarget;
     DMF_CALLBACKS_DMF dmfCallbacksDmf_DeviceInterfaceTarget;
+    DmfModuleOpenOption openOption;
 
     PAGED_CODE();
 
     FuncEntry(DMF_TRACE);
+        
+    // For dynamic instances, this Module will register for 
+    // PnP notifications upon create. 
+    //
+    if (DmfModuleAttributes->DynamicModule)
+    {
+        openOption = DMF_MODULE_OPEN_OPTION_NOTIFY_Create;
+    }
+    else
+    {
+        openOption = DMF_MODULE_OPEN_OPTION_NOTIFY_PrepareHardware;
+    }
+
+    DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_DeviceInterfaceTarget,
+                                            DeviceInterfaceTarget,
+                                            DMF_CONTEXT_DeviceInterfaceTarget,
+                                            DMF_MODULE_OPTIONS_DISPATCH_MAXIMUM,
+                                            openOption);
 
     DMF_CALLBACKS_DMF_INIT(&dmfCallbacksDmf_DeviceInterfaceTarget);
     dmfCallbacksDmf_DeviceInterfaceTarget.DeviceOpen = DMF_DeviceInterfaceTarget_Open;
@@ -1849,12 +1881,6 @@ Return Value:
     dmfCallbacksDmf_DeviceInterfaceTarget.DeviceNotificationRegister = DMF_DeviceInterfaceTarget_NotificationRegister;
     dmfCallbacksDmf_DeviceInterfaceTarget.DeviceNotificationUnregister = DMF_DeviceInterfaceTarget_NotificationUnregister;
 #endif // defined(DMF_USER_MODE)
-
-    DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_DeviceInterfaceTarget,
-                                            DeviceInterfaceTarget,
-                                            DMF_CONTEXT_DeviceInterfaceTarget,
-                                            DMF_MODULE_OPTIONS_DISPATCH_MAXIMUM,
-                                            DMF_MODULE_OPEN_OPTION_NOTIFY_PrepareHardware);
 
     dmfModuleDescriptor_DeviceInterfaceTarget.CallbacksDmf = &dmfCallbacksDmf_DeviceInterfaceTarget;
 
@@ -2054,6 +2080,92 @@ Return Value:
                                                RequestType,
                                                RequestIoctl,
                                                RequestTimeoutMilliseconds,
+                                               moduleContext->DefaultCompletionOption,
+                                               EvtContinuousRequestTargetSingleAsynchronousRequest,
+                                               SingleAsynchronousRequestClientContext);
+
+    DMF_ModuleDereference(DmfModule);
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_DeviceInterfaceTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    )
+/*++
+
+Routine Description:
+
+    Creates and sends an Asynchronous request to the IoTarget given a buffer, IOCTL and other information.
+    Once the request completes, EvtContinuousRequestTargetSingleAsynchronousRequest will be called at passive level.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    RequestBuffer - Buffer of data to attach to request to be sent.
+    RequestLength - Number of bytes to in RequestBuffer to send.
+    ResponseBuffer - Buffer of data that is returned by the request.
+    ResponseLength - Size of Response Buffer in bytes.
+    RequestType - Read or Write or Ioctl
+    RequestIoctl - The given IOCTL.
+    RequestTimeoutMilliseconds - Timeout value in milliseconds of the transfer or zero for no timeout.
+    CompletionOption - Completion option associated with the completion routine. 
+    EvtContinuousRequestTargetSingleAsynchronousRequest - Callback to be called in completion routine.
+    SingleAsynchronousRequestClientContext - Client context sent in callback
+
+Return Value:
+
+    STATUS_SUCCESS if a buffer is added to the list.
+    Other NTSTATUS if there is an error.
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
+
+    FuncEntry(DMF_TRACE);
+
+    // This Module Method can be called when SSH is removed or being removed. The code in this function is 
+    // protected due to call to ModuleAcquire.
+    //
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 DeviceInterfaceTarget);
+
+    ntStatus = DMF_ModuleReference(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleReference");
+        goto Exit;
+    }
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    ASSERT(moduleContext->IoTarget != NULL);
+    ntStatus = moduleContext->RequestSink_Send(DmfModule,
+                                               RequestBuffer,
+                                               RequestLength,
+                                               ResponseBuffer,
+                                               ResponseLength,
+                                               RequestType,
+                                               RequestIoctl,
+                                               RequestTimeoutMilliseconds,
+                                               CompletionOption,
                                                EvtContinuousRequestTargetSingleAsynchronousRequest,
                                                SingleAsynchronousRequestClientContext);
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -1646,7 +1646,7 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
-    if (DMF_IsModulePassive(DmfModule))
+    if (DMF_IsModulePassiveLevel(DmfModule))
     {
         moduleContext->DefaultCompletionOption = ContinuousRequestTarget_CompletionOptions_Passive;
     }

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -119,6 +119,22 @@ DMF_DeviceInterfaceTarget_Send(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS
+DMF_DeviceInterfaceTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
 DMF_DeviceInterfaceTarget_SendSynchronously(
     _In_ DMFMODULE DmfModule,
     _In_reads_bytes_(RequestLength) VOID* RequestBuffer,

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -236,6 +236,51 @@ SingleAsynchronousRequestClientContext | The Client specific context that is sen
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_DeviceInterfaceTarget_SendEx
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_DeviceInterfaceTarget_SendEx(
+  _In_ DMFMODULE DmfModule,
+  _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+  _In_ size_t RequestLength,
+  _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+  _In_ size_t ResponseLength,
+  _In_ DeviceInterfaceTarget_RequestType RequestType,
+  _In_ ULONG RequestIoctl,
+  _In_ ULONG RequestTimeoutMilliseconds,
+  _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+  _In_opt_ DeviceInterfaceTarget_CallbackType_SingleAsynchronousBufferOutput EvtContinuousRequestTargetSingleAsynchronousRequest,
+  _In_opt_ VOID* SingleAsynchronousRequestClientContext
+  );
+````
+
+This Method uses the given parameters to create a Request and send it asynchronously to the Module's underlying WDFIOTARGET.
+Ex version of DMF_RequestTarget_Send, allows the clients to specify ContinuousRequestTarget_CompletionOptions, which controls how completion routine will be called. 
+
+##### Returns
+
+NTSTATUS. Fails if the Request cannot be sent to the Modules internal WDFIOTARGET.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DeviceInterfaceTarget Module handle.
+RequestBuffer | The Client buffer that is sent to this Module's underlying WDFIOTARGET.
+RequestLength | The size in bytes of RequestBuffer.
+ResponseBuffer | The Client buffer that receives data from this Module's underlying WDFIOTARGET.
+ResponseLength | The size in bytes of ResponseBuffer.
+RequestType | The type of Request to send to this Module's underlying WDFIOTARGET.
+RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purpose of the associated Request that is sent.
+RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
+CompletionOption | Completion option associated with the completion routine.
+EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
+SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_DeviceInterfaceTarget_SendSynchronously
 
 ````

--- a/Dmf/Modules.Library/Dmf_Pdo.h
+++ b/Dmf/Modules.Library/Dmf_Pdo.h
@@ -20,6 +20,51 @@ Environment:
 
 #pragma once
 
+// Holds information for a single device property.
+//
+typedef struct
+{
+    // The device property data that can be set on the SID driver.
+    //
+    WDF_DEVICE_PROPERTY_DATA DevicePropertyData;
+    
+    // The property type.
+    //
+    DEVPROPTYPE ValueType;
+    
+    // The value data for this property.
+    //
+    VOID* ValueData;
+
+    // The size of the value data.
+    //
+    ULONG ValueSize;
+    
+    // BOOL to specify if we should register the device interface GUID.
+    //
+    BOOLEAN RegisterDeviceInterface;
+
+    // Device interface GUID that will be set on this property, so that
+    // we can retrieve the properties at runtime with the CM API's.
+    // 
+    GUID* DeviceInterfaceGuid;
+} Pdo_DevicePropertyEntry;
+
+
+// Holds information for a branch of registry entries which consist of one
+// or more registry entries under a single key.
+//
+typedef struct
+{
+    // The entries int he branch.
+    //
+    Pdo_DevicePropertyEntry* TableEntries;
+
+    // The number of entries in the branch.
+    //
+    ULONG ItemCount;
+} Pdo_DeviceProperty_Table;
+
 // Allows Client to indicate if the that is about to be created PDO is required.
 //
 typedef
@@ -115,6 +160,10 @@ typedef struct
     // The callback function that instantiates DMF Modules, if applicable.
     //
     PFN_DMF_DEVICE_MODULES_ADD EvtDmfDeviceModulesAdd;
+
+    // The table entry for this device's properties.
+    //
+    Pdo_DeviceProperty_Table* DeviceProperties;
 } PDO_RECORD;
 
 // Client uses this structure to configure the Module specific parameters.

--- a/Dmf/Modules.Library/Dmf_Registry.h
+++ b/Dmf/Modules.Library/Dmf_Registry.h
@@ -224,6 +224,16 @@ DMF_Registry_HandleOpenByHandle(
 
 _Must_inspect_result_
 _IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_Registry_HandleOpenById(
+    _In_ DMFMODULE DmfModule,
+    _In_ ULONG PredefinedKeyId,
+    _In_ ULONG AccessMask,
+    _Out_ HANDLE* RegistryHandle
+    );
+
+_Must_inspect_result_
+_IRQL_requires_max_(PASSIVE_LEVEL)
 HANDLE
 DMF_Registry_HandleOpenByName(
     _In_ DMFMODULE DmfModule,

--- a/Dmf/Modules.Library/Dmf_Registry.md
+++ b/Dmf/Modules.Library/Dmf_Registry.md
@@ -418,7 +418,6 @@ Handle | The given registry handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
-
 ##### DMF_Registry_HandleOpenByHandle
 
 ````
@@ -446,6 +445,38 @@ DmfModule | An open DMF_Registry Module handle.
 Handle | The given registry handle.
 Name | The given registry path name.
 TryToCreate | Creates the path specified by Name if the path does not exist.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Registry_HandleOpenById
+
+````
+_Must_inspect_result_
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_Registry_HandleOpenById(
+    _In_ DMFMODULE DmfModule,
+    _In_ ULONG PredefinedKeyId,
+    _In_ ULONG AccessMask,
+    _Out_ HANDLE* RegistryHandle
+    );
+````
+
+Open a predefined registry key.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Registry Module handle.
+PredefinedKeyId | The Id of the predefined key to open. See IoOpenDeviceRegistryKey documentation for a list of Ids.
+AccessMask | The desired access mask. See MSDN.
+RegistryHandle | The address of the handle that is returned to the Client.
 
 ##### Remarks
 

--- a/Dmf/Modules.Library/Dmf_RequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.c
@@ -1076,12 +1076,24 @@ Return Value:
 
 --*/
 {
-    NTSTATUS ntStatus = STATUS_SUCCESS;
+    ContinuousRequestTarget_CompletionOptions completionOption;
+    NTSTATUS ntStatus;
 
     FuncEntry(DMF_TRACE);
 
     DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
                                  RequestTarget);
+
+    ntStatus = STATUS_SUCCESS;
+
+    if (DMF_IsModulePassive(DmfModule))
+    {
+        completionOption = ContinuousRequestTarget_CompletionOptions_Passive;
+    }
+    else
+    {
+        completionOption = ContinuousRequestTarget_CompletionOptions_Dispatch;
+    }
 
     ntStatus = RequestTarget_RequestCreateAndSend(DmfModule,
                                                   FALSE,
@@ -1092,7 +1104,7 @@ Return Value:
                                                   RequestType,
                                                   RequestIoctl,
                                                   RequestTimeoutMilliseconds,
-                                                  ContinuousRequestTarget_CompletionOptions_Default,
+                                                  completionOption,
                                                   NULL,
                                                   EvtRequestTargetSingleAsynchronousRequest,
                                                   SingleAsynchronousRequestClientContext);

--- a/Dmf/Modules.Library/Dmf_RequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.c
@@ -1086,7 +1086,7 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
-    if (DMF_IsModulePassive(DmfModule))
+    if (DMF_IsModulePassiveLevel(DmfModule))
     {
         completionOption = ContinuousRequestTarget_CompletionOptions_Passive;
     }

--- a/Dmf/Modules.Library/Dmf_RequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.c
@@ -46,9 +46,6 @@ typedef struct
     // Queued workitem for passive level completion routine.
     //
     DMFMODULE DmfModuleQueuedWorkitemSingle;
-    // Completion routine for single asynchronous requests.
-    //
-    EVT_WDF_REQUEST_COMPLETION_ROUTINE* CompletionRoutineSingle;
     // IO Target to Send Requests to.
     //
     WDFIOTARGET IoTarget;
@@ -526,6 +523,7 @@ RequestTarget_RequestCreateAndSend(
     _In_ ContinuousRequestTarget_RequestType RequestType,
     _In_ ULONG RequestIoctl,
     _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _Out_opt_ size_t* BytesWritten,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
@@ -545,7 +543,10 @@ Arguments:
     ResponseLength - Size of Response Buffer in bytes.
     RequestIoctl - The given IOCTL.
     RequestTimeoutMilliseconds - Timeout value in milliseconds of the transfer or zero for no timeout.
+    CompletionOption - Completion option associated with the completion routine. 
     BytesWritten - Bytes returned by the transaction.
+    EvtContinuousRequestTargetSingleAsynchronousRequest - Completion routine. 
+    SingleAsynchronousRequestClientContext - Client context returned in completion routine. 
 
 Return Value:
 
@@ -565,6 +566,7 @@ Return Value:
     BOOLEAN requestSendResult;
     DMF_CONTEXT_RequestTarget* moduleContext;
     WDFDEVICE device;
+    EVT_WDF_REQUEST_COMPLETION_ROUTINE* completionRoutineSingle;
     RequestTarget_SingleAsynchronousRequestContext* singleAsynchronousRequestContext;
     VOID* singleBufferContext;
 
@@ -667,6 +669,20 @@ Return Value:
             goto Exit;
         }
 
+        if (CompletionOption == ContinuousRequestTarget_CompletionOptions_Default)
+        {
+            completionRoutineSingle = RequestTarget_CompletionRoutine;
+        }
+        else if (CompletionOption == ContinuousRequestTarget_CompletionOptions_Passive)
+        {
+            completionRoutineSingle = RequestTarget_CompletionRoutinePassive;
+        }
+        else
+        {
+            completionRoutineSingle = RequestTarget_CompletionRoutine;
+            ASSERT(FALSE);
+        }
+
         singleAsynchronousRequestContext->DmfModule = DmfModule;
         singleAsynchronousRequestContext->SingleAsynchronousCallbackClientContext = SingleAsynchronousRequestClientContext;
         singleAsynchronousRequestContext->EvtRequestTargetSingleAsynchronousRequest = EvtRequestTargetSingleAsynchronousRequest;
@@ -675,7 +691,7 @@ Return Value:
         // Set the completion routine to internal completion routine of this Module.
         //
         WdfRequestSetCompletionRoutine(request,
-                                       moduleContext->CompletionRoutineSingle,
+                                       completionRoutineSingle,
                                        singleAsynchronousRequestContext);
     }
 
@@ -848,31 +864,22 @@ Return Value:
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &moduleContext->DmfModuleBufferPoolContext);
 
-    if (DmfParentModuleAttributes->PassiveLevel)
-    {
-        moduleContext->CompletionRoutineSingle = RequestTarget_CompletionRoutinePassive;
-
-        // QueuedWorkItemSingle
-        // --------------------
-        //
-        DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItem,
-                                                      &moduleAttributes);
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferSize = sizeof(RequestTarget_QueuedWorkitemContext);
-        // This has to be NonPagedPoolNx because completion routine runs at dispatch level.
-        //
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
-        moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
-        moduleConfigQueuedWorkItem.EvtQueuedWorkitemFunction = RequestTarget_QueuedWorkitemCallbackSingle;
-        DMF_DmfModuleAdd(DmfModuleInit,
-                         &moduleAttributes,
-                         WDF_NO_OBJECT_ATTRIBUTES,
-                         &moduleContext->DmfModuleQueuedWorkitemSingle);
-    }
-    else
-    {
-        moduleContext->CompletionRoutineSingle = RequestTarget_CompletionRoutine;
-    }
+    // QueuedWorkItemSingle
+    // --------------------
+    //
+    DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT(&moduleConfigQueuedWorkItem,
+                                                    &moduleAttributes);
+    moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferCount = DEFAULT_NUMBER_OF_PENDING_PASSIVE_LEVEL_COMPLETION_ROUTINES;
+    moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.BufferSize = sizeof(RequestTarget_QueuedWorkitemContext);
+    // This has to be NonPagedPoolNx because completion routine runs at dispatch level.
+    //
+    moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.PoolType = NonPagedPoolNx;
+    moduleConfigQueuedWorkItem.BufferQueueConfig.SourceSettings.EnableLookAside = TRUE;
+    moduleConfigQueuedWorkItem.EvtQueuedWorkitemFunction = RequestTarget_QueuedWorkitemCallbackSingle;
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleQueuedWorkitemSingle);
 
     FuncExitVoid(DMF_TRACE);
 }
@@ -1085,6 +1092,80 @@ Return Value:
                                                   RequestType,
                                                   RequestIoctl,
                                                   RequestTimeoutMilliseconds,
+                                                  ContinuousRequestTarget_CompletionOptions_Default,
+                                                  NULL,
+                                                  EvtRequestTargetSingleAsynchronousRequest,
+                                                  SingleAsynchronousRequestClientContext);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "RequestTarget_RequestCreateAndSend fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+Exit:
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_RequestTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    )
+/*++
+
+Routine Description:
+
+    Creates and sends a Asynchronous request to the IoTarget given a buffer, IOCTL and other information.
+    And once the request is complete, EvtContinuousRequestTargetSingleAsynchronousRequest will be called at Passive level.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    RequestBuffer - Buffer of data to attach to request to be sent.
+    RequestLength - Number of bytes to in RequestBuffer to send.
+    ResponseBuffer - Buffer of data that is returned by the request.
+    ResponseLength - Size of Response Buffer in bytes.
+    RequestType - Read or Write or Ioctl
+    RequestIoctl - The given IOCTL.
+    RequestTimeoutMilliseconds - Timeout value in milliseconds of the transfer or zero for no timeout.
+    EvtRequestTargetSingleAsynchronousRequest - Callback to be called in completion routine.
+    SingleAsynchronousRequestClientContext - Client context sent in callback
+
+Return Value:
+
+    STATUS_SUCCESS if a buffer is added to the list.
+    Other NTSTATUS if there is an error.
+
+--*/
+{
+    NTSTATUS ntStatus = STATUS_SUCCESS;
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 RequestTarget);
+
+    ntStatus = RequestTarget_RequestCreateAndSend(DmfModule,
+                                                  FALSE,
+                                                  RequestBuffer,
+                                                  RequestLength,
+                                                  ResponseBuffer,
+                                                  ResponseLength,
+                                                  RequestType,
+                                                  RequestIoctl,
+                                                  RequestTimeoutMilliseconds,
+                                                  CompletionOption,
                                                   NULL,
                                                   EvtRequestTargetSingleAsynchronousRequest,
                                                   SingleAsynchronousRequestClientContext);
@@ -1153,6 +1234,7 @@ Return Value:
                                                   RequestType,
                                                   RequestIoctl,
                                                   RequestTimeoutMilliseconds,
+                                                  ContinuousRequestTarget_CompletionOptions_Default,
                                                   BytesWritten,
                                                   NULL,
                                                   NULL);

--- a/Dmf/Modules.Library/Dmf_RequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.h
@@ -75,6 +75,22 @@ DMF_RequestTarget_Send(
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS
+DMF_RequestTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
 DMF_RequestTarget_SendSynchronously(
     _In_ DMFMODULE DmfModule,
     _In_reads_bytes_(RequestLength) VOID* RequestBuffer,

--- a/Dmf/Modules.Library/Dmf_RequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.md
@@ -186,6 +186,51 @@ SingleAsynchronousRequestClientContext | A Client specific context that is sent 
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_RequestTarget_SendEx
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_RequestTarget_SendEx(
+  _In_ DMFMODULE DmfModule,
+  _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+  _In_ size_t RequestLength,
+  _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+  _In_ size_t ResponseLength,
+  _In_ ContinuousRequestTarget_RequestType RequestType,
+  _In_ ULONG RequestIoctl,
+  _In_ ULONG RequestTimeoutMilliseconds,
+  _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+  _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
+  _In_opt_ VOID* SingleAsynchronousRequestClientContext
+  );
+````
+
+Creates a WDFREQUEST and asynchronously sends it to the DMF_RequestTarget Module instance's WDFIOTARGET.
+Ex version of DMF_RequestTarget_Send, allows the clients to specify ContinuousRequestTarget_CompletionOptions, which controls how completion routine will be called. 
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_RequestTarget Module handle.
+RequestBuffer | The input buffer.
+RequestLength | The size in bytes of the input buffer.
+ResponseBuffer | The output buffer.
+ResponseLength | The size in bytes of the output buffer.
+RequestType | Indicates the type of request to send to the underlying WDFIOTARGET.
+RequestIoctl | The IOCTL code to send to the underlying WDFIOTARGET.
+RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
+CompletionOption | Indicates the completion option associated with the completion routine.
+EvtRequestTargetSingleAsynchronousRequest | The Client callback that is called when request completes.
+SingleAsynchronousRequestClientContext | A Client specific context that is sent to the Client callback that is called when the request completes.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_RequestTarget_SendSynchronously
 
 ````

--- a/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.c
+++ b/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.c
@@ -388,6 +388,45 @@ Return Value:
 }
 #pragma code_seg()
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+VOID
+DMF_ThreadedBufferQueue_Close(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Uninitialize an instance of a DMF Module of type ThreadedBufferQueue.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_ThreadedBufferQueue* moduleContext;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    // In case, Client has not explicitly stopped the thread, do that now.
+    //
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    DMF_Thread_Stop(moduleContext->DmfModuleThread);
+
+    FuncExitNoReturn(DMF_TRACE);
+}
+#pragma code_seg()
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Public Calls by Client
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -432,6 +471,7 @@ Return Value:
 
     DMF_CALLBACKS_DMF_INIT(&dmfCallbacksDmf_ThreadedBufferQueue);
     dmfCallbacksDmf_ThreadedBufferQueue.ChildModulesAdd = DMF_ThreadedBufferQueue_ChildModulesAdd;
+    dmfCallbacksDmf_ThreadedBufferQueue.DeviceClose = DMF_ThreadedBufferQueue_Close;
 
     DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_ThreadedBufferQueue,
                                             ThreadedBufferQueue,


### PR DESCRIPTION
1. Add Methods to Dmf_Registry to allow Client to easily access predefined keys.
2. Add Methods to Dmf_CmApi to allow Client to get properties from target.
3. Changes to how Dynamic Modules are torn down to correct issues found during stress testing. Associated changes to Dmf_ContinuousRequestTarget to better support Dynamic instantiation.
4. Changes to Dmf_Pdo to allow Client to easily set properties of PDOs that are created.
5. Changes to Dmf_Thread and Dmf_ThreadedBufferQeueue to stop thread during tear down in case Client fails to do so.
7. Updates to Tests Modules to add tests.
8. Prevent compiler optimizations related to Module Config structures during Modules Add callback.