### PR TITLE
Merge20190816

### DIFF
--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -1268,6 +1268,7 @@ Return Value:
 
     ASSERT(dmfObject->ClientModuleInstanceNameMemory != NULL);
     WdfObjectDelete(dmfObject->ClientModuleInstanceNameMemory);
+    dmfObject->ClientModuleInstanceNameMemory = NULL;
 
 #if !defined(DMF_USER_MODE)
     if (dmfObject->InFlightRecorder != NULL)
@@ -1295,6 +1296,9 @@ Return Value:
     if (DeleteMemory)
     {
         WdfObjectDelete(dmfObject->MemoryDmfObject);
+        // Memory associated with dmfObject is deleted here.
+        // Thus, dmfObject->MemoryDmfObject is not set to NULL.
+        //
         dmfObject = NULL;
     }
 

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -158,7 +158,7 @@ struct _DMF_OBJECT_
     VOID* ModuleContext;
     // Reference counter for DMF Object references.
     //
-    LONG ReferenceCount;
+    volatile LONG ReferenceCount;
     // Associated WDF Device.
     //
     WDFDEVICE ParentDevice;

--- a/Dmf/Framework/DmfUtility.c
+++ b/Dmf/Framework/DmfUtility.c
@@ -420,7 +420,7 @@ Return Value:
 typedef
 NTSTATUS
 (*PFN_IO_GET_ACTIVITY_ID_IRP) (
-    _In_ PIRP   Irp,
+    _In_ IRP* Irp,
     _Out_ LPGUID Guid
     );
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
@@ -345,7 +345,7 @@ Return Value:
             *BytesReturned = OutputBufferSize;
             // Prevent this thread from using too much CPU time.
             //
-            DMF_Utility_DelayMilliseconds(1000);
+            DMF_Utility_DelayMilliseconds(10);
             break;
         }
     }

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
@@ -30,7 +30,7 @@ Environment:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#define THREAD_COUNT                            (4)
+#define THREAD_COUNT                            (2)
 // Don't use an ever increasing serial number because those serial numbers will be remembered
 // by Windows and will slow down the test computer eventually.
 //

--- a/Dmf/Modules.Library/DmfModules.Library.h
+++ b/Dmf/Modules.Library/DmfModules.Library.h
@@ -83,6 +83,7 @@ extern "C"
 #include "Dmf_VirtualHidAmbientLightSensor.h"
 #include "Dmf_VirtualHidAmbientColorSensor.h"
 #include "Dmf_String.h"
+#include "Dmf_Rundown.h"
 #include "Dmf_File.h"
 
 #if defined(__cplusplus)

