### PR TITLE
Merge20200206

### DIFF
--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1289,6 +1289,19 @@ DMF_ModuleConfigRetrieve(
     _In_ size_t ModuleConfigSize
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_ModuleReference(
+    _In_ DMFMODULE DmfModule
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_ModuleDereference(
+    _In_ DMFMODULE DmfModule
+    );
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Filter Driver Support (FilterControl API)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1302,7 +1315,7 @@ DMF_FilterControl_DeviceCreate(
     _In_ WDFDEVICE Device,
     _In_opt_ DMF_CONFIG_BranchTrack* FilterBranchTrackConfig,
     _In_opt_ PWDF_IO_QUEUE_CONFIG QueueConfig,
-    _In_ PWCHAR ControlDeviceName
+    _In_ WCHAR* ControlDeviceName
     );
 
 _IRQL_always_function_max_(PASSIVE_LEVEL)

--- a/Dmf/Framework/DmfFilter.c
+++ b/Dmf/Framework/DmfFilter.c
@@ -29,13 +29,137 @@ Environment:
 
 #if !defined(DMF_USER_MODE)
 
+typedef struct
+{
+    // List of all the filtered WDFDEVICE objects.
+    //
+    WDFCOLLECTION FilterDeviceCollection;
+    // A lock for the above list.
+    //
+    WDFWAITLOCK FilterDeviceCollectionLock;
+} DMF_FILTER_CONTROL_GLOBALS, *PDMF_FILTER_CONTROL_GLOBALS;
+
+// The single instance of all Filter Control Object variables.
+//
+DMF_FILTER_CONTROL_GLOBALS g_DMF_FilterControlGlobals;
+
+NTSTATUS
+DMF_FilterControl_GlobalCreate(
+    _In_ WDFDEVICE Device
+    )
+/*++
+
+Routine Description:
+
+    Create Filter Control Object's global variables.
+
+Arguments:
+
+    Device - The given WDFDEVICE.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    WDFDRIVER driver;
+    WDF_OBJECT_ATTRIBUTES attributes;
+
+    driver = WdfDeviceGetDriver(Device);
+
+    WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+    // When we create FilterDeviceCollection and FilterDeviceCollectionLock, we need to set ParentObject as the driver.
+    // Then FilterDeviceCollection and FilterDeviceCollectionLock will be automatically deleted.
+    //
+    attributes.ParentObject = driver;
+
+    // These need to be created only once for each Driver.
+    //
+    if (g_DMF_FilterControlGlobals.FilterDeviceCollection == NULL)
+    {
+        ntStatus = WdfCollectionCreate(&attributes,
+                                       &g_DMF_FilterControlGlobals.FilterDeviceCollection);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionCreate fails: ntStatus=%!STATUS!", ntStatus);
+            goto Exit;
+        }
+    }
+
+    if (g_DMF_FilterControlGlobals.FilterDeviceCollectionLock == NULL)
+    {
+        ntStatus = WdfWaitLockCreate(&attributes,
+                                     &g_DMF_FilterControlGlobals.FilterDeviceCollectionLock);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfWaitLockCreate fails: ntStatus=%!STATUS!", ntStatus);
+            WdfObjectDelete(&g_DMF_FilterControlGlobals.FilterDeviceCollection);
+            g_DMF_FilterControlGlobals.FilterDeviceCollection = NULL;
+            goto Exit;
+        }
+    }
+
+    ntStatus = STATUS_SUCCESS;
+
+Exit:
+
+    return ntStatus;
+}
+
+VOID
+DMF_FilterControl_Lock()
+/*++
+
+Routine Description:
+
+    Lock the Filter Control Object global variables using global lock.
+
+Arguments:
+
+    None
+
+Return Value:
+
+    None
+
+--*/
+{
+    DmfAssert(g_DMF_FilterControlGlobals.FilterDeviceCollectionLock != NULL);
+    WdfWaitLockAcquire(g_DMF_FilterControlGlobals.FilterDeviceCollectionLock,
+                       NULL);
+}
+
+VOID
+DMF_FilterControl_Unlock()
+/*++
+
+Routine Description:
+
+    Unlock the Filter Control Object global variables using global lock.
+
+Arguments:
+
+    None
+
+Return Value:
+
+    None
+
+--*/
+{
+    DmfAssert(g_DMF_FilterControlGlobals.FilterDeviceCollectionLock != NULL);
+    WdfWaitLockRelease(g_DMF_FilterControlGlobals.FilterDeviceCollectionLock);
+}
+
 _IRQL_always_function_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_FilterControl_DeviceCreate(
     _In_ WDFDEVICE Device,
     _In_opt_ DMF_CONFIG_BranchTrack* FilterBranchTrackConfig,
     _In_opt_ PWDF_IO_QUEUE_CONFIG QueueConfig,
-    _In_ PWCHAR ControlDeviceName
+    _In_ WCHAR* ControlDeviceName
     )
 /*++
 
@@ -53,6 +177,7 @@ Arguments:
 
     Device - The given WDFDEVICE.
     FilterBranchTrackConfig - BranchTrack Module Config.
+    QueueConfig - The Client Driver passes an initialized structure or NULL if not used.
     ControlDeviceName - The name of the Filter Control Device to create.
 
 Return Value:
@@ -69,10 +194,18 @@ Return Value:
     UNICODE_STRING controlDeviceName;
     WDFQUEUE queue;
     PDMFDEVICE_INIT dmfDeviceInit;
+    ULONG numberOfDevicesInCollection;
 
     controlDevice = NULL;
     dmfDeviceInit = NULL;
     queue = NULL;
+
+    ntStatus = DMF_FilterControl_GlobalCreate(Device);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Filter Control Global Create fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
 
     driver = WdfDeviceGetDriver(Device);
     dmfDeviceContext = DmfDeviceContextGet(Device);
@@ -81,96 +214,122 @@ Return Value:
     //
     DmfAssert(dmfDeviceContext->WdfControlDevice == NULL);
 
-    // In order to create a control device, we first need to allocate a
-    // WDFDEVICE_INIT structure and set all properties.
+    DMF_FilterControl_Lock();
+
+    // Add the device into the list of currently running filter devices
+    // which is necessary for BranchTrack.
     //
-    deviceInit = WdfControlDeviceInitAllocate(driver,
-                                              &SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RWX_RES_RWX);
-    if (NULL == deviceInit)
+    ntStatus = WdfCollectionAdd(g_DMF_FilterControlGlobals.FilterDeviceCollection,
+                                Device);
+    if (!NT_SUCCESS(ntStatus))
     {
-        ntStatus = STATUS_INSUFFICIENT_RESOURCES;
-        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfControlDeviceInitAllocate fails: ntStatus=STATUS_INSUFFICIENT_RESOURCES");
-        goto Error;
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionAdd fails: ntStatus=%!STATUS!", ntStatus);
+
+        DMF_FilterControl_Unlock();
+        goto Exit;
     }
 
-    dmfDeviceInit = DMF_DmfControlDeviceInitAllocate(deviceInit);
+    numberOfDevicesInCollection = WdfCollectionGetCount(g_DMF_FilterControlGlobals.FilterDeviceCollection);
 
-    DMF_DmfControlDeviceInitSetClientDriverDevice(dmfDeviceInit,
-                                                  Device);
+    // We can unlock here because another WdfCollectionAdd cannot occur till the end of this function
+    // due to the sequential nature of its caller DeviceAdd.
+    DMF_FilterControl_Unlock();
 
-    // Ensure only a single application can talk to the Control Device at a time.
-    //
-    WdfDeviceInitSetExclusive(deviceInit,
-                              TRUE);
-
-    // It is mandatory that Filter Control Devices have this name assigned, otherwise the
-    // symbolic link cannot be created.
-    //
-    DmfAssert(ControlDeviceName != NULL);
-    RtlUnicodeStringInit(&controlDeviceName,
-                         ControlDeviceName);
-    ntStatus = WdfDeviceInitAssignName(deviceInit,
-                                       &controlDeviceName);
-    if (! NT_SUCCESS(ntStatus))
+    if (1 == numberOfDevicesInCollection)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfDeviceInitAssignName fails: ntStatus=%!STATUS!", ntStatus);
-        goto Error;
-    }
-
-    ntStatus = WdfDeviceCreate(&deviceInit,
-                               WDF_NO_OBJECT_ATTRIBUTES,
-                               &controlDevice);
-    if (! NT_SUCCESS(ntStatus))
-    {
-        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfDeviceCreate fails: ntStatus=%!STATUS!", ntStatus);
-        goto Error;
-    }
-
-    if (QueueConfig != NULL)
-    {
-        // Client Driver provides QueueConfig if it wants to process IOCTLs from User-mode
-        // In that case Create the default queue for control device here, to enable Client IOCTL callback to be dispatched.
-        // If not, DMF will create a default queue for control device.
+        // In order to create a control device, we first need to allocate a
+        // WDFDEVICE_INIT structure and set all properties.
         //
-        DMF_DmfDeviceInitHookQueueConfig(dmfDeviceInit,
-                                         QueueConfig);
-        ntStatus = WdfIoQueueCreate(controlDevice,
-                                    QueueConfig,
-                                    WDF_NO_OBJECT_ATTRIBUTES,
-                                    &queue);
-        if (! NT_SUCCESS(ntStatus))
+        deviceInit = WdfControlDeviceInitAllocate(driver,
+                                                  &SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RWX_RES_RWX);
+        if (NULL == deviceInit)
         {
-            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfIoQueueCreate fails: ntStatus=%!STATUS!", ntStatus);
+            ntStatus = STATUS_INSUFFICIENT_RESOURCES;
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfControlDeviceInitAllocate fails: ntStatus=STATUS_INSUFFICIENT_RESOURCES");
             goto Error;
         }
+
+        dmfDeviceInit = DMF_DmfControlDeviceInitAllocate(deviceInit);
+
+        DMF_DmfControlDeviceInitSetClientDriverDevice(dmfDeviceInit,
+                                                      Device);
+
+        // Ensure only a single application can talk to the Control Device at a time.
+        //
+        WdfDeviceInitSetExclusive(deviceInit,
+                                  TRUE);
+
+        // It is mandatory that Filter Control Devices have this name assigned, otherwise the
+        // symbolic link cannot be created.
+        //
+        DmfAssert(ControlDeviceName != NULL);
+        RtlUnicodeStringInit(&controlDeviceName,
+                             ControlDeviceName);
+        ntStatus = WdfDeviceInitAssignName(deviceInit,
+                                           &controlDeviceName);
+        if (! NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfDeviceInitAssignName fails: ntStatus=%!STATUS!", ntStatus);
+            goto Error;
+        }
+
+        ntStatus = WdfDeviceCreate(&deviceInit,
+                                   WDF_NO_OBJECT_ATTRIBUTES,
+                                   &controlDevice);
+        if (! NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfDeviceCreate fails: ntStatus=%!STATUS!", ntStatus);
+            goto Error;
+        }
+
+        if (QueueConfig != NULL)
+        {
+            // Client Driver provides QueueConfig if it wants to process IOCTLs from User-mode
+            // In that case Create the default queue for control device here, to enable Client IOCTL callback to be dispatched.
+            // If not, DMF will create a default queue for control device.
+            //
+            DMF_DmfDeviceInitHookQueueConfig(dmfDeviceInit,
+                                             QueueConfig);
+            ntStatus = WdfIoQueueCreate(controlDevice,
+                                        QueueConfig,
+                                        WDF_NO_OBJECT_ATTRIBUTES,
+                                        &queue);
+            if (! NT_SUCCESS(ntStatus))
+            {
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfIoQueueCreate fails: ntStatus=%!STATUS!", ntStatus);
+                goto Error;
+            }
+        }
+
+        DMF_DmfDeviceInitSetBranchTrackConfig(dmfDeviceInit,
+                                              FilterBranchTrackConfig);
+
+        ntStatus = DMF_ModulesCreate(controlDevice,
+                                     &dmfDeviceInit);
+        if (! NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModulesCreate fails: ntStatus=%!STATUS!", ntStatus);
+            goto Error;
+        }
+
+        // Control devices must notify WDF when they are done initializing. I/O is
+        // rejected until this call is made.
+        //
+        WdfControlFinishInitializing(controlDevice);
     }
-
-    DMF_DmfDeviceInitSetBranchTrackConfig(dmfDeviceInit,
-                                          FilterBranchTrackConfig);
-
-    ntStatus = DMF_ModulesCreate(controlDevice,
-                                 &dmfDeviceInit);
-    if (! NT_SUCCESS(ntStatus))
-    {
-        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModulesCreate fails: ntStatus=%!STATUS!", ntStatus);
-        goto Error;
-    }
-
-    // Control devices must notify WDF when they are done initializing. I/O is
-    // rejected until this call is made.
-    //
-    WdfControlFinishInitializing(controlDevice);
 
     ntStatus = STATUS_SUCCESS;
+    dmfDeviceContext->WdfControlDevice = controlDevice;
     goto Exit;
 
 Error:
 
-    if (deviceInit != NULL)
-    {
-        WdfDeviceInitFree(deviceInit);
-        deviceInit = NULL;
-    }
+    DMF_FilterControl_Lock();
+    //Remove item added above since it is no longer valid because this function has failed.
+    //
+    WdfCollectionRemoveItem(g_DMF_FilterControlGlobals.FilterDeviceCollection,
+                            0);
+    DMF_FilterControl_Unlock();
 
     if (controlDevice != NULL)
     {
@@ -181,9 +340,13 @@ Error:
         controlDevice = NULL;
     }
 
-Exit:
+    if (deviceInit != NULL)
+    {
+        WdfDeviceInitFree(deviceInit);
+        deviceInit = NULL;
+    }
 
-    dmfDeviceContext->WdfControlDevice = controlDevice;
+Exit:
 
     return ntStatus;
 }
@@ -197,7 +360,7 @@ DMF_FilterControl_DeviceDelete(
 
 Routine Description:
 
-    This routine deletes the control device which was create for the given WdfDevice instance.
+    This routine deletes the control device which was created.
 
 Arguments:
 
@@ -210,15 +373,54 @@ Return Value:
 --*/
 {
     DMF_DEVICE_CONTEXT* dmfDeviceContext;
+    ULONG numberOfDevicesInCollection;
+    ULONG collectionIndex;
+    WDFDEVICE deviceToDelete;
+    WDFDEVICE deviceInCollection;
 
     FuncEntry(DMF_TRACE);
 
+    deviceToDelete = NULL;
+
+    DMF_FilterControl_Lock();
+
+    numberOfDevicesInCollection = WdfCollectionGetCount(g_DMF_FilterControlGlobals.FilterDeviceCollection);
+    for (collectionIndex = 0; collectionIndex < numberOfDevicesInCollection; collectionIndex++)
+    {
+        deviceInCollection = (WDFDEVICE)WdfCollectionGetItem(g_DMF_FilterControlGlobals.FilterDeviceCollection,
+                                                             collectionIndex);
+        if (Device == deviceInCollection)
+        {
+            WdfCollectionRemoveItem(g_DMF_FilterControlGlobals.FilterDeviceCollection,
+                                    collectionIndex);
+            break;
+        }
+    }
+    if (collectionIndex == numberOfDevicesInCollection)
+    {
+        TraceEvents(TRACE_LEVEL_WARNING, DMF_TRACE, "Device 0x%p not found in Filter Device Collection", Device);
+    }   
+
     dmfDeviceContext = DmfDeviceContextGet(Device);
 
-    if (dmfDeviceContext->WdfControlDevice != NULL)
+    if (1 == numberOfDevicesInCollection)
     {
-        WdfObjectDelete(dmfDeviceContext->WdfControlDevice);
+        // We should avoid holding locks when calling into WDF to avoid deadlocks.
+        // So store the device to delete in context in a local variable,
+        // clear the device in context while lock is held and the delete the local variable later.
+        //
+        deviceToDelete = dmfDeviceContext->WdfControlDevice;
         dmfDeviceContext->WdfControlDevice = NULL;
+    }
+
+    DMF_FilterControl_Unlock();
+
+    // The last Filter Object is deleted so delete the Filter Control Object.
+    //
+    if (deviceToDelete != NULL)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Delete WdfControlDevice=0x%p", deviceToDelete);
+        WdfObjectDelete(deviceToDelete);
     }
 
     FuncExitVoid(DMF_TRACE);

--- a/Dmf/Framework/DmfModule.h
+++ b/Dmf/Framework/DmfModule.h
@@ -792,19 +792,6 @@ DMF_IsModulePassiveLevel(
     _In_ DMFMODULE DmfModule
     );
 
-_IRQL_requires_max_(DISPATCH_LEVEL)
-_Must_inspect_result_
-NTSTATUS
-DMF_ModuleReference(
-    _In_ DMFMODULE DmfModule
-    );
-
-_IRQL_requires_max_(DISPATCH_LEVEL)
-VOID
-DMF_ModuleDereference(
-    _In_ DMFMODULE DmfModule
-    );
-
 VOID
 DMF_ModuleInContextSave(
     _In_ WDFOBJECT WdfObject,


### PR DESCRIPTION
1. Give Client drivers access to DMF_ModuleReference() and DMF_ModuleDereference().

2. Ensure that only a single Control Device is created for filter drivers.