### PR TITLE
Merge20200421

### DIFF
--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -1529,13 +1529,13 @@ Return Value:
     WdfObjectDelete(dmfObject->ClientModuleInstanceNameMemory);
     dmfObject->ClientModuleInstanceNameMemory = NULL;
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     if (dmfObject->InFlightRecorder != NULL)
     {
         WppRecorderLogDelete(dmfObject->InFlightRecorder);
         dmfObject->InFlightRecorder = NULL;
     }
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 
     if (dmfObject->ModuleConfigMemory != NULL)
     {

--- a/Dmf/Framework/DmfFilter.c
+++ b/Dmf/Framework/DmfFilter.c
@@ -29,7 +29,7 @@ Environment:
 #include "DmfFilter.tmh"
 #endif
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
 
 typedef struct
 {
@@ -455,7 +455,7 @@ Return Value:
     FuncExitVoid(DMF_TRACE);
 }
 
-#endif // !defined(DMF_USER_MODE)
+#endif // defined(DMF_KERNEL_MODE)
 
 // eof: DmfFilter.c
 //

--- a/Dmf/Framework/DmfPortable.c
+++ b/Dmf/Framework/DmfPortable.c
@@ -606,7 +606,7 @@ Return Value:
 
 --*/
 {
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     ExInitializeRundownProtection(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -615,7 +615,7 @@ Return Value:
     //
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 }
 
 VOID
@@ -638,7 +638,7 @@ Return Value:
 
 --*/
 {
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     ExReInitializeRundownProtection(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -647,7 +647,7 @@ Return Value:
     //
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 }
 
 BOOLEAN
@@ -673,7 +673,7 @@ Return Value:
 {
     BOOLEAN returnValue;
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     returnValue = ExAcquireRundownProtection(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -683,7 +683,7 @@ Return Value:
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
     returnValue = FALSE;
-#endif
+#endif // defined(DMF_KERNEL_MODE)
     
     return returnValue;
 }
@@ -708,7 +708,7 @@ Return Value:
 
 --*/
 {
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     ExReleaseRundownProtection(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -717,7 +717,7 @@ Return Value:
     //
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 }
 
 VOID
@@ -741,7 +741,7 @@ Return Value:
 
 --*/
 {
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     ExWaitForRundownProtectionRelease(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -750,7 +750,7 @@ Return Value:
     //
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 }
 
 VOID
@@ -774,7 +774,7 @@ Return Value:
 
 --*/
 {
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     ExRundownCompleted(&RundownRef->RundownRef);
 #else
     // TODO: Equivalent code will go here. Change is pending.
@@ -783,7 +783,7 @@ Return Value:
     //
     UNREFERENCED_PARAMETER(RundownRef);
     DmfAssert(FALSE);
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 }
 
 // eof: DmfPortable.c

--- a/Dmf/Framework/DmfTrace.h
+++ b/Dmf/Framework/DmfTrace.h
@@ -72,6 +72,10 @@ Environment:
 // CUSTOM_TYPE(SMFX_MACHINE_EXCEPTION, ItemEnum(SmFx::MachineException));
 // CUSTOM_TYPE(SMFX_TRANSITION_TYPE, ItemEnum(SmFx::TransitionType));
 // CUSTOM_TYPE(UCMUCSI_PPM_IOCTL, ItemEnum(_UCMUCSI_PPM_IOCTL));
+// CUSTOM_TYPE(MachineException, ItemEnum(StateMachine_MachineException));
+// CUSTOM_TYPE(TransitionType, ItemEnum(StateMachine_TransitionType));
+// CUSTOM_TYPE(ComponentFirmwareUpdateV2Event, ItemEnum(ComponentFirmwareUpdateV2EventId));
+// CUSTOM_TYPE(ComponentFirmwareUpdateV2State, ItemEnum(ComponentFirmwareUpdateV2StateId));
 // end_wpp
 
 #if !defined(DMF_WDF_DRIVER)

--- a/Dmf/Framework/DmfUtility.c
+++ b/Dmf/Framework/DmfUtility.c
@@ -247,7 +247,7 @@ Return Value:
 
 #endif // defined(DMF_USER_MODE)
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
 
 #pragma code_seg("PAGE")
 _Must_inspect_result_
@@ -332,7 +332,7 @@ Exit:
 }
 #pragma code_seg()
 
-#endif // !defined(DMF_USER_MODE)
+#endif // defined(DMF_KERNEL_MODE)
 
 #pragma code_seg("PAGE")
 VOID
@@ -1041,7 +1041,7 @@ Exit:
     FuncExitNoReturn(DMF_TRACE);
 }
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
 
 // Event log support for Kernel-mode Drivers.
 //
@@ -1885,7 +1885,7 @@ Exit:
 
     FuncExitNoReturn(DMF_TRACE);
 }
-#endif // !defined(DMF_USER_MODE)
+#endif // defined(DMF_KERNEL_MODE)
 
 // eof: DmfUtility.c
 //

--- a/Dmf/Framework/Modules.Core/DMF_String.c
+++ b/Dmf/Framework/Modules.Core/DMF_String.c
@@ -641,7 +641,7 @@ Return Value:
     for (ULONG stringIndex = 0; stringIndex < NumberOfStringsInStringList; stringIndex++)
     {
         DmfAssert(StringList[stringIndex] != NULL);
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Compare StringList[%u]=[%s] with [%s]", 
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Compare StringList[%u]=[%s] with [%s]", 
                     stringIndex,
                     StringList[stringIndex],
                     LookFor);
@@ -649,7 +649,7 @@ Return Value:
                                StringList[stringIndex],
                                LookFor) == 0)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Compare StringList[%u]=[%s] with [%s]: Match", 
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Compare StringList[%u]=[%s] with [%s]: Match", 
                         stringIndex,
                         StringList[stringIndex],
                         LookFor);
@@ -971,7 +971,7 @@ Return Value:
     DmfAssert(DestinationString != NULL);
     DmfAssert(SourceString != NULL);
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     // Kernel-mode directly supports the conversion.
     //
     ntStatus = RtlAnsiStringToUnicodeString(DestinationString,
@@ -1023,7 +1023,7 @@ Return Value:
 
 Exit:
     ;
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 
     // AnsiString has the converted string.
     //
@@ -1072,7 +1072,7 @@ Return Value:
     DmfAssert(DestinationString != NULL);
     DmfAssert(SourceString != NULL);
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
     // Kernel-mode directly supports the conversion.
     //
     ntStatus = RtlUnicodeStringToAnsiString(DestinationString,
@@ -1124,7 +1124,7 @@ Return Value:
 
 Exit:
     ;
-#endif
+#endif // defined(DMF_KERNEL_MODE)
 
     // AnsiString has the converted string.
     //

--- a/Dmf/Framework/Modules.Core/Dmf_IoctlHandler.c
+++ b/Dmf/Framework/Modules.Core/Dmf_IoctlHandler.c
@@ -370,7 +370,7 @@ Return Value:
         ioctlRecord = &moduleConfig->IoctlRecords[tableIndex];
         if ((ULONG)(ioctlRecord->IoctlCode) == IoControlCode)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE,
                         "Matching IOCTL Found: 0x%08X tableIndex=%d",
                         IoControlCode,
                         tableIndex);
@@ -471,7 +471,7 @@ Return Value:
                 }
             }
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE,
                         "InputBufferSize=%d OutputBufferSize=%d tableIndex=%d",
                         (ULONG)inputBufferSize,
                         (ULONG)outputBufferSize,
@@ -509,11 +509,11 @@ Exit:
                                               ntStatus,
                                               bytesReturned);
         }
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Handled: Request=0x%p ntStatus=%!STATUS!", Request, ntStatus);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Handled: Request=0x%p ntStatus=%!STATUS!", Request, ntStatus);
     }
     else
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Not Handled: Request=0x%p", Request);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Not Handled: Request=0x%p", Request);
     }
 
     // NOTE: No entry/exit logging to eliminate spurious logging.