--- a/Dmf/Modules.Library/Dmf_CmApi.h
+++ b/Dmf/Modules.Library/Dmf_CmApi.h
@@ -84,6 +84,15 @@ DMF_CmApi_DeviceInstanceIdAndHardwareIdsGet(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_CmApi_ParentDevNodeGet(
+    _In_ DMFMODULE DmfModule,
+    _Out_ DEVINST* ParentDevNode,
+    _Out_ WCHAR* ParentDeviceInstanceId,
+    _In_ ULONG ParentDeviceInstanceIdBufferSize
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 DMF_CmApi_ParentTargetCloseAndDestroy(
     _In_ DMFMODULE DmfModule,

--- a/Dmf/Modules.Library/Dmf_CmApi.md
+++ b/Dmf/Modules.Library/Dmf_CmApi.md
@@ -250,6 +250,39 @@ ParentWdfIoTarget | The returned WDFIOTARGET of the parent ready for use.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_CmApi_ParentTargetDevNodeGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_CmApi_ParentTargetDevNodeGet(
+    _In_ DMFMODULE DmfModule,
+    _Out_ DEVINST* ParentDevNode,
+    _Out_ WCHAR* ParentDeviceInstanceId,
+    _In_ ULONG ParentDeviceInstanceIdBufferSize
+    );
+````
+
+Given a DMFMODULE, retrieve its corresponding DEVINST and Instance Id.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | The given open DMF_CmApi Module handle.
+ParentDevNode | The returned DEVINST.
+ParentDeviceInstanceId | The buffer where the corresponding Instance Id is written.
+ParentDeviceInstanceIdBufferSize | The size of ParentDeviceInstanceId in bytes.
+
+##### Remarks
+
+* This Method is useful in cases where caller needs to know which specific parent it is attached to.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
 ##### DMF_CmApi_ParentTargetInterfacesEnumerate
 
 ````

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -727,6 +727,8 @@ Return Value:
     moduleContext = DMF_CONTEXT_GET(*dmfModuleAddress);
     moduleConfig = DMF_CONFIG_GET(*dmfModuleAddress);
 
+    ASSERT(moduleContext->IoTarget == IoTarget);
+
     if (moduleConfig->EvtDeviceInterfaceTargetOnStateChange)
     {
         moduleConfig->EvtDeviceInterfaceTargetOnStateChange(*dmfModuleAddress,
@@ -738,7 +740,7 @@ Return Value:
         DMF_DeviceInterfaceTarget_StreamStop(*dmfModuleAddress);
     }
 
-    WdfIoTargetCloseForQueryRemove(IoTarget);
+    WdfIoTargetCloseForQueryRemove(moduleContext->IoTarget);
 
     FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
 
@@ -782,14 +784,17 @@ Return Value:
     moduleContext = DMF_CONTEXT_GET(*dmfModuleAddress);
     moduleConfig = DMF_CONFIG_GET(*dmfModuleAddress);
 
+    ASSERT(moduleContext->IoTarget == IoTarget);
+
     WDF_IO_TARGET_OPEN_PARAMS_INIT_REOPEN(&openParams);
 
-    ntStatus = WdfIoTargetOpen(IoTarget,
+    ntStatus = WdfIoTargetOpen(moduleContext->IoTarget,
                                &openParams);
     if (! NT_SUCCESS(ntStatus))
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Failed to re-open serial target - %!STATUS!", ntStatus);
-        WdfObjectDelete(IoTarget);
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Failed to re-open io target - %!STATUS!", ntStatus);
+        WdfObjectDelete(moduleContext->IoTarget);
+        moduleContext->IoTarget = NULL;
         goto Exit;
     }
 

--- a/Dmf/Modules.Library/Dmf_I2cTarget.c
+++ b/Dmf/Modules.Library/Dmf_I2cTarget.c
@@ -14,6 +14,7 @@ Abstract:
 Environment:
 
     Kernel-mode Driver Framework
+    User-mode Driver Framework
 
 --*/
 
@@ -796,7 +797,7 @@ Return Value:
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "I2C resources not found");
         ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
-        NT_ASSERT(FALSE);
+        ASSERT(FALSE);
         goto Exit;
     }
 
@@ -838,7 +839,7 @@ Return Value:
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "I2C Resources not assigned");
         ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
-        NT_ASSERT(FALSE);
+        ASSERT(FALSE);
         goto Exit;
     }
 

--- a/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.c
+++ b/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.c
@@ -494,6 +494,7 @@ Return Value:
                                                STATUS_CANCELLED);
 
     WdfObjectDelete(moduleContext->EventRequestQueue);
+    moduleContext->EventRequestQueue = NULL;
 
     FuncExitVoid(DMF_TRACE);
 }

