### PR TITLE
Merge20200423

### DIFF
--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -3124,6 +3124,7 @@ Return Value:
 
     return lockHeld;
 }
+#endif // defined(DEBUG)
 
 BOOLEAN
 DMF_ModuleLockIsPassive(
@@ -3134,7 +3135,6 @@ DMF_ModuleLockIsPassive(
 Routine Description:
 
     Indicates if the Module lock is a passive level lock.
-    NOTE: This function is for debug purposes only.
 
 Arguments:
 
@@ -3174,7 +3174,6 @@ DMF_IsPoolTypePassiveLevel(
 Routine Description:
 
     Indicates if the given pool type is passive level.
-    NOTE: This function is for debug purposes only.
 
 Arguments:
 
@@ -3199,7 +3198,7 @@ Return Value:
         case NonPagedPoolCacheAlignedSession:
         case NonPagedPoolCacheAlignedMustSSession:
 #if (!defined(_ARM_) && !defined(_ARM64_)) || (!defined(POOL_NX_OPTIN_AUTO))
-        // If POOL_NX_OPTIN_AUTO is defined, it means that NonPagedPoolNx = NonPagedPool.
+        // If POOL_NX_OPTION_AUTO is defined, it means that NonPagedPoolNx = NonPagedPool.
         // So, don't include this case as it is a duplicate. This is the case for ARM and ARM64.
         //
         // NOTE: The condition has the OR so that the check is compatible with EWDK that does
@@ -3223,7 +3222,6 @@ Return Value:
 
     return returnValue;
 }
-#endif // defined(DEBUG)
 
 VOID
 DMF_ModuleAuxiliaryLock(

--- a/Dmf/Framework/DmfModule.h
+++ b/Dmf/Framework/DmfModule.h
@@ -742,6 +742,7 @@ BOOLEAN
 DMF_ModuleIsLocked(
     _In_ DMFMODULE DmfModule
     );
+#endif // defined(DEBUG)
 
 BOOLEAN
 DMF_ModuleLockIsPassive(
@@ -752,7 +753,6 @@ BOOLEAN
 DMF_IsPoolTypePassiveLevel(
     _In_ POOL_TYPE PoolType
     );
-#endif // defined(DEBUG)
 
 VOID
 DMF_ModuleAuxiliaryLock(

--- a/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
+++ b/Dmf/Framework/Modules.Core/Dmf_BufferPool.c
@@ -1494,7 +1494,6 @@ Return Value:
         goto Exit;
     }
 
-#if defined(DEBUG)
     // If Client wants to use paged pool buffers, then Client must instantiate this Module at Passive Level (which this Module allows).
     // To do so, the DmfModuleAttributes->PassiveLevel must equal TRUE.
     //
@@ -1507,9 +1506,9 @@ Return Value:
     if ((moduleConfig->BufferPoolMode == BufferPool_Mode_Source) &&
         (DMF_IsPoolTypePassiveLevel(moduleConfig->Mode.SourceSettings.PoolType)))
     {
-        DmfAssert(DMF_ModuleLockIsPassive(*DmfModule));
+        DmfVerifierAssert("Invalid Pool/Lock combination",
+                          DMF_ModuleLockIsPassive(*DmfModule));
     }
-#endif
 
 Exit:
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -1765,6 +1765,145 @@ Return Value:
                             &moduleContext->DmfModuleAlertableSleepManualOutput[threadIndex]);
     }
 
+    // Test valid combinations of pool types.
+    //
+
+    // BufferPool=Paged
+    // DeviceInterfaceTarget=Paged
+    // Input
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferInputSize = sizeof(Tests_IoctlHandler_Sleep);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeInput = PagedPool;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_SLEEP;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = Tests_DeviceInterfaceTarget_BufferInput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.PassiveLevel = TRUE;
+    moduleAttributes.ClientModuleInstanceName = "Input/Paged/Paged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // BufferPool=NonPagedNx
+    // DeviceInterfaceTarget=Paged
+    // Input
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferInputSize = sizeof(Tests_IoctlHandler_Sleep);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeInput = NonPagedPoolNx;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_SLEEP;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = Tests_DeviceInterfaceTarget_BufferInput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.PassiveLevel = TRUE;
+    moduleAttributes.ClientModuleInstanceName = "Input/NonPaged/Paged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // BufferPool=NonPagedNx
+    // DeviceInterfaceTarget=NonPaged
+    // Input
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferInputSize = sizeof(Tests_IoctlHandler_Sleep);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeInput = NonPagedPoolNx;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_SLEEP;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = Tests_DeviceInterfaceTarget_BufferInput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.ClientModuleInstanceName = "Input/NonPaged/NonPaged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // BufferPool=Paged
+    // DeviceInterfaceTarget=Paged
+    // Output
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = PagedPool;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = Tests_DeviceInterfaceTarget_BufferOutput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.PassiveLevel = TRUE;
+    moduleAttributes.ClientModuleInstanceName = "Output/Paged/Paged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // BufferPool=NonPaged
+    // DeviceInterfaceTarget=Paged
+    // Output
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPool;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = Tests_DeviceInterfaceTarget_BufferOutput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.PassiveLevel = TRUE;
+    moduleAttributes.ClientModuleInstanceName = "Output/NonPaged/Paged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // BufferPool=NonPaged
+    // DeviceInterfaceTarget=NonPaged
+    // Output
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPool;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = Tests_DeviceInterfaceTarget_BufferOutput;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
+    moduleAttributes.ClientModuleInstanceName = "Output/NonPaged/NonPaged";
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
     FuncExitVoid(DMF_TRACE);
 }
 #pragma code_seg()

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.c
@@ -2127,7 +2127,14 @@ Return Value:
         moduleConfigBufferPoolInput.Mode.SourceSettings.BufferSize = moduleConfig->BufferInputSize;
         moduleConfigBufferPoolInput.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextInputSize;
         moduleAttributes.ClientModuleInstanceName = "BufferPoolInput";
-        moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
+        // Automatically select the proper lock/pool type based on parameters passed by Client.
+        //
+        if (DMF_IsPoolTypePassiveLevel(moduleConfigBufferPoolInput.Mode.SourceSettings.PoolType))
+        {
+            // Client pool type is passive so this Module must run using PASSIVE_LEVEL lock
+            //
+            moduleAttributes.PassiveLevel = TRUE;
+        }
         DMF_DmfModuleAdd(DmfModuleInit,
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,
@@ -2152,7 +2159,14 @@ Return Value:
         moduleConfigBufferPoolOutput.Mode.SourceSettings.BufferSize = moduleConfig->BufferOutputSize;
         moduleConfigBufferPoolOutput.Mode.SourceSettings.BufferContextSize = moduleConfig->BufferContextOutputSize;
         moduleAttributes.ClientModuleInstanceName = "BufferPoolOutput";
-        moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
+        // Automatically select the proper lock/pool type based on parameters passed by Client.
+        //
+        if (DMF_IsPoolTypePassiveLevel(moduleConfigBufferPoolOutput.Mode.SourceSettings.PoolType))
+        {
+            // Client pool type is passive so this Module must run using PASSIVE_LEVEL lock
+            //
+            moduleAttributes.PassiveLevel = TRUE;
+        }
         DMF_DmfModuleAdd(DmfModuleInit,
                          &moduleAttributes,
                          WDF_NO_OBJECT_ATTRIBUTES,

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
@@ -82,8 +82,8 @@ BufferContextInputSize | Size of each input DMF_BufferPool's buffer's context.
 BufferOutputSize | Size of each output DMF_BufferPool buffer.
 BufferContextOutputSize | Size of each output DMF_BufferPool's buffer's context.
 EnableLookAsideOutput | Indicates whether or not the underlying DMF_BufferPool’s are opened in Infinite Mode.
-PoolTypeInput | Type if memory for input buffers.
-PoolTypeOutput | Type of memory for output buffers.
+PoolTypeInput | Type of memory for input buffers. See remarks section below for more information.
+PoolTypeOutput | Type of memory for output buffers. See remarks section below for more information.
 EvtContinuousRequestTargetBufferInput | The callback that allows the Client to populate input buffers before they are sent to the underlying target.
 EvtContinuousRequestTargetBufferOutput | The callback that allows the Client to read data from output buffers that have been returned by the underlying target.
 ClientContext | Client specific context that is sent to the Client callback functions.
@@ -618,6 +618,9 @@ DmfModule | An open DMF_ContinuousRequestTarget Module handle.
 * This Module does all the work of allocating the buffers and Requests as specified by the Client.
 * This Module stops and start streaming automatically during power transition.
 * This Module is similar to the USB Continuous Reader in WDF but for any WDFIOTARGET.
+* Child BufferPool Module's locks are automatically set based on the PoolType chosen by the Client. That is, if the Client chooses a paged pool type, then the
+Child BufferPool Module is automatically created using PASSIVE_LEVEL locks, otherwise it is created using DISPATCH_LEVEL locks.'
+* Using non-paged pool type input/output buffers and PASSIVE_LEVEL locks for the Child Module is not supported at this time, but may be later if needed.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -639,6 +642,8 @@ DmfModule | An open DMF_ContinuousRequestTarget Module handle.
 -----------------------------------------------------------------------------------------------------------------------------------
 
 #### To Do
+
+* Support non-paged pool type input/output buffers and PASSIVE_LEVEL locks for BufferPool.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 #### Module Category


### PR DESCRIPTION
1. Instantiate Child DMF_BufferPool Module as DISPATCH_LEVEL by default in DMF_ContinuousRequestTarget even if the Parent is instantiated as PASSIVE_LEVEL so that its Methods can be called at DISPATCH_LEVEL.
2. Convert the verification check in DMF_BufferPool which was only in DEBUG build to a check done always using Verifier.
3. Update documentation to explain the above change.
(Previously, the mode of the Child BufferPool was the same as its Parent, ContinuousRequestTarget.)