@@ -585,7 +585,7 @@ Return Value:
         // Callback does nothing...just do what WDF would normally do.
         // This call supports both filter and non-filter drivers correctly.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "IoctlHandler_AccessModeDefault");
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "IoctlHandler_AccessModeDefault");
         if (DMF_ModuleIsInFilterDriver(DmfModule))
         {
             handled = DMF_ModuleRequestCompleteOrForward(DmfModule,
@@ -605,7 +605,7 @@ Return Value:
         WdfRequestGetParameters(Request,
                                 &requestParameters);
 
-#if !defined(DMF_USER_MODE)
+#if defined(DMF_KERNEL_MODE)
         PIO_SECURITY_CONTEXT ioSecurityContext;
         PACCESS_TOKEN accessToken;
 
@@ -668,7 +668,7 @@ RequestComplete:
 
 #endif // !defined(DMF_USER_MODE)
 
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "EVT_DMF_IoctlHandler_AccessModeFilterAdministrator* ntStatus=%!STATUS!", ntStatus);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "EVT_DMF_IoctlHandler_AccessModeFilterAdministrator* ntStatus=%!STATUS!", ntStatus);
         if (!NT_SUCCESS(ntStatus))
         {
             // This call completes the request correctly for both filter and non-filter drivers.
@@ -682,7 +682,7 @@ RequestComplete:
     {
         // Allow the Client to determine if the connection to User-mode should be allowed.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "EVT_DMF_IoctlHandler_AccessModeFilterClientCallback");
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "EVT_DMF_IoctlHandler_AccessModeFilterClientCallback");
         DmfAssert(moduleConfig->EvtIoctlHandlerAccessModeFilter != NULL);
         // NOTE: This callback must use DMF_ModuleRequestCompleteOrForward() to complete the request if the 
         //       return status is not STATUS_SUCCESS; or, return FALSE.

--- a/Dmf/Framework/Modules.Core/Dmf_RingBuffer.c
+++ b/Dmf/Framework/Modules.Core/Dmf_RingBuffer.c
@@ -142,7 +142,7 @@ Return Value:
     DmfAssert(RingBuffer != NULL);
     DmfAssert(RingBuffer->ItemSize > 0);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE,
                 "ReadPointer=%d", (LONG)((RingBuffer->ReadPointer - RingBuffer->Items) / RingBuffer->ItemSize));
 
     RingBuffer->ReadPointer += RingBuffer->ItemSize;
@@ -151,7 +151,7 @@ Return Value:
     if (RingBuffer->ReadPointer == RingBuffer->BufferEnd)
     {
         RingBuffer->ReadPointer = RingBuffer->Items;
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wrap Read RingBuffer->ReadPointer");
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Wrap Read RingBuffer->ReadPointer");
     }
 
     // An item has been read. There is now one less item.
@@ -379,7 +379,7 @@ Return Value:
         }
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE,
                 "WritePointer=%d BufferSize=%d",
                 (LONG)((RingBuffer->WritePointer - RingBuffer->Items) / RingBuffer->ItemSize),
                 BufferSize);
@@ -420,7 +420,7 @@ Return Value:
     if (RingBuffer->WritePointer == RingBuffer->BufferEnd)
     {
         RingBuffer->WritePointer = RingBuffer->Items;
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wrap Read RingBuffer->WritePointer");
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Wrap Read RingBuffer->WritePointer");
     }
 
     // An item has just been written (added), so increment the number of items in the buffer.
@@ -482,7 +482,7 @@ Return Value:
         goto Exit;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE,
                 "ReadPointer=%d", (LONG)((RingBuffer->ReadPointer - RingBuffer->Items) / RingBuffer->ItemSize));
 
     DmfAssert(BufferSize == RingBuffer->ItemSize);

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
@@ -443,7 +443,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     DMF_CONTEXT_Tests_DefaultTarget* moduleContext;
     NTSTATUS ntStatus;
     size_t bytesWritten;
-    RequestTarget_DmfRequest DmfRequest;
+    RequestTarget_DmfRequest DmfRequestId;
     BOOLEAN requestCanceled;
     LONG timeToSleepMilliseconds;
 
@@ -481,7 +481,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletion,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -502,7 +502,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // Cancel the request if possible.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetDispatchInput,
-                                               DmfRequest);
+                                               DmfRequestId);
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -527,7 +527,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletion,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
     {
@@ -541,7 +541,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // Cancel the request if possible.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetPassiveInput,
-                                               DmfRequest);
+                                               DmfRequestId);
 
     ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
                                         0,
@@ -578,7 +578,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletion,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -589,7 +589,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // Cancel the request immediately after sending it.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetDispatchInput,
-                                               DmfRequest);
+                                               DmfRequestId);
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -614,7 +614,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletion,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
     {
@@ -624,7 +624,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // Cancel the request if possible right after sending it.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetPassiveInput,
-                                               DmfRequest);
+                                               DmfRequestId);
 
     /////////////////////////////////////////////////////////////////////////////////////
     // Cancel the request before it is normally completed. It should always cancel.
@@ -653,7 +653,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletionMustBeCancelled,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -668,7 +668,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // It should always cancel since the time just waited is 1/4 the time that was sent above.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetDispatchInput,
-                                               DmfRequest);
+                                               DmfRequestId);
     // Even though the attempt to cancel happens in 1/4 of the total time out, it is possible
     // that the cancel call happens just as the underlying driver is going away. In that case,
     // the request is not canceled by this call, but it will be canceled by the underlying
@@ -706,7 +706,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
                                         0,
                                         Tests_DefaultTarget_SendCompletion,
                                         moduleContext,
-                                        &DmfRequest);
+                                        &DmfRequestId);
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
     {
@@ -721,7 +721,7 @@ Tests_DefaultTarget_ThreadAction_AsynchronousCancel(
     // It should always cancel since the time just waited is 1/4 the time that was sent above.
     //
     requestCanceled = DMF_DefaultTarget_Cancel(moduleContext->DmfModuleDefaultTargetPassiveInput,
-                                               DmfRequest);
+                                               DmfRequestId);
     // Even though the attempt to cancel happens in 1/4 of the total time out, it is possible
     // that the cancel call happens just as the underlying driver is going away. In that case,
     // the request is not canceled by this call, but it will be canceled by the underlying

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
@@ -67,6 +67,8 @@ typedef struct
     //
     DMFMODULE DmfModuleDeviceInterfaceMultipleTargetDispatchInput;
     DMFMODULE DmfModuleDeviceInterfaceMultipleTargetPassiveInput;
+    DMFMODULE DmfModuleDeviceInterfaceMultipleTargetDispatchInputNonContinuous;
+    DMFMODULE DmfModuleDeviceInterfaceMultipleTargetPassiveInputNonContinuous;
     // Source of buffers sent asynchronously.
     //
     DMFMODULE DmfModuleBufferPool;
@@ -242,7 +244,7 @@ Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousDispatchInput(
 
 Routine Description:
 
-    Sends synchronous requests to a given Target on the PassiveInput instance.
+    Sends synchronous requests to a given Target on the DispatchInput instance.
 
 Arguments:
 
@@ -268,6 +270,47 @@ Return Value:
                                                                  DmfModuleAlertableSleep,
                                                                  Target,
                                                                  moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInput);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousDispatchInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends synchronous requests to a given Target on the DispatchInputNonContinuous instance.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+    
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_Synchronous(DmfModule,
+                                                                 DmfModuleAlertableSleep,
+                                                                 Target,
+                                                                 moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInputNonContinuous);
 }
 #pragma code_seg()
 
@@ -309,6 +352,47 @@ Return Value:
                                                                  DmfModuleAlertableSleep,
                                                                  Target,
                                                                  moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInput);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousPassiveInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends synchronous requests to a given Target on the PassiveInputNonContinuous instance.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+    
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_Synchronous(DmfModule,
+                                                                 DmfModuleAlertableSleep,
+                                                                 Target,
+                                                                 moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInputNonContinuous);
 }
 #pragma code_seg()
 