--- a/Dmf/Modules.Library/Dmf_Rundown.c
+++ b/Dmf/Modules.Library/Dmf_Rundown.c
@@ -1,0 +1,563 @@
+/*++
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+
+Module Name:
+
+    Dmf_Rundown.c
+
+Abstract:
+    
+    This is used for rundown management when an object is being unregistered but its Methods may still 
+    be called or running. It allows DMF to make sure the resource is available while Methods that are 
+    already running continue running, but disallows new Methods from starting to run.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+// DMF and this Module's Library specific definitions.
+//
+#include "DmfModule.h"
+#include "DmfModules.Library.h"
+#include "DmfModules.Library.Trace.h"
+
+#include "Dmf_Rundown.tmh"
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Enumerations and Structures
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Context
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+typedef struct
+{
+    // Reference counter for DMF Object references.
+    //
+    volatile LONG ReferenceCount;
+    
+    // Flag indicating that the resource close is pending.
+    // This is necessary to synchronize close with methods that might still be
+    // using the resource.
+    //
+    BOOLEAN WaitingForRundown;
+
+} DMF_CONTEXT_Rundown;
+
+// This macro declares the following function:
+// DMF_CONTEXT_GET()
+//
+DMF_MODULE_DECLARE_CONTEXT(Rundown)
+
+// This macro declares the following function:
+// DMF_CONFIG_GET()
+//
+DMF_MODULE_DECLARE_NO_CONFIG(Rundown)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Support Code
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+LONG
+Rundown_ReferenceAdd(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Increment the Module's Reference Count.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    The updated reference count.
+
+--*/
+{
+    LONG returnValue;
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p", DmfModule);
+
+    // This routine must always be called in locked state.
+    //
+    ASSERT(DMF_ModuleIsLocked(DmfModule));
+
+    returnValue = InterlockedIncrement(&moduleContext->ReferenceCount);
+
+    FuncExit(DMF_TRACE, "DmfModule=0x%p returnValue=%d", DmfModule, returnValue);
+
+    return returnValue;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+LONG
+Rundown_ReferenceDelete(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Decrement the Module's Reference Count.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    The updated reference count.
+
+--*/
+{
+    LONG returnValue;
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p", DmfModule);
+
+    // This routine must always be called in locked state.
+    //
+    ASSERT(DMF_ModuleIsLocked(DmfModule));
+    ASSERT(moduleContext->ReferenceCount > 0);
+
+    returnValue = InterlockedDecrement(&moduleContext->ReferenceCount);
+
+    FuncExit(DMF_TRACE, "DmfModule=0x%p returnValue=%d", DmfModule, returnValue);
+
+    return returnValue;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// WDF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+static
+NTSTATUS
+DMF_Rundown_Open(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Initialize an instance of a DMF Module of type Rundown.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    ntStatus = STATUS_SUCCESS;
+
+    ASSERT(0 == moduleContext->ReferenceCount);
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+VOID
+DMF_Rundown_Close(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Uninitialize an instance of a DMF Module of type Rundown.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Rundown* moduleContext;
+    BOOLEAN endForClient;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+    endForClient = FALSE;
+
+    DMF_ModuleLock(DmfModule);
+
+    if ((! moduleContext->WaitingForRundown) &&
+        (moduleContext->ReferenceCount >= 1))
+    {
+        // This path should be avoided. Client did not call DMF_Rundown_EndAndWait().
+        //
+        ASSERT(FALSE);
+        endForClient = TRUE;
+    }
+    else
+    {
+        // This is the normal path that should execute.
+        //
+        ASSERT(0 == moduleContext->ReferenceCount);
+    }
+
+    DMF_ModuleUnlock(DmfModule);
+
+    if (endForClient)
+    {
+        // Module cleans up for misbehaving Client, but this path should be avoided.
+        //
+        DMF_Rundown_EndAndWait(DmfModule);
+    }
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Calls by Client
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Rundown_Create(
+    _In_ WDFDEVICE Device,
+    _In_ DMF_MODULE_ATTRIBUTES* DmfModuleAttributes,
+    _In_ WDF_OBJECT_ATTRIBUTES* ObjectAttributes,
+    _Out_ DMFMODULE* DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Create an instance of a DMF Module of type Rundown.
+
+Arguments:
+
+    Device - Client driver's WDFDEVICE object.
+    DmfModuleAttributes - Opaque structure that contains parameters DMF needs to initialize the Module.
+    ObjectAttributes - WDF object attributes for DMFMODULE.
+    DmfModule - Address of the location where the created DMFMODULE handle is returned.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_MODULE_DESCRIPTOR dmfModuleDescriptor_Rundown;
+    DMF_CALLBACKS_DMF dmfCallbacksDmf_Rundown;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    DMF_CALLBACKS_DMF_INIT(&dmfCallbacksDmf_Rundown);
+    dmfCallbacksDmf_Rundown.DeviceOpen = DMF_Rundown_Open;
+    dmfCallbacksDmf_Rundown.DeviceClose = DMF_Rundown_Close;
+
+    DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_Rundown,
+                                            Rundown,
+                                            DMF_CONTEXT_Rundown,
+                                            DMF_MODULE_OPTIONS_PASSIVE,
+                                            DMF_MODULE_OPEN_OPTION_OPEN_Create);
+
+    dmfModuleDescriptor_Rundown.CallbacksDmf = &dmfCallbacksDmf_Rundown;
+
+    ntStatus = DMF_ModuleCreate(Device,
+                                DmfModuleAttributes,
+                                ObjectAttributes,
+                                &dmfModuleDescriptor_Rundown,
+                                DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleCreate fails: ntStatus=%!STATUS!", ntStatus);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return(ntStatus);
+}
+#pragma code_seg()
+
+// Module Methods
+//
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_Rundown_Dereference(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Releases the Module acquired in DMF_Rundown_Reference.
+
+Arguments:
+
+    DmfModule - The given DMF Module.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Rundown);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    DMF_ModuleLock(DmfModule);
+
+    Rundown_ReferenceDelete(DmfModule);
+    // The reference count should never reach zero if Client is using this
+    // Module's Methods correctly.
+    // Start sets REference to 1.
+    // Reference will always increment to 2 minimum.
+    //
+    ASSERT(moduleContext->ReferenceCount >= 1);
+
+    DMF_ModuleUnlock(DmfModule);
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_EndAndWait(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Waits for the Module's reference count to reach zero. This is used for rundown management 
+    when an object is being unregistered but its Methods may still be called or running. 
+    It allows DMF to make sure the resource is available while Methods that are 
+    already running continue running, but disallows new Methods from starting to run.
+
+Arguments:
+
+    DmfModule - The given DMF Module.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Rundown* moduleContext;
+    LONG referenceCount;
+    // This value is chosen to give running thread time to execute,
+    // but short enough to allow fast response.
+    //
+    const ULONG referenceCountPollingIntervalMs = 100;
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Rundown);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    DMF_ModuleLock(DmfModule);
+
+    // Set WaitingForRundown to TRUE, to avoid Module Method from acquiring
+    // a reference to the Module infinitely and blocking the Module from closing.
+    //
+    moduleContext->WaitingForRundown = TRUE;
+    referenceCount = moduleContext->ReferenceCount;
+
+    // Ensure Client called DMF_Rundown_Start() before calling this Method.
+    //
+    ASSERT(referenceCount >= 1);
+
+    DMF_ModuleUnlock(DmfModule);
+
+    while (referenceCount > 0)
+    {
+        DMF_ModuleLock(DmfModule);
+
+        if (referenceCount == 1)
+        {
+            // Module Method is not running. Prevent any Module Method from starting because call Acquire will fail.
+            //
+            moduleContext->ReferenceCount = 0;
+            // For modules which open on notification callback, ReferenceCount = 0 means the Module is now closed.
+            //
+            moduleContext->WaitingForRundown = FALSE;
+        }
+        referenceCount = moduleContext->ReferenceCount;
+
+        DMF_ModuleUnlock(DmfModule);
+
+        if (referenceCount == 0)
+        {
+            break;
+        }
+
+        // Reference count > 1 means a Module Method is running.
+        // Wait for Reference count to run down to 0.
+        //
+        DMF_Utility_DelayMilliseconds(referenceCountPollingIntervalMs);
+        TraceInformation(DMF_TRACE, "DmfModule=0x%p Waiting to close", DmfModule);
+    }
+
+    FuncExitVoid(DMF_TRACE);
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Rundown_Reference(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Can be wrapped around a resource to make sure it exists until Rundown_Dereference
+    method is called.
+
+Arguments:
+
+    DmfModule - The given DMF Module.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Rundown);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    DMF_ModuleLock(DmfModule);
+
+    // Client must call DMF_Rundown_Start() before calling this Method.
+    //
+    ASSERT(moduleContext->ReferenceCount >= 1);
+
+    // Increase reference only if Module is open (ReferenceCount >= 1) and if the Module close is not pending.
+    // This is to stop new Module method callers from repeatedly accessing the Module when it should be closing.
+    //
+    if ((moduleContext->ReferenceCount >= 1) &&
+        (! moduleContext->WaitingForRundown))
+    {
+        // Increase reference count to ensure that Module will not be closed while a Module method is running.
+        //
+        Rundown_ReferenceAdd(DmfModule);
+        ntStatus = STATUS_SUCCESS;
+    }
+    else
+    {
+        // Tell caller that this Module has not started and that Module Method should not do anything.
+        //
+        ntStatus = STATUS_INVALID_DEVICE_STATE;
+    }
+
+    DMF_ModuleUnlock(DmfModule);
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_Start(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description: 
+
+    Used to set initial reference count at the start of the Rundown lifetime to 1.
+    Needs to be called by the Client before the Rundown Reference and Dereference use. 
+
+Arguments:
+
+    DmfModule - The given DMF Module.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Rundown* moduleContext;
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Rundown);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    DMF_ModuleLock(DmfModule);
+
+    // This is a reference that will be dereferenced in DMF_Rundown_EndAndWait().
+    //
+    moduleContext->WaitingForRundown = FALSE;
+    moduleContext->ReferenceCount = 1;
+
+    DMF_ModuleUnlock(DmfModule);
+
+    FuncExitVoid(DMF_TRACE);
+}
+
+// eof: Dmf_Rundown.c
+//

--- a/Dmf/Modules.Library/Dmf_Rundown.h
+++ b/Dmf/Modules.Library/Dmf_Rundown.h
@@ -1,0 +1,58 @@
+/*++
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+
+Module Name:
+
+    Dmf_Rundown.h
+
+Abstract:
+
+    Companion file to Dmf_Rundown.c.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+#pragma once
+
+// This macro declares the following functions:
+// DMF_Registry_ATTRIBUTES_INIT()
+// DMF_Registry_Create()
+//
+DECLARE_DMF_MODULE_NO_CONFIG(Rundown)
+
+// Module Methods
+//
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_Rundown_Dereference(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_EndAndWait(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Rundown_Reference(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_Start(
+    _In_ DMFMODULE DmfModule
+    );
+
+// eof: Dmf_Rundown.h
+//

--- a/Dmf/Modules.Library/Dmf_Rundown.md
+++ b/Dmf/Modules.Library/Dmf_Rundown.md
@@ -1,0 +1,175 @@
+## DMF_Rundown
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Summary
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+This is used for rundown management when an object is being unregistered but its Methods may still 
+be called or running. It allows DMF to make sure the resource is available while Methods that are 
+already running continue running, but disallows new Methods from starting to run.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Configuration
+
+-----------------------------------------------------------------------------------------------------------------------------------
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Enumeration Types
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Structures
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Callbacks
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Methods
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Rundown_Dereference
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_Rundown_Dereference(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+Releases the Module acquired in DMF_Rundown_Reference.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Rundown Module handle.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_Rundown_EndAndWait
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_EndAndWait(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+Waits for the Module's reference count to reach zero. This is used for rundown management 
+when an object is being unregistered but its Methods may still be called or running. 
+It allows DMF to make sure the resource is available while Methods that are 
+already running continue running, but disallows new Methods from starting to run.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Rundown Module handle.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Rundown_Reference
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Rundown_Reference(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+Can be wrapped around a resource to make sure it exists until Rundown_Dereference method is called.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Rundown Module handle.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_Rundown_Start
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_Rundown_Start(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+Used to set initial reference count at the start of the Rundown lifetime to 1.
+Needs to be called by the Client before the Rundown Reference and Dereference use. 
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Rundown Module handle.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module IOCTLs
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Remarks
+
+To use this Module the Start method needs to be invoked at the beginning of the resource creation/registration and the
+EndAndWait method needs to be invoked at the end of the resource use (deletion/unregistration).
+
+During the lifetime of the resource if any other methods need access to it the Reference and Dereference Methods can be 
+nested around those accesses which respectively increment and decrement the reference count of the resource.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Children
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Examples
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### To Do
+
+-----------------------------------------------------------------------------------------------------------------------------------
+#### Module Category
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+Task Execution
+
+-----------------------------------------------------------------------------------------------------------------------------------
+

--- a/Dmf/Modules.Library/Dmf_SpiTarget.c
+++ b/Dmf/Modules.Library/Dmf_SpiTarget.c
@@ -575,6 +575,7 @@ Return Value:
     {
         ASSERT(NT_SUCCESS(ntStatus));
         WdfObjectDelete(moduleContext->Target);
+        moduleContext->Target = NULL;
         TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfIoTargetOpen fails: ntStatus=%!STATUS!", ntStatus);
         goto Exit;
     }

--- a/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj
+++ b/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_ContinuousRequestTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_RequestTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_ResourceHub.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_Rundown.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_ScheduledTask.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_SelfTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_SerialTarget.c" />
@@ -86,6 +87,7 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_ContinuousRequestTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_RequestTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_ResourceHub.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_Rundown.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_ScheduledTask.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_SelfTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_SerialTarget.h" />
@@ -386,6 +388,7 @@
   <ItemGroup>
     <None Include="..\..\Modules.Library\Dmf_DefaultTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_InterruptResource.md" />
+    <None Include="..\..\Modules.Library\Dmf_Rundown.md" />
     <None Include="..\..\Modules.Library\Dmf_SpbTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_String.md" />
     <None Include="..\..\Modules.Library\Dmf_VirtualHidAmbientColorSensor.md" />

--- a/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj.filters
@@ -106,6 +106,9 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_String.c">
       <Filter>Modules\Driver Patterns</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_Rundown.c">
+      <Filter>Modules\Driver Patterns</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Modules.Library\Dmf_PingPongBuffer.h">
@@ -223,6 +226,9 @@
       <Filter>Headers\Hid</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Modules.Library\Dmf_String.h">
+      <Filter>Headers\Driver Patterns</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_Rundown.h">
       <Filter>Headers\Driver Patterns</Filter>
     </ClInclude>
   </ItemGroup>
@@ -402,6 +408,9 @@
       <Filter>Documentation\Modules\Hid</Filter>
     </None>
     <None Include="..\..\Modules.Library\Dmf_String.md">
+      <Filter>Documentation\Modules\Driver Patterns</Filter>
+    </None>
+    <None Include="..\..\Modules.Library\Dmf_Rundown.md">
       <Filter>Documentation\Modules\Driver Patterns</Filter>
     </None>
   </ItemGroup>

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_ComponentFirmwareUpdateHidTransport.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_DefaultTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_File.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_I2cTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_Interface_ComponentFirmwareUpdate.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_QueuedWorkItem.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_PingPongBuffer.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_ComponentFirmwareUpdateHidTransport.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_DefaultTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_File.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_I2cTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_Interface_ComponentFirmwareUpdate.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_QueuedWorkItem.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_PingPongBuffer.c" />

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_File.h">
       <Filter>Headers\Modules\Driver Patterns</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_I2cTarget.h">
+      <Filter>Headers\Modules\Targets</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Modules.Library\Dmf_CmApi.c">
@@ -202,6 +205,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Modules.Library\Dmf_File.c">
       <Filter>Modules\Driver Patterns</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_I2cTarget.c">
+      <Filter>Modules\Targets</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
1. Correct BSOD during arrival/removal stress in DMF_DeviceInterfaceTarget.
2. Add Methods to DMF_CmApi.
3. Add DMF_Rundown.
4. Add DMF_I2cTarget to User-mode Library.
5. Correct a couple of issues where pointers to objects were not cleared after being deleted.
6. Correct issue in DMF_Tests_DeviceInteraceTarget where device arrival/removal callbacks were not set.