### PR TITLE
Merge20200515

### DIFF
--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
@@ -37,7 +37,11 @@ Environment:
 #define BUFFER_SIZE                 (32)
 // Number of preallocated buffers in Source
 //
+#if defined(DMF_KERNEL_MODE)
 #define BUFFER_COUNT_PREALLOCATED   (16)
+#else
+#define BUFFER_COUNT_PREALLOCATED   (64)
+#endif
 // Max number of buffers we get from Source, preallocated + dynamic
 //
 #define BUFFER_COUNT_MAX            (24)

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -32,6 +32,12 @@ Environment:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
+#include <initguid.h>
+
+// {5F4F3758-D11E-4684-B5AD-FE6D19D82A51}
+//
+DEFINE_GUID(GUID_NO_DEVICE, 0x5f4f3758, 0xd11e, 0x4684, 0xb5, 0xad, 0xfe, 0x6d, 0x19, 0xd8, 0x2a, 0x51);
+
 #define THREAD_COUNT                            (1)
 #define MAXIMUM_SLEEP_TIME_MS                   (15000)
 // Keep synchronous maximum time short to make driver disable faster.
@@ -46,6 +52,8 @@ Environment:
 #define TIMEOUT_FAST_MS             100
 #define TIMEOUT_SLOW_MS             5000
 #define TIMEOUT_TRAFFIC_DELAY_MS    250
+
+#define NUMBER_OF_CONTINUOUS_REQUESTS   32
 
 typedef enum _TEST_ACTION
 {
@@ -384,6 +392,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
     {
         goto Exit;
     }
+
 Exit:
     ;
 }
@@ -1677,9 +1686,9 @@ Return Value:
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPoolNx;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
@@ -1843,9 +1852,9 @@ Return Value:
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = PagedPool;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
@@ -1866,9 +1875,9 @@ Return Value:
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPool;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
@@ -1889,9 +1898,9 @@ Return Value:
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_Tests_IoctlHandler;
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
-    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 32;
+    moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPool;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
@@ -1909,6 +1918,21 @@ Return Value:
     DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
                                                          &moduleAttributes);
     moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_DEVINTERFACE_DISK;
+    moduleConfigDeviceInterfaceTarget.OpenMode = GENERIC_READ;
+    moduleConfigDeviceInterfaceTarget.ShareAccess = FILE_SHARE_READ;
+ 
+    // NOTE: No Module handle is needed since no Methods are called.
+    //
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     NULL);
+
+    // This instance tests for no device attached ever.
+    //
+    DMF_CONFIG_DeviceInterfaceTarget_AND_ATTRIBUTES_INIT(&moduleConfigDeviceInterfaceTarget,
+                                                         &moduleAttributes);
+    moduleConfigDeviceInterfaceTarget.DeviceInterfaceTargetGuid = GUID_NO_DEVICE;
     moduleConfigDeviceInterfaceTarget.OpenMode = GENERIC_READ;
     moduleConfigDeviceInterfaceTarget.ShareAccess = FILE_SHARE_READ;
  

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Registry.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Registry.c
@@ -2007,7 +2007,6 @@ Return Value:
     ntStatus = DMF_AlertableSleep_Sleep(moduleContext->DmfModuleAlertableSleep,
                                         0,
                                         5000);
-    DmfAssert(STATUS_SUCCESS == ntStatus);
 
     DMF_AlertableSleep_ResetForReuse(moduleContext->DmfModuleAlertableSleep,
                                      0);

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
@@ -1350,6 +1350,10 @@ Return Value:
 
     target->IoTarget = IoTarget;
 
+    // Clear this flag in case it was set during QueryRemove.
+    //
+    target->QueryRemoveHappened = FALSE;
+
     WDF_IO_TARGET_OPEN_PARAMS_INIT_REOPEN(&openParams);
 
     ntStatus = WdfIoTargetOpen(IoTarget,

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_DeviceInterfaceTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_ContinuousRequestTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_RequestTarget.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_Rundown.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_ScheduledTask.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_SimpleOrientation.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_SmbiosWmi.h" />
@@ -215,6 +216,7 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_ContinuousRequestTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_Registry.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_RequestTarget.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_Rundown.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_ScheduledTask.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_SimpleOrientation.cpp" />
     <ClCompile Include="..\..\Modules.Library\Dmf_SmbiosWmi.c" />
@@ -248,6 +250,7 @@
     <None Include="..\..\Modules.Library\Dmf_PingPongBuffer.md" />
     <None Include="..\..\Modules.Library\Dmf_QueuedWorkItem.md" />
     <None Include="..\..\Modules.Library\Dmf_Registry.md" />
+    <None Include="..\..\Modules.Library\Dmf_Rundown.md" />
     <None Include="..\..\Modules.Library\Dmf_ScheduledTask.md" />
     <None Include="..\..\Modules.Library\Dmf_SimpleOrientation.md" />
     <None Include="..\..\Modules.Library\Dmf_SmbiosWmi.md" />

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
@@ -195,6 +195,9 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_MobileBroadband.h">
       <Filter>Headers\Modules\Network</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_Rundown.h">
+      <Filter>Headers\Modules\Driver Patterns</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Modules.Library\Dmf_CmApi.c">
@@ -277,6 +280,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Modules.Library\Dmf_MobileBroadband.cpp">
       <Filter>Modules\Network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_Rundown.c">
+      <Filter>Modules\Driver Patterns</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -362,6 +368,9 @@
     </None>
     <None Include="..\..\Modules.Library\Dmf_MobileBroadband.md">
       <Filter>Documentation\Modules\Network</Filter>
+    </None>
+    <None Include="..\..\Modules.Library\Dmf_Rundown.md">
+      <Filter>Documentation\Modules\Driver Patterns</Filter>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1. Correct synchronization issues in QueryRemove/RemoveCancel/RemoveComplete path in DMF_DeviceInterfaceTarget.
2. Properly clear a the QueryRemoveHappened flag in DMF_DeviceInterfaceMulitpleTarget.
3. Correct issue in DMF_ContinuousRequestTarget and DMF_RequestTarget where request id was improperly read from the request context after the request was sent. Applicable only to SendEx() API. 
4. Correct bug in DMF_Tests_IoctlHandler (unit test code) related to request cancellation (verifier issue). (Test code bug.)
5. Add missing DMF_Rundown to User-mode Library. (New feature.)
6. Correct two issues in unit test code in DMF_Tests_Registry and DMF_Tests_BufferQueue. (Test code bug.)
7. Update units test code in DMF_Test_DeviceInterfaceTarget to add case for non-attached IoTarget. (New test code.)