@@ -361,6 +445,11 @@ Return Value:
 
     moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget*)ClientRequestContext;
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "RECEIVE sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p", 
+                sleepIoctlBuffer->TimeToSleepMilliseconds,
+                InputBuffer);
+
     DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
                        (VOID*)sleepIoctlBuffer);
 }
@@ -545,6 +634,48 @@ Return Value:
 #pragma code_seg("PAGE")
 static
 void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousDispatchInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends asynchronous requests to a Target of the DispatchInputNonContinuous instance.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+    InstanceToSendTo - Which of the instantiated Modules to send to.
+    
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_Asynchronous(DmfModule,
+                                                                  DmfModuleAlertableSleep,
+                                                                  Target,
+                                                                  moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInputNonContinuous);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
 Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousPassiveInput(
     _In_ DMFMODULE DmfModule,
     _In_ DMFMODULE DmfModuleAlertableSleep,
@@ -587,6 +718,48 @@ Return Value:
 #pragma code_seg("PAGE")
 static
 void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousPassiveInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends asynchronous requests to a given Target of the PassiveInputNonContinuous instance.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+    InstanceToSendTo - Which of the instantiated Modules to send to.
+    
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    UNREFERENCED_PARAMETER(DmfModuleAlertableSleep);
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_Asynchronous(DmfModule,
+                                                                  DmfModuleAlertableSleep,
+                                                                  Target,
+                                                                  moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInputNonContinuous);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
 Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancel(
     _In_ DMFMODULE DmfModule,
     _In_ DMFMODULE DmfModuleAlertableSleep,
@@ -615,7 +788,7 @@ Return Value:
     DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
     NTSTATUS ntStatus;
     size_t bytesWritten;
-    RequestTarget_DmfRequest DmfRequest;
+    RequestTarget_DmfRequest DmfRequestId;
     BOOLEAN requestCanceled;
     LONG timeToSleepMilliseconds;
     Tests_IoctlHandler_Sleep* sleepIoctlBuffer;
@@ -651,7 +824,7 @@ Return Value:
                                                         0,
                                                         Tests_DeviceInterfaceMultipleTarget_SendCompletion,
                                                         moduleContext,
-                                                        &DmfRequest);
+                                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -659,9 +832,11 @@ Return Value:
         goto Exit;
     }
 
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
     ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
                                         0,
-                                        timeToSleepMilliseconds / 4);
+                                        timeToSleepMilliseconds);
     if (!NT_SUCCESS(ntStatus))
     {
         // Driver is shutting down...get out.
@@ -673,7 +848,65 @@ Return Value:
     //
     requestCanceled = DMF_DeviceInterfaceMultipleTarget_Cancel(InstanceToSendTo,
                                                                Target,
-                                                               DmfRequest);
+                                                               DmfRequestId);
+
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
+
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&sleepIoctlBuffer,
+                                  NULL);
+    ASSERT(NT_SUCCESS(ntStatus));
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Cancel the request after waiting the same time sent in timeout. 
+    // It may or may not be canceled.
+    //
+
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&sleepIoctlBuffer,
+                                  NULL);
+    ASSERT(NT_SUCCESS(ntStatus));
+
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
+
+    sleepIoctlBuffer->TimeToSleepMilliseconds = timeToSleepMilliseconds;
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceMultipleTarget_SendEx(InstanceToSendTo,
+                                                        Target,
+                                                        sleepIoctlBuffer,
+                                                        sizeof(Tests_IoctlHandler_Sleep),
+                                                        NULL,
+                                                        NULL,
+                                                        ContinuousRequestTarget_RequestType_Ioctl,
+                                                        IOCTL_Tests_IoctlHandler_SLEEP,
+                                                        0,
+                                                        Tests_DeviceInterfaceMultipleTarget_SendCompletion,
+                                                        moduleContext,
+                                                        &DmfRequestId);
+
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        timeToSleepMilliseconds);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Driver is shutting down...get out.
+        //
+        goto Exit;
+    }
+
+    // Cancel the request if possible.
+    //
+    requestCanceled = DMF_DeviceInterfaceMultipleTarget_Cancel(InstanceToSendTo,
+                                                               Target,
+                                                               DmfRequestId);
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -708,7 +941,7 @@ Return Value:
                                                         0,
                                                         Tests_DeviceInterfaceMultipleTarget_SendCompletion,
                                                         moduleContext,
-                                                        &DmfRequest);
+                                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -720,7 +953,65 @@ Return Value:
     //
     requestCanceled = DMF_DeviceInterfaceMultipleTarget_Cancel(InstanceToSendTo,
                                                                Target,
-                                                               DmfRequest);
+                                                               DmfRequestId);
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Cancel the request after it is normally completed. It should never cancel unless driver is shutting down.
+    //
+
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&sleepIoctlBuffer,
+                                  NULL);
+    ASSERT(NT_SUCCESS(ntStatus));
+
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(MINIMUM_SLEEP_TIME_MS, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
+    
+    DmfAssert(timeToSleepMilliseconds >= MINIMUM_SLEEP_TIME_MS);
+    sleepIoctlBuffer->TimeToSleepMilliseconds = timeToSleepMilliseconds;
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "SEND: sleepIoctlBuffer->TimeToSleepMilliseconds=%d sleepIoctlBuffer=0x%p", 
+                timeToSleepMilliseconds,
+                sleepIoctlBuffer);
+    bytesWritten = 0;
+    ntStatus = DMF_DeviceInterfaceMultipleTarget_SendEx(InstanceToSendTo,
+                                                        Target,
+                                                        sleepIoctlBuffer,
+                                                        sizeof(Tests_IoctlHandler_Sleep),
+                                                        NULL,
+                                                        NULL,
+                                                        ContinuousRequestTarget_RequestType_Ioctl,
+                                                        IOCTL_Tests_IoctlHandler_SLEEP,
+                                                        0,
+                                                        Tests_DeviceInterfaceMultipleTarget_SendCompletion,
+                                                        moduleContext,
+                                                        &DmfRequestId);
+
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = DMF_AlertableSleep_Sleep(DmfModuleAlertableSleep,
+                                        0,
+                                        timeToSleepMilliseconds * 4);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Driver is shutting down...get out.
+        //
+        goto Exit;
+    }
+
+    // Cancel the request if possible.
+    // It should never cancel since the time just waited is 4 times what was sent above.
+    //
+    requestCanceled = DMF_DeviceInterfaceMultipleTarget_Cancel(InstanceToSendTo,
+                                                               Target,
+                                                               DmfRequestId);
+    DmfAssert(! requestCanceled);
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "END: sleepIoctlBuffer->TimeToSleepMilliseconds=%d sleepIoctlBuffer=0x%p", 
+                timeToSleepMilliseconds,
+                sleepIoctlBuffer);
 
     /////////////////////////////////////////////////////////////////////////////////////
     // Cancel the request before it is normally completed. It should always cancel.
@@ -734,6 +1025,7 @@ Return Value:
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(MINIMUM_SLEEP_TIME_MS, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
 
+    DmfAssert(timeToSleepMilliseconds >= MINIMUM_SLEEP_TIME_MS);
     sleepIoctlBuffer->TimeToSleepMilliseconds = timeToSleepMilliseconds;
     bytesWritten = 0;
     ntStatus = DMF_DeviceInterfaceMultipleTarget_SendEx(InstanceToSendTo,
@@ -747,7 +1039,7 @@ Return Value:
                                                         0,
                                                         Tests_DeviceInterfaceMultipleTarget_SendCompletionMustBeCancelled,
                                                         moduleContext,
-                                                        &DmfRequest);
+                                                        &DmfRequestId);
 
     DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
     if (!NT_SUCCESS(ntStatus))
