### PR TITLE
Merge20200302

### DIFF
--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1395,7 +1395,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_Portable_EventWaitForSingleObject(
     _In_ DMF_PORTABLE_EVENT* EventPointer,
-    _In_ ULONG* TimeoutMs,
+    _In_opt_ ULONG* TimeoutMs,
     _In_ BOOLEAN Alertable
     );
 

--- a/Dmf/Framework/DmfPortable.c
+++ b/Dmf/Framework/DmfPortable.c
@@ -147,7 +147,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 DMF_Portable_EventWaitForSingleObject(
     _In_ DMF_PORTABLE_EVENT* EventPointer,
-    _In_ ULONG* TimeoutMs,
+    _In_opt_ ULONG* TimeoutMs,
     _In_ BOOLEAN Alertable
     )
 /*++
@@ -237,7 +237,7 @@ Return Value:
                                         Executive,
                                         KernelMode,
                                         Alertable,
-                                        &timeout100ns);
+                                        timeout100nsPointer);
 #endif // defined(DMF_USER_MODE)
 
     FuncExit(DMF_TRACE, "returnValue=0x%X", returnValue);

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -32,11 +32,6 @@ Environment:
 
 #define THREAD_COUNT                            (2)
 #define MAXIMUM_SLEEP_TIME_MS                   (15000)
-// This timeout is necessary for causing asynchronous single requests to complete fast so that
-// driver disable works well (since it is not possible to cancel asynchronous requests at this time.
-// using DMF).
-//
-#define ASYNCHRONOUS_REQUEST_TIMEOUT_MS         (50)
 // Keep synchronous maximum time short to make driver disable faster.
 //
 #define MAXIMUM_SLEEP_TIME_SYNCHRONOUS_MS       (1000)
@@ -247,6 +242,33 @@ Tests_DeviceInterfaceTarget_SendCompletion(
     UNREFERENCED_PARAMETER(CompletionStatus);
 }
 
+_Function_class_(EVT_DMF_ContinuousRequestTarget_SendCompletion)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+Tests_DeviceInterfaceTarget_SendCompletionMustBeCancelled(
+    _In_ DMFMODULE DmfModule,
+    _In_ VOID* ClientRequestContext,
+    _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
+    _In_ size_t InputBufferBytesWritten,
+    _In_reads_(OutputBufferBytesRead) VOID* OutputBuffer,
+    _In_ size_t OutputBufferBytesRead,
+    _In_ NTSTATUS CompletionStatus
+    )
+{
+    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
+    UNREFERENCED_PARAMETER(InputBuffer);
+    UNREFERENCED_PARAMETER(InputBufferBytesWritten);
+    UNREFERENCED_PARAMETER(OutputBuffer);
+    UNREFERENCED_PARAMETER(OutputBufferBytesRead);
+    UNREFERENCED_PARAMETER(CompletionStatus);
+
+    DmfAssert(STATUS_CANCELLED == CompletionStatus);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
+}
+
 #pragma code_seg("PAGE")
 static
 void
@@ -259,6 +281,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+    ULONG timeoutMs;
 
     UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
 
@@ -268,6 +291,17 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
 
     RtlZeroMemory(&sleepIoctlBuffer,
                   sizeof(sleepIoctlBuffer));
+
+    if (TestsUtility_GenerateRandomNumber(0,
+                                          1))
+    {
+        timeoutMs = TestsUtility_GenerateRandomNumber(1,
+                                                      5);
+    }
+    else
+    {
+        timeoutMs = 0;
+    }
 
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
                                                                                  MAXIMUM_SLEEP_TIME_MS);
@@ -279,7 +313,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
+                                              timeoutMs,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
@@ -294,15 +328,13 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
                                               NULL,
                                               ContinuousRequestTarget_RequestType_Ioctl,
                                               IOCTL_Tests_IoctlHandler_SLEEP,
-                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
+                                              timeoutMs,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               NULL);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
 }
 #pragma code_seg()
 
-// TODO: Module does not support cancellation of individual requests.
-//
 #pragma code_seg("PAGE")
 static
 void
@@ -315,27 +347,38 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
     NTSTATUS ntStatus;
     Tests_IoctlHandler_Sleep sleepIoctlBuffer;
     size_t bytesWritten;
+    RequestTarget_DmfRequest DmfRequest;
+    BOOLEAN requestCancelled;
 
     PAGED_CODE();
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "-->%!FUNC!");
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     RtlZeroMemory(&sleepIoctlBuffer,
                   sizeof(sleepIoctlBuffer));
 
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Cancel the request after waiting for a while. It may or may not be canceled.
+    //
+
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
                                                                                  MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
-    ntStatus = DMF_DeviceInterfaceTarget_Send(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
-                                              &sleepIoctlBuffer,
-                                              sizeof(sleepIoctlBuffer),
-                                              NULL,
-                                              NULL,
-                                              ContinuousRequestTarget_RequestType_Ioctl,
-                                              IOCTL_Tests_IoctlHandler_SLEEP,
-                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
-                                              Tests_DeviceInterfaceTarget_SendCompletion,
-                                              NULL);
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletion,
+                                                NULL,
+                                                &DmfRequest);
+
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
                                         0,
@@ -347,25 +390,153 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
         goto Exit;
     }
 
+    // Cancel the request if possible.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                        DmfRequest);
+
     sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
                                                                                  MAXIMUM_SLEEP_TIME_MS);
     bytesWritten = 0;
-    ntStatus = DMF_DeviceInterfaceTarget_Send(moduleContext->DmfModuleDeviceInterfaceTargetPassiveInput,
-                                              &sleepIoctlBuffer,
-                                              sizeof(sleepIoctlBuffer),
-                                              NULL,
-                                              NULL,
-                                              ContinuousRequestTarget_RequestType_Ioctl,
-                                              IOCTL_Tests_IoctlHandler_SLEEP,
-                                              ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
-                                              Tests_DeviceInterfaceTarget_SendCompletion,
-                                              NULL);
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetPassiveInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletion,
+                                                NULL,
+                                                &DmfRequest);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     DMF_AlertableSleep_ResetForReuse(DmfModuleAlertableSleep,
                                      0);
     ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
                                         0,
                                         sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+
+    // Cancel the request if possible.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                        DmfRequest);
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Cancel the request immediately after sending it. It may or may not be canceled.
+    //
+
+    sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletion,
+                                                NULL,
+                                                &DmfRequest);
+
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+
+    // Cancel the request immediately after sending it.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                DmfRequest);
+
+    sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetPassiveInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletion,
+                                                NULL,
+                                                &DmfRequest);
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+
+    // Cancel the request if possible right after sending it.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                        DmfRequest);
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Cancel the before it is normally completed. It should always cancel.
+    //
+
+    sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(4, 
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletionMustBeCancelled,
+                                                NULL,
+                                                &DmfRequest);
+
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Driver is shutting down...get out.
+        //
+        goto Exit;
+    }
+
+    // Cancel the request if possible.
+    // It should always cancel since the time just waited is 1/2 the time that was sent above.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                        DmfRequest);
+    DmfAssert(requestCancelled);
+
+    sleepIoctlBuffer.TimeToSleepMilliSeconds = TestsUtility_GenerateRandomNumber(4, 
+                                                                                 MAXIMUM_SLEEP_TIME_MS);
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceTarget_SendEx(moduleContext->DmfModuleDeviceInterfaceTargetPassiveInput,
+                                                &sleepIoctlBuffer,
+                                                sizeof(sleepIoctlBuffer),
+                                                NULL,
+                                                NULL,
+                                                ContinuousRequestTarget_RequestType_Ioctl,
+                                                IOCTL_Tests_IoctlHandler_SLEEP,
+                                                0,
+                                                ContinuousRequestTarget_CompletionOptions_Default,
+                                                Tests_DeviceInterfaceTarget_SendCompletion,
+                                                NULL,
+                                                &DmfRequest);
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DMF_AlertableSleep_ResetForReuse(DmfModuleAlertableSleep,
+                                     0);
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        sleepIoctlBuffer.TimeToSleepMilliSeconds / 2);
+
+    // Cancel the request if possible.
+    // It should always cancel since the time just waited is 1/2 the time that was sent above.
+    //
+    requestCancelled = DMF_DeviceInterfaceTarget_Cancel(moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput,
+                                                        DmfRequest);
+    //DmfAssert(requestCancelled);
 
 Exit:
     ;

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
@@ -31,6 +31,10 @@ typedef enum
     ContinuousRequestTarget_RequestType_Write
 } ContinuousRequestTarget_RequestType;
 
+// WDFOBJECT that abstracts a WDFREQUEST instance.
+//
+DECLARE_HANDLE(RequestTarget_DmfRequest);
+
 // Enum to specify who owns the buffer and whether to continue streaming the request or stop
 // The streaming callback function returns this value.
 //
@@ -201,6 +205,13 @@ DMF_ContinuousRequestTarget_BufferPut(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_ContinuousRequestTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DMF_ContinuousRequestTarget_IoTargetClear(
     _In_ DMFMODULE DmfModule
@@ -241,7 +252,8 @@ DMF_ContinuousRequestTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
-    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.h
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.h
@@ -47,6 +47,13 @@ DMF_DefaultTarget_BufferPut(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_DefaultTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DMF_DefaultTarget_Get(
     _In_ DMFMODULE DmfModule,
@@ -66,6 +73,23 @@ DMF_DefaultTarget_Send(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_DefaultTarget_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+    _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.md
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.md
@@ -88,7 +88,7 @@ BOOLEAN
 DMF_DefaultTarget_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ RequestTarget_DmfRequest DmfRequest
-    )
+    );
 ````
 
 This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.md
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.md
@@ -78,6 +78,36 @@ ClientBuffer | The given DMF_BufferPool buffer.
 ##### Remarks
 
 * NOTE: ClientBuffer must be a properly formed DMF_BufferPool buffer.
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_DefaultTarget_Cancel
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_DefaultTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    )
+````
+
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+
+##### Returns
+
+TRUE if the underlying WDFREQUEST has been canceled.
+FALSE if the underlying WDFREQUEST could not be canceled because it has been completed or is being completed.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DefaultTarget Module handle.
+DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_DefaultTarget_SendEx()`.
+
+##### Remarks
+* **Caller must use DMF_DefaultTarget_Cancel() to cancel the DmfRequest returned by `DMF_DefaultTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
+** 
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -148,6 +178,59 @@ EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that i
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
 
 ##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_DefaultTarget_SendEx
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_DefaultTarget_SendEx(
+  _In_ DMFMODULE DmfModule,
+  _In_reads_bytes_(RequestLength) VOID* RequestBuffer,
+  _In_ size_t RequestLength,
+  _Out_writes_bytes_(ResponseLength) VOID* ResponseBuffer,
+  _In_ size_t ResponseLength,
+  _In_ DefaultTarget_RequestType RequestType,
+  _In_ ULONG RequestIoctl,
+  _In_ ULONG RequestTimeoutMilliseconds,
+  _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
+  _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+  _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  );
+````
+
+This Method uses the given parameters to create a Request and send it asynchronously to the Module's underlying WDFIOTARGET.
+
+##### Returns
+
+NTSTATUS. Fails if the Request cannot be sent to the Modules internal WDFIOTARGET.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DefaultTarget Module handle.
+RequestBuffer | The Client buffer that is sent to this Module's underlying WDFIOTARGET.
+RequestLength | The size in bytes of RequestBuffer.
+ResponseBuffer | The Client buffer that receives data from this Module's underlying WDFIOTARGET.
+ResponseLength | The size in bytes of ResponseBuffer.
+RequestType | The type of Request to send to this Module's underlying WDFIOTARGET.
+RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purpose of the associated Request that is sent.
+RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
+CompletionOption | Indicates if asynchronous callback should happen at PASSIVE_LEVEL or DISPATCH_LEVEL.
+EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
+SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
+DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
+
+##### Remarks
+* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+sent to the underlying WDFIOTARGET.
+* **Caller must use `DMF_DefaultTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
+** 
+* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_DefaultTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -96,6 +96,13 @@ DMF_DeviceInterfaceTarget_BufferPut(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_DeviceInterfaceTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS
 DMF_DeviceInterfaceTarget_Get(
     _In_ DMFMODULE DmfModule,
@@ -137,7 +144,8 @@ DMF_DeviceInterfaceTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
-    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -173,7 +173,7 @@ BOOLEAN
 DMF_DeviceInterfaceTarget_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ RequestTarget_DmfRequest DmfRequest
-    )
+    );
 ````
 
 This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -163,6 +163,36 @@ ClientBuffer | The given DMF_BufferPool buffer.
 ##### Remarks
 
 * NOTE: ClientBuffer must be a properly formed DMF_BufferPool buffer.
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_DeviceInterfaceTarget_Cancel
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_DeviceInterfaceTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    )
+````
+
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+
+##### Returns
+
+TRUE if the underlying WDFREQUEST has been canceled.
+FALSE if the underlying WDFREQUEST could not be canceled because it has been completed or is being completed.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DeviceInterfaceTarget Module handle.
+DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_DeviceInterfaceTarget_SendEx()`.
+
+##### Remarks
+* **Caller must use DMF_DeviceInterfaceTarget_Cancel() to cancel the DmfRequest returned by `DMF_DeviceInterfaceTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
+** 
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -284,8 +314,9 @@ DMF_DeviceInterfaceTarget_SendEx(
   _In_ ULONG RequestIoctl,
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
-  _In_opt_ DeviceInterfaceTarget_CallbackType_SingleAsynchronousBufferOutput EvtContinuousRequestTargetSingleAsynchronousRequest,
-  _In_opt_ VOID* SingleAsynchronousRequestClientContext
+  _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+  _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
   );
 ````
 
@@ -310,8 +341,15 @@ RequestTimeoutMilliseconds | A time in milliseconds that causes the call to time
 CompletionOption | Completion option associated with the completion routine.
 EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
+DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
 
 ##### Remarks
+* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+sent to the underlying WDFIOTARGET.
+* **Caller must use `DMF_DefaultTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
+** 
+* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_DefaultTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_DeviceInterfaceTarget_SendSynchronously

--- a/Dmf/Modules.Library/Dmf_Registry.c
+++ b/Dmf/Modules.Library/Dmf_Registry.c
@@ -2193,7 +2193,7 @@ Return Value:
     //
     WDF_TIMER_CONFIG_INIT(&timerConfig,
                           Registry_DeferredOperationHandler);
-    timerConfig.AutomaticSerialization = TRUE;
+    timerConfig.AutomaticSerialization = FALSE;
 
     WDF_OBJECT_ATTRIBUTES_INIT(&timerAttributes);
     timerAttributes.ParentObject = DmfModule;

--- a/Dmf/Modules.Library/Dmf_RequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.h
@@ -46,6 +46,13 @@ DECLARE_DMF_MODULE_NO_CONFIG(RequestTarget)
 //
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+BOOLEAN
+DMF_RequestTarget_Cancel(
+    _In_ DMFMODULE DmfModule,
+    _In_ RequestTarget_DmfRequest DmfRequest
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DMF_RequestTarget_IoTargetClear(
     _In_ DMFMODULE DmfModule
@@ -86,7 +93,8 @@ DMF_RequestTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_ ContinuousRequestTarget_CompletionOptions CompletionOption,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
-    _In_opt_ VOID* SingleAsynchronousRequestClientContext
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/DmfTest/DmfKTest/sys/DmfInterface.c
+++ b/DmfTest/DmfKTest/sys/DmfInterface.c
@@ -235,6 +235,7 @@ Return Value:
 
     if (isFunctionDriver)
     {
+#if 0
         // Tests_DefaultTarget
         // -------------------
         //
@@ -243,7 +244,8 @@ Return Value:
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          NULL);
-
+#endif
+#if 1
         // Tests_DeviceInterfaceTarget
         // ---------------------------
         //
@@ -252,6 +254,7 @@ Return Value:
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
                          NULL);
+#endif
     }
     else
     {


### PR DESCRIPTION
Merge20200302
1. Add support for cancelling asynchronous requests.
2. Correct issue in DMF_Registry which caused failure in cases when WDFDEVICE is set to synchronous operation.
3. Merge some SAL fixes.
4. Merge a fix in DMF_Portable_EventWaitForSingleObject when timeout value is set in User-mode.