@@ -763,7 +1055,7 @@ Return Value:
     //
     requestCanceled = DMF_DeviceInterfaceMultipleTarget_Cancel(InstanceToSendTo,
                                                                Target,
-                                                               DmfRequest);
+                                                               DmfRequestId);
     // Even though the attempt to cancel happens in 1/4 of the total time out, it is possible
     // that the cancel call happens just as the underlying driver is going away. In that case,
     // the request is not canceled by this call, but it will be canceled by the underlying
@@ -825,6 +1117,45 @@ Return Value:
 #pragma code_seg("PAGE")
 static
 void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelDispatchInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends requests to a Target of a DispatchInputNonContinous instance and cancels them.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancel(DmfModule,
+                                                                        DmfModuleAlertableSleep,
+                                                                        Target,
+                                                                        moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInputNonContinuous);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
 Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelPassiveInput(
     _In_ DMFMODULE DmfModule,
     _In_ DMFMODULE DmfModuleAlertableSleep,
@@ -858,6 +1189,45 @@ Return Value:
                                                                         DmfModuleAlertableSleep,
                                                                         Target,
                                                                         moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInput);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+static
+void
+Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelPassiveInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleAlertableSleep,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    )
+/*++
+
+Routine Description:
+
+    Sends requests to a Target of a PassiveInputNonContinuous instance and cancels them.
+
+Arguments:
+
+    DmfModule - DMF_DeviceInterfaceMultipleTarget.
+    DmfModuleAlertableSleep - Used to wait.
+    Target - The given Target.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget* moduleContext;
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancel(DmfModule,
+                                                                        DmfModuleAlertableSleep,
+                                                                        Target,
+                                                                        moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInputNonContinuous);
 }
 #pragma code_seg()
 
@@ -903,18 +1273,89 @@ Return Value:
     {
         case TEST_ACTION_SYNCHRONOUS:
             Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousDispatchInput(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
-                                                                                 threadContext->DmfModuleAlertableSleep,
-                                                                                 threadContext->Target);
+                                                                                      threadContext->DmfModuleAlertableSleep,
+                                                                                      threadContext->Target);
             break;
         case TEST_ACTION_ASYNCHRONOUS:
             Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousDispatchInput(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
-                                                                                  threadContext->DmfModuleAlertableSleep,
-                                                                                  threadContext->Target);
+                                                                                       threadContext->DmfModuleAlertableSleep,
+                                                                                       threadContext->Target);
             break;
         case TEST_ACTION_ASYNCHRONOUSCANCEL:
             Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelDispatchInput(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
-                                                                                        threadContext->DmfModuleAlertableSleep,
-                                                                                        threadContext->Target);
+                                                                                             threadContext->DmfModuleAlertableSleep,
+                                                                                             threadContext->Target);
+            break;
+        default:
+            DmfAssert(FALSE);
+            break;
+    }
+
+    // Repeat the test, until stop is signaled.
+    //
+    if (!DMF_Thread_IsStopPending(DmfModuleThread))
+    {
+        DMF_Thread_WorkReady(DmfModuleThread);
+    }
+
+    TestsUtility_YieldExecution();
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_Function_class_(EVT_DMF_Thread_Function)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+VOID
+Tests_DeviceInterfaceMultipleTarget_WorkThreadDispatchInputNonContinuous(
+    _In_ DMFMODULE DmfModuleThread
+    )
+/*++
+
+Routine Description:
+
+    Thread work callback for DispatchInput instance.
+
+Arguments:
+
+    DmfModule - DMF_Thread.
+
+Return Value:
+
+    None
+
+--*/
+{
+    TEST_ACTION testAction;
+    THREAD_CONTEXT* threadContext;
+
+    PAGED_CODE();
+
+    threadContext = WdfObjectGet_THREAD_CONTEXT(DmfModuleThread);
+
+    // Generate a random test action Id for a current iteration.
+    //
+    testAction = (TEST_ACTION)TestsUtility_GenerateRandomNumber(TEST_ACTION_MINIUM,
+                                                                TEST_ACTION_MAXIMUM);
+
+    // Execute the test action.
+    //
+    switch (testAction)
+    {
+        case TEST_ACTION_SYNCHRONOUS:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousDispatchInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                   threadContext->DmfModuleAlertableSleep,
+                                                                                                   threadContext->Target);
+            break;
+        case TEST_ACTION_ASYNCHRONOUS:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousDispatchInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                    threadContext->DmfModuleAlertableSleep,
+                                                                                                    threadContext->Target);
+            break;
+        case TEST_ACTION_ASYNCHRONOUSCANCEL:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelDispatchInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                          threadContext->DmfModuleAlertableSleep,
+                                                                                                          threadContext->Target);
             break;
         default:
             DmfAssert(FALSE);
@@ -986,6 +1427,77 @@ Return Value:
             Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelPassiveInput(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
                                                                                             threadContext->DmfModuleAlertableSleep,
                                                                                             threadContext->Target);
+            break;
+        default:
+            DmfAssert(FALSE);
+            break;
+    }
+
+    // Repeat the test, until stop is signaled.
+    //
+    if (!DMF_Thread_IsStopPending(DmfModuleThread))
+    {
+        DMF_Thread_WorkReady(DmfModuleThread);
+    }
+
+    TestsUtility_YieldExecution();
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_Function_class_(EVT_DMF_Thread_Function)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+VOID
+Tests_DeviceInterfaceMultipleTarget_WorkThreadPassiveInputNonContinuous(
+    _In_ DMFMODULE DmfModuleThread
+    )
+/*++
+
+Routine Description:
+
+    Thread work callback for PassiveInput instance.
+
+Arguments:
+
+    DmfModule - DMF_Thread.
+
+Return Value:
+
+    None
+
+--*/
+{
+    TEST_ACTION testAction;
+    THREAD_CONTEXT* threadContext;
+
+    PAGED_CODE();
+
+    threadContext = WdfObjectGet_THREAD_CONTEXT(DmfModuleThread);
+
+    // Generate a random test action Id for a current iteration.
+    //
+    testAction = (TEST_ACTION)TestsUtility_GenerateRandomNumber(TEST_ACTION_MINIUM,
+                                                                TEST_ACTION_MAXIMUM);
+
+    // Execute the test action.
+    //
+    switch (testAction)
+    {
+        case TEST_ACTION_SYNCHRONOUS:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_SynchronousPassiveInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                  threadContext->DmfModuleAlertableSleep,
+                                                                                                  threadContext->Target);
+            break;
+        case TEST_ACTION_ASYNCHRONOUS:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousPassiveInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                   threadContext->DmfModuleAlertableSleep,
+                                                                                                   threadContext->Target);
+            break;
+        case TEST_ACTION_ASYNCHRONOUSCANCEL:
+            Tests_DeviceInterfaceMultipleTarget_ThreadAction_AsynchronousCancelPassiveInputNonContinuous(threadContext->DmfModuleDeviceInterfaceMultipleTarget,
+                                                                                                         threadContext->DmfModuleAlertableSleep,
+                                                                                                         threadContext->Target);
             break;
         default:
             DmfAssert(FALSE);
@@ -1341,6 +1853,52 @@ Return Value:
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _IRQL_requires_same_
 VOID
+Tests_DeviceInterfaceMultipleTarget_OnStateChangeDispatchInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target,
+    _In_ DeviceInterfaceMultipleTarget_StateType IoTargetState
+    )
+/*++
+
+Routine Description:
+
+    Called when a given Target arrives or is being removed.
+
+Arguments:
+
+    DmfModule - DMF_Tests_DeviceInterfaceMultipleTarget.
+    Target - The given target.
+    IoTargetState - Indicates how the given Target state is changing.
+
+Return Value:
+
+    None
+
+--*/
+{
+    if ((IoTargetState == DeviceInterfaceMultipleTarget_StateType_Open) ||
+        (IoTargetState == DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled))
+    {
+        Tests_DeviceInterfaceMultipleTarget_OnTargetArrival(DmfModule,
+                                                            Target,
+                                                            Tests_DeviceInterfaceMultipleTarget_WorkThreadDispatchInputNonContinuous);
+    }
+    else if ((IoTargetState == DeviceInterfaceMultipleTarget_StateType_QueryRemove) ||
+             (IoTargetState == DeviceInterfaceMultipleTarget_StateType_Close))
+    {
+        TARGET_CONTEXT* targetContext = DeviceInterfaceMultipleTarget_TargetContextGet(Target);
+        if (! targetContext->Closed)
+        {
+            targetContext->Closed = TRUE;
+            Tests_DeviceInterfaceMultipleTarget_OnTargetRemoval(DmfModule,
+                                                                Target);
+        }
+    }
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
 Tests_DeviceInterfaceMultipleTarget_OnStateChangePassiveInput(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_Target Target,
@@ -1370,6 +1928,52 @@ Return Value:
         Tests_DeviceInterfaceMultipleTarget_OnTargetArrival(DmfModule,
                                                             Target,
                                                             Tests_DeviceInterfaceMultipleTarget_WorkThreadPassiveInput);
+    }
+    else if ((IoTargetState == DeviceInterfaceMultipleTarget_StateType_QueryRemove) ||
+             (IoTargetState == DeviceInterfaceMultipleTarget_StateType_Close))
+    {
+        TARGET_CONTEXT* targetContext = DeviceInterfaceMultipleTarget_TargetContextGet(Target);
+        if (! targetContext->Closed)
+        {
+            targetContext->Closed = TRUE;
+            Tests_DeviceInterfaceMultipleTarget_OnTargetRemoval(DmfModule,
+                                                                Target);
+        }
+    }
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+Tests_DeviceInterfaceMultipleTarget_OnStateChangePassiveInputNonContinuous(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target,
+    _In_ DeviceInterfaceMultipleTarget_StateType IoTargetState
+    )
+/*++
+
+Routine Description:
+
+    Called when a given Target arrives or is being removed.
+
+Arguments:
+
+    DmfModule - DMF_Tests_DeviceInterfaceMultipleTarget.
+    Target - The given target.
+    IoTargetState - Indicates how the given Target state is changing.
+
+Return Value:
+
+    None
+
+--*/
+{
+    if ((IoTargetState == DeviceInterfaceMultipleTarget_StateType_Open) ||
+        (IoTargetState == DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled))
+    {
+        Tests_DeviceInterfaceMultipleTarget_OnTargetArrival(DmfModule,
+                                                            Target,
+                                                            Tests_DeviceInterfaceMultipleTarget_WorkThreadPassiveInputNonContinuous);
     }
     else if ((IoTargetState == DeviceInterfaceMultipleTarget_StateType_QueryRemove) ||
              (IoTargetState == DeviceInterfaceMultipleTarget_StateType_Close))
@@ -1470,6 +2074,19 @@ Return Value:
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInput);
 
+    // DeviceInterfaceMultipleTarget (DISPATCH_LEVEL)
+    // Processes Input Buffers.
+    //
+    DMF_CONFIG_DeviceInterfaceMultipleTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceMultipleTarget,
+                                                                 &moduleAttributes);
+    moduleConfigDeviceInterfaceMultipleTarget.DeviceInterfaceMultipleTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceMultipleTarget.EvtDeviceInterfaceMultipleTargetOnStateChange = Tests_DeviceInterfaceMultipleTarget_OnStateChangeDispatchInputNonContinuous;
+
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleDeviceInterfaceMultipleTargetDispatchInputNonContinuous);
+
     // DeviceInterfaceMultipleTarget (PASSIVE_LEVEL)
     // Processes Input Buffers.
     //
@@ -1492,6 +2109,20 @@ Return Value:
                      &moduleAttributes,
                      WDF_NO_OBJECT_ATTRIBUTES,
                      &moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInput);
+
+    // DeviceInterfaceMultipleTarget (PASSIVE_LEVEL)
+    // Processes Input Buffers.
+    //
+    DMF_CONFIG_DeviceInterfaceMultipleTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceMultipleTarget,
+                                                                 &moduleAttributes);
+    moduleConfigDeviceInterfaceMultipleTarget.DeviceInterfaceMultipleTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceMultipleTarget.EvtDeviceInterfaceMultipleTargetOnStateChange = Tests_DeviceInterfaceMultipleTarget_OnStateChangePassiveInputNonContinuous;
+
+    moduleAttributes.PassiveLevel = TRUE;
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleDeviceInterfaceMultipleTargetPassiveInputNonContinuous);
 
     FuncExitVoid(DMF_TRACE);
 }

--- a/Dmf/Modules.Library/Dmf_AlertableSleep.c
+++ b/Dmf/Modules.Library/Dmf_AlertableSleep.c
@@ -479,7 +479,7 @@ Return Value:
 
     DMF_ModuleLock(DmfModule);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait EventIndex=%u: Milliseconds%d-ms DoNotWait=%d Closing=%!bool!",
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Wait EventIndex=%u: Milliseconds%d-ms DoNotWait=%d Closing=%!bool!",
                 EventIndex,
                 Milliseconds,
                 moduleContext->DoNotWait[EventIndex],
@@ -489,17 +489,17 @@ Return Value:
     {
         // Don't wait on the event if the Module is closing.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Event[%u] closing. Do not wait.", EventIndex);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Event[%u] closing. Do not wait.", EventIndex);
     }
     else if (moduleContext->DoNotWait[EventIndex])
     {
         // The event has already been set. Do not wait and return unsuccessful.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Event[%u] already interrupted. Do not wait.", EventIndex);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Event[%u] already interrupted. Do not wait.", EventIndex);
     }
     else
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait[%u] for %d-ms...", EventIndex, Milliseconds);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Wait[%u] for %d-ms...", EventIndex, Milliseconds);
 
         DmfAssert(! moduleContext->CurrentlyWaiting[EventIndex]);
         moduleContext->CurrentlyWaiting[EventIndex] = TRUE;
@@ -523,7 +523,7 @@ Return Value:
             // The thread delayed for the time specified by the caller. It is considered success.
             //
             ntStatus = STATUS_SUCCESS;
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait[%u] Satisfied", EventIndex);
+            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait[%u] Satisfied Milliseconds=%d DmfModule=0x%p", EventIndex, Milliseconds, DmfModule);
         }
         else
         {
@@ -531,7 +531,7 @@ Return Value:
             // did not happen. It is considered unsuccessful.
             //
             ntStatus = STATUS_UNSUCCESSFUL;
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait[%u] Interrupted", EventIndex);
+            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Wait[%u] Interrupted Milliseconds=%d DmfModule=0x%p", EventIndex, Milliseconds, DmfModule);
         }
 
         moduleContext->CurrentlyWaiting[EventIndex] = FALSE;

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
@@ -208,7 +208,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_ContinuousRequestTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -252,7 +252,7 @@ DMF_ContinuousRequestTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
@@ -315,11 +315,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_ContinuousRequestTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 ````
 
-This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequestId.
 
 ##### Returns
 
@@ -330,10 +330,10 @@ FALSE if the underlying WDFREQUEST could not be canceled because it has been com
 Parameter | Description
 ----|----
 DmfModule | An open DMF_ContinuousRequestTarget Module handle.
-DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_ContinuousRequestTarget_SendEx()`.
+DmfRequestId | The unique request id returned by `DMF_ContinuousRequestTarget_SendEx()`.
 
 ##### Remarks
-* **Caller must use DMF_ContinuousRequestTarget_Cancel() to cancel the DmfRequest returned by `DMF_ContinuousRequestTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+* **Caller must use DMF_ContinuousRequestTarget_Cancel() to cancel the DmfRequestId returned by `DMF_ContinuousRequestTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
 
@@ -452,7 +452,7 @@ DMF_ContinuousRequestTarget_SendEx(
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
   _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
   );
 ````
 
@@ -477,16 +477,16 @@ RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purp
 RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
 EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
-DmfRequest | Contains a handle to the WDFREQUEST that was sent to the underlying IoTarget so that caller can cancel the WDFREQUEST using DMF_ContinuousRequestTarget_Cancel().
+DmfRequestId | Returns a unique id associated with the underlying WDFREQUEST. Client may use this id to cancel the asynchronous transaction.
 
 ##### Remarks
 
-* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+* Caller passes `DmfRequestId` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
 sent to the underlying WDFIOTARGET.
-* **Caller must use `DMF_ContinuousRequestTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+* **Caller must use `DMF_ContinuousRequestTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequestId. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
-* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_ContinuousRequestTarget_Cancel()`.** For example, do not assign a context to the handle.
+* **Caller must not use value returned in DmfRequestId for any purpose except to pass it `DMF_ContinuousRequestTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_ContinuousRequestTarget_SendSynchronously

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.c
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.c
@@ -44,7 +44,7 @@ typedef
 BOOLEAN
 RequestSink_Cancel_Type(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 typedef
@@ -89,7 +89,7 @@ RequestSink_SendEx_Type(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 typedef
@@ -171,7 +171,7 @@ DMF_MODULE_DECLARE_CONFIG(DefaultTarget)
 BOOLEAN
 DefaultTarget_Stream_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -183,7 +183,7 @@ DefaultTarget_Stream_Cancel(
     DmfAssert(moduleContext->OpenedInStreamMode);
 
     returnValue = DMF_ContinuousRequestTarget_Cancel(moduleContext->DmfModuleContinuousRequestTarget,
-                                                     DmfRequest);
+                                                     DmfRequestId);
 
     return returnValue;
 }
@@ -260,7 +260,7 @@ DefaultTarget_Stream_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     DMF_CONTEXT_DefaultTarget* moduleContext;
@@ -279,7 +279,7 @@ DefaultTarget_Stream_SendEx(
                                               RequestTimeoutMilliseconds,
                                               EvtRequestSinkSingleAsynchronousRequest,
                                               SingleAsynchronousRequestClientContext,
-                                              DmfRequest);
+                                              DmfRequestId);
 }
 
 VOID
@@ -317,7 +317,7 @@ DefaultTarget_Stream_IoTargetClear(
 BOOLEAN
 DefaultTarget_Target_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -328,7 +328,7 @@ DefaultTarget_Target_Cancel(
     DmfAssert(! moduleContext->OpenedInStreamMode);
 
     returnValue = DMF_RequestTarget_Cancel(moduleContext->DmfModuleRequestTarget,
-                                           DmfRequest);
+                                           DmfRequestId);
 
     return returnValue;
 }
@@ -411,7 +411,7 @@ DefaultTarget_Target_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     DMF_CONTEXT_DefaultTarget* moduleContext;
@@ -430,7 +430,7 @@ DefaultTarget_Target_SendEx(
                                     RequestTimeoutMilliseconds,
                                     EvtRequestSinkSingleAsynchronousRequest,
                                     SingleAsynchronousRequestClientContext,
-                                    DmfRequest);
+                                    DmfRequestId);
 }
 
 VOID
@@ -1057,18 +1057,18 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DefaultTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 /*++
 
 Routine Description:
 
-    Cancels a given WDFREQUEST associated with DmfRequest.
+    Cancels a given WDFREQUEST associated with DmfRequestId.
 
 Arguments:
 
     DmfModule - This Module's handle.
-    DmfRequest - The given DmfRequest.
+    DmfRequestId - The given DmfRequestId.
 
 Return Value:
 
@@ -1096,7 +1096,7 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
     returnValue = moduleContext->RequestSink_Cancel(DmfModule,
-                                                    DmfRequest);
+                                                    DmfRequestId);
 
     DMF_ModuleDereference(DmfModule);
 
@@ -1252,7 +1252,7 @@ DMF_DefaultTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 /*++
 
@@ -1311,7 +1311,7 @@ Return Value:
                                                  RequestTimeoutMilliseconds,
                                                  EvtContinuousRequestTargetSingleAsynchronousRequest,
                                                  SingleAsynchronousRequestClientContext,
-                                                 DmfRequest);
+                                                 DmfRequestId);
 
     DMF_ModuleDereference(DmfModule);
 

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.h
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.h
@@ -50,7 +50,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DefaultTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -88,7 +88,7 @@ DMF_DefaultTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.md
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.md
@@ -87,11 +87,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DefaultTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 ````
 
-This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequestId.
 
 ##### Returns
 
@@ -102,10 +102,10 @@ FALSE if the underlying WDFREQUEST could not be canceled because it has been com
 Parameter | Description
 ----|----
 DmfModule | An open DMF_DefaultTarget Module handle.
-DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_DefaultTarget_SendEx()`.
+DmfRequestId | The unique request id returned by `DMF_DefaultTarget_SendEx()`.
 
 ##### Remarks
-* **Caller must use DMF_DefaultTarget_Cancel() to cancel the DmfRequest returned by `DMF_DefaultTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+* **Caller must use DMF_DefaultTarget_Cancel() to cancel the DmfRequestId returned by `DMF_DefaultTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
 
@@ -197,7 +197,7 @@ DMF_DefaultTarget_SendEx(
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
   _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
   );
 ````
 
@@ -220,15 +220,15 @@ RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purp
 RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
 EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
-DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
+DmfRequestId | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
 
 ##### Remarks
-* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+* Caller passes `DmfRequestId` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
 sent to the underlying WDFIOTARGET.
-* **Caller must use `DMF_DefaultTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+* **Caller must use `DMF_DefaultTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequestId. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
-* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_DefaultTarget_Cancel()`.** For example, do not assign a context to the handle.
+* **Caller must not use value returned in DmfRequestId for any purpose except to pass it `DMF_DefaultTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
@@ -101,7 +101,7 @@ BOOLEAN
 RequestSink_Cancel_Type(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_IoTarget* Target,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 typedef
@@ -149,7 +149,7 @@ RequestSink_SendEx_Type(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 typedef
@@ -584,7 +584,7 @@ BOOLEAN
 DeviceInterfaceMultipleTarget_Stream_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_IoTarget* Target,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -594,7 +594,7 @@ DeviceInterfaceMultipleTarget_Stream_Cancel(
 
     DmfAssert(moduleContext->ContinuousReaderMode);
     returnValue = DMF_ContinuousRequestTarget_Cancel(Target->DmfModuleRequestTarget,
-                                                     DmfRequest);
+                                                     DmfRequestId);
 
     return returnValue;
 }
@@ -674,7 +674,7 @@ DeviceInterfaceMultipleTarget_Stream_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     DMF_CONTEXT_DeviceInterfaceMultipleTarget* moduleContext;
@@ -692,7 +692,7 @@ DeviceInterfaceMultipleTarget_Stream_SendEx(
                                               RequestTimeoutMilliseconds,
                                               EvtRequestSinkSingleAsynchronousRequest,
                                               SingleAsynchronousRequestClientContext,
-                                              DmfRequest);
+                                              DmfRequestId);
 }
 
 VOID
@@ -733,7 +733,7 @@ BOOLEAN
 DeviceInterfaceMultipleTarget_Target_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_IoTarget* Target,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -744,7 +744,7 @@ DeviceInterfaceMultipleTarget_Target_Cancel(
     DmfAssert(! moduleContext->ContinuousReaderMode);
 
     returnValue = DMF_RequestTarget_Cancel(Target->DmfModuleRequestTarget,
-                                           DmfRequest);
+                                           DmfRequestId);
 
     return returnValue;
 }
@@ -830,7 +830,7 @@ DeviceInterfaceMultipleTarget_Target_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     NTSTATUS ntStatus;
@@ -849,7 +849,7 @@ DeviceInterfaceMultipleTarget_Target_SendEx(
                                         RequestTimeoutMilliseconds,
                                         EvtRequestSinkSingleAsynchronousRequest,
                                         SingleAsynchronousRequestClientContext,
-                                        DmfRequest);
+                                        DmfRequestId);
 
     return ntStatus;
 }
@@ -2817,19 +2817,19 @@ BOOLEAN
 DMF_DeviceInterfaceMultipleTarget_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_Target Target,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 /*++
 
 Routine Description:
 
-    Cancels a given WDFREQUEST associated with DmfRequest that has been sent to a given Target.
+    Cancels a given WDFREQUEST associated with DmfRequestId that has been sent to a given Target.
 
 Arguments:
 
     DmfModule - This Module's handle.
     Target - The given Target.
-    DmfRequest - The given DmfRequest.
+    DmfRequestId - The given DmfRequestId.
 
 Return Value:
 
@@ -2875,7 +2875,7 @@ Return Value:
     DmfAssert(target->IoTarget != NULL);
     returnValue = moduleContext->RequestSink_Cancel(DmfModule,
                                                     target,
-                                                    DmfRequest);
+                                                    DmfRequestId);
 
     DMF_Rundown_Dereference(target->DmfModuleRundown);
     DMF_ModuleDereference(DmfModule);
@@ -3125,7 +3125,7 @@ DMF_DeviceInterfaceMultipleTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 /*++
 
@@ -3199,7 +3199,7 @@ Return Value:
                                                  RequestTimeoutMilliseconds,
                                                  EvtContinuousRequestTargetSingleAsynchronousRequest,
                                                  SingleAsynchronousRequestClientContext,
-                                                 DmfRequest);
+                                                 DmfRequestId);
 
     DMF_Rundown_Dereference(target->DmfModuleRundown);
     DMF_ModuleDereference(DmfModule);

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.h
@@ -125,7 +125,7 @@ BOOLEAN
 DMF_DeviceInterfaceMultipleTarget_Cancel(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_Target Target,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -173,7 +173,7 @@ DMF_DeviceInterfaceMultipleTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.md
@@ -198,11 +198,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DeviceInterfaceMultipleTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 ````
 
-This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequestId.
 
 ##### Returns
 
@@ -213,10 +213,10 @@ FALSE if the underlying WDFREQUEST could not be canceled because it has been com
 Parameter | Description
 ----|----
 DmfModule | An open DMF_DeviceInterfaceMultipleTarget Module handle.
-DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_DeviceInterfaceMultipleTarget_SendEx()`.
+DmfRequestId | The unique request id returned by `DMF_DeviceInterfaceMultipleTarget_SendEx()`.
 
 ##### Remarks
-* **Caller must use DMF_DeviceInterfaceMultipleTarget_Cancel() to cancel the DmfRequest returned by `DMF_DeviceInterfaceMultipleTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+* **Caller must use DMF_DeviceInterfaceMultipleTarget_Cancel() to cancel the DmfRequestId returned by `DMF_DeviceInterfaceMultipleTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
 
@@ -346,7 +346,7 @@ DMF_DeviceInterfaceMultipleTarget_SendEx(
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
   _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
   );
 ````
 
@@ -370,15 +370,15 @@ RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purp
 RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
 EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
-DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
+DmfRequestId | Returns a unique id associated with the underlying WDFREQUEST. Client may use this id to cancel the asynchronous transaction.
 
 ##### Remarks
-* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+* Caller passes `DmfRequestId` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
 sent to the underlying WDFIOTARGET.
-* **Caller must use `DMF_DeviceInterfaceMultipleTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+* **Caller must use `DMF_DeviceInterfaceMultipleTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequestId. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
-* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_DeviceInterfaceMultipleTarget_Cancel()`.** For example, do not assign a context to the handle.
+* **Caller must not use value returned in DmfRequestId for any purpose except to pass it `DMF_DeviceInterfaceMultipleTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -44,7 +44,7 @@ typedef
 BOOLEAN
 RequestSink_Cancel_Type(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 typedef
@@ -89,7 +89,7 @@ RequestSink_SendEx_Type(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 typedef
@@ -413,7 +413,7 @@ Return Value:
 BOOLEAN
 DeviceInterfaceTarget_Stream_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -423,7 +423,7 @@ DeviceInterfaceTarget_Stream_Cancel(
 
     DmfAssert(moduleContext->ContinuousReaderMode);
     returnValue = DMF_ContinuousRequestTarget_Cancel(moduleContext->DmfModuleContinuousRequestTarget,
-                                                     DmfRequest);
+                                                     DmfRequestId);
 
     return returnValue;
 }
@@ -501,7 +501,7 @@ DeviceInterfaceTarget_Stream_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
@@ -520,7 +520,7 @@ DeviceInterfaceTarget_Stream_SendEx(
                                               RequestTimeoutMilliseconds,
                                               EvtRequestSinkSingleAsynchronousRequest,
                                               SingleAsynchronousRequestClientContext,
-                                              DmfRequest);
+                                              DmfRequestId);
 }
 
 VOID
@@ -558,7 +558,7 @@ DeviceInterfaceTarget_Stream_IoTargetClear(
 BOOLEAN
 DeviceInterfaceTarget_Target_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 {
     BOOLEAN returnValue;
@@ -569,7 +569,7 @@ DeviceInterfaceTarget_Target_Cancel(
     DmfAssert(! moduleContext->ContinuousReaderMode);
 
     returnValue = DMF_RequestTarget_Cancel(moduleContext->DmfModuleRequestTarget,
-                                           DmfRequest);
+                                           DmfRequestId);
 
     return returnValue;
 }
@@ -651,7 +651,7 @@ DeviceInterfaceTarget_Target_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 {
     DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
@@ -670,7 +670,7 @@ DeviceInterfaceTarget_Target_SendEx(
                                     RequestTimeoutMilliseconds,
                                     EvtRequestSinkSingleAsynchronousRequest,
                                     SingleAsynchronousRequestClientContext,
-                                    DmfRequest);
+                                    DmfRequestId);
 }
 
 VOID
@@ -2138,18 +2138,18 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DeviceInterfaceTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     )
 /*++
 
 Routine Description:
 
-    Cancels a given WDFREQUEST associated with DmfRequest.
+    Cancels a given WDFREQUEST associated with DmfRequestId.
 
 Arguments:
 
     DmfModule - This Module's handle.
-    DmfRequest - The given DmfRequest.
+    DmfRequestId - The given DmfRequestId.
 
 Return Value:
 
@@ -2177,7 +2177,7 @@ Return Value:
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
     returnValue = moduleContext->RequestSink_Cancel(DmfModule,
-                                                    DmfRequest);
+                                                    DmfRequestId);
 
     DMF_ModuleDereference(DmfModule);
 
@@ -2390,7 +2390,7 @@ DMF_DeviceInterfaceTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     )
 /*++
 
@@ -2450,7 +2450,7 @@ Return Value:
                                                  RequestTimeoutMilliseconds,
                                                  EvtContinuousRequestTargetSingleAsynchronousRequest,
                                                  SingleAsynchronousRequestClientContext,
-                                                 DmfRequest);
+                                                 DmfRequestId);
 
     DMF_ModuleDereference(DmfModule);
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -99,7 +99,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DeviceInterfaceTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -144,7 +144,7 @@ DMF_DeviceInterfaceTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -172,11 +172,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_DeviceInterfaceTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 ````
 
-This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequestId.
 
 ##### Returns
 
@@ -187,10 +187,10 @@ FALSE if the underlying WDFREQUEST could not be canceled because it has been com
 Parameter | Description
 ----|----
 DmfModule | An open DMF_DeviceInterfaceTarget Module handle.
-DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_DeviceInterfaceTarget_SendEx()`.
+DmfRequestId | The unique request id returned by `DMF_DeviceInterfaceTarget_SendEx()`.
 
 ##### Remarks
-* **Caller must use DMF_DeviceInterfaceTarget_Cancel() to cancel the DmfRequest returned by `DMF_DeviceInterfaceTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+* **Caller must use DMF_DeviceInterfaceTarget_Cancel() to cancel the DmfRequestId returned by `DMF_DeviceInterfaceTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
 
@@ -315,7 +315,7 @@ DMF_DeviceInterfaceTarget_SendEx(
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_opt_ EVT_DMF_ContinuousRequestTarget_SendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
   _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
   );
 ````
 
@@ -339,15 +339,15 @@ RequestIoctl | The IOCTL that tells the Module's underlying WDFIOTARGET the purp
 RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
 EvtContinuousRequestTargetSingleAsynchronousRequest | The Client callback that is called when this Module's underlying WDFIOTARGET completes the request.
 SingleAsynchronousRequestClientContext | The Client specific context that is sent to EvtContinuousRequestTargetSingleAsynchronousRequest.
-DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
+DmfRequestId | Returns a unique id associated with the underlying WDFREQUEST. Client may use this id to cancel the asynchronous transaction.
 
 ##### Remarks
-* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+* Caller passes `DmfRequestId` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
 sent to the underlying WDFIOTARGET.
-* **Caller must use `DMF_DeviceInterfaceTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+* **Caller must use `DMF_DeviceInterfaceTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequestId. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
-* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_DeviceInterfaceTarget_Cancel()`.** For example, do not assign a context to the handle.
+* **Caller must not use value returned in DmfRequestId for any purpose except to pass it `DMF_DeviceInterfaceTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_DeviceInterfaceTarget_SendSynchronously

--- a/Dmf/Modules.Library/Dmf_RequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.h
@@ -49,7 +49,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_RequestTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -93,7 +93,7 @@ DMF_RequestTarget_SendEx(
     _In_ ULONG RequestTimeoutMilliseconds,
     _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
     _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-    _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/Dmf/Modules.Library/Dmf_RequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_RequestTarget.md
@@ -98,11 +98,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 BOOLEAN
 DMF_RequestTarget_Cancel(
     _In_ DMFMODULE DmfModule,
-    _In_ RequestTarget_DmfRequest DmfRequest
+    _In_ RequestTarget_DmfRequest DmfRequestId
     );
 ````
 
-This Method cancels the underlying WDFREQUEST associated with a given DmfRequest.
+This Method cancels the underlying WDFREQUEST associated with a given DmfRequestId.
 
 ##### Returns
 
@@ -113,10 +113,10 @@ FALSE if the underlying WDFREQUEST could not be canceled because it has been com
 Parameter | Description
 ----|----
 DmfModule | An open DMF_RequestTarget Module handle.
-DmfRequest | A handle to a WDFREQUEST that is returned by `DMF_RequestTarget_SendEx()`.
+DmfRequestId | The unique request id returned by `DMF_RequestTarget_SendEx()`.
 
 ##### Remarks
-* **Caller must use DMF_RequestTarget_Cancel() to cancel the DmfRequest returned by `DMF_RequestTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
+* **Caller must use DMF_RequestTarget_Cancel() to cancel the DmfRequestId returned by `DMF_RequestTarget_SendEx()`. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
 
@@ -233,7 +233,7 @@ DMF_RequestTarget_SendEx(
   _In_ ULONG RequestTimeoutMilliseconds,
   _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestTargetSingleAsynchronousRequest,
   _In_opt_ VOID* SingleAsynchronousRequestClientContext,
-  _Out_opt_ RequestTarget_DmfRequest* DmfRequest
+  _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
   );
 ````
 
@@ -257,16 +257,16 @@ RequestIoctl | The IOCTL code to send to the underlying WDFIOTARGET.
 RequestTimeoutMilliseconds | A time in milliseconds that causes the call to timeout if it is not completed in that time period. Use zero for no timeout.
 EvtRequestTargetSingleAsynchronousRequest | The Client callback that is called when request completes.
 SingleAsynchronousRequestClientContext | A Client specific context that is sent to the Client callback that is called when the request completes.
-DmfRequest | Optional address of the handle to the handle to the WDFREQUEST that has been sent.
+DmfRequestId | Returns a unique id associated with the underlying WDFREQUEST. Client may use this id to cancel the asynchronous transaction.
 
 ##### Remarks
 
-* Caller passes `DmfRequest` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
+* Caller passes `DmfRequestId` when it is possible that the caller may want to cancel the WDFREQUEST that was created and
 sent to the underlying WDFIOTARGET.
-* **Caller must use `DMF_RequestTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequest. Caller may not use WdfRequestCancel() because 
+* **Caller must use `DMF_RequestTarget_Cancel()` to cancel the WDFREQUEST associated with DmfRequestId. Caller may not use WdfRequestCancel() because 
 the Module may asynchronously process, complete and delete the underlying WDFREQUEST at any time.**
 ** 
-* **Caller must not use value returned in DmfRequest for any purpose except to pass it `DMF_RequestTarget_Cancel()`.** For example, do not assign a context to the handle.
+* **Caller must not use value returned in DmfRequestId for any purpose except to pass it `DMF_RequestTarget_Cancel()`.** For example, do not assign a context to the handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_RequestTarget_SendSynchronously

--- a/DmfTest/DmfKTest/sys/Trace.h
+++ b/DmfTest/DmfKTest/sys/Trace.h
@@ -21,16 +21,12 @@ Environment:
 // Define the tracing flags.
 //
 // DmfKTest Tracing GUID - {61C379CE-3A6B-4E34-B8B1-BEF18A0F6209}
-// DMF Tracing GUID - {48F112EC-38AC-417B-935D-2250A46BDC89}
 //
 
 #define WPP_CONTROL_GUIDS                                                                                                               \
     WPP_DEFINE_CONTROL_GUID(                                                                                                            \
-        DmfTraceGuid, (48F112EC,38AC,417B,935D,2250A46BDC89),                                                                           \
-        WPP_DEFINE_BIT(DMF_TRACE)                                                                                                       \
-        )                                                                                                                               \
-    WPP_DEFINE_CONTROL_GUID(                                                                                                            \
         DmfKTestDriverTraceGuid, (61C379CE,3A6B,4E34,B8B1,BEF18A0F6209),                                                                \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                                                                       \
         WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                                                                               \
         WPP_DEFINE_BIT(TRACE_DRIVER)                                                                                                    \
         )                                                                                                                               \

--- a/DmfTest/DmfUTest/sys/trace.h
+++ b/DmfTest/DmfUTest/sys/trace.h
@@ -25,12 +25,9 @@ Environment:
 //
 
 #define WPP_CONTROL_GUIDS                                                               \
-   WPP_DEFINE_CONTROL_GUID(                                                             \
-        DmfTraceGuid, (E028F9D9,8BD5,494F,B288,CF1C049F4BD1),                           \
-        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
-        )                                                                               \
     WPP_DEFINE_CONTROL_GUID(                                                            \
         DmfUTestDriverTraceGuid, (EAF8F31E,30E1,499B,ABEB,8E6B051E1A75),                \
+        WPP_DEFINE_BIT(DMF_TRACE)                                                       \
         WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                                               \
         WPP_DEFINE_BIT(TRACE_DEVICE)                                                    \
         WPP_DEFINE_BIT(TRACE_CALLBACK)                                                  \


### PR DESCRIPTION
1. Fix race condition in cancel path of ..._Cancel() in DMF_RequestTarget and DMF_ContinuousRequestTarget.
2. Fix related issue when the WDFREQUEST handle values are reused.
3. Update documentation for the above two items.
4. Update Unit Test Modules to add more tests including tests that test more possible cancel paths.
5. Remove spurious logging from several Modules.
6. Update some compile time inclusion code to support further work.
7. Update trace GUIDs in Test Driver.