### PR TITLE
Merge20201029

### DIFF
--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -680,7 +680,6 @@ Return Value:
         goto Exit;
     }
 
-
 Exit:
 
     return ntStatus;
@@ -1498,6 +1497,10 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoInit != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoInit)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
 Exit:
 
@@ -1538,6 +1541,10 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoSuspend != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoSuspend)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     // Dispatch callback to Child DMF Modules next.
     //
@@ -1597,6 +1604,10 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoRestart != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleSelfManagedIoRestart)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
 Exit:
 
@@ -1678,13 +1689,17 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleQueryRemove != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleQueryRemove)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     // Dispatch callback to Child DMF Modules next.
     //
     ntStatus = DMF_ChildDispatchSingleParameterNtStatus(DmfModule,
                                                         DMF_Module_QueryRemove,
                                                         &DmfChildObjectIterateBackward);
-    if (!NT_SUCCESS(ntStatus))
+    if (! NT_SUCCESS(ntStatus))
     {
         goto Exit;
     }
@@ -1728,13 +1743,17 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleQueryStop != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleQueryStop)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     // Dispatch callback to Child DMF Modules next.
     //
     ntStatus = DMF_ChildDispatchSingleParameterNtStatus(DmfModule,
                                                         DMF_Module_QueryStop,
                                                         &DmfChildObjectIterateBackward);
-    if (!NT_SUCCESS(ntStatus))
+    if (! NT_SUCCESS(ntStatus))
     {
         goto Exit;
     }
@@ -1900,6 +1919,10 @@ Return Value:
     //
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleArmWakeFromS0 != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleArmWakeFromS0)(DmfModule);
+    if (! NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     // Dispatch callback to Child DMF Modules next.
     //
@@ -2040,7 +2063,7 @@ Return Value:
     ntStatus = (parentDmfObject->ModuleDescriptor.CallbacksWdf->ModuleArmWakeFromSxWithReason)(DmfModule,
                                                                                                DeviceWakeEnabled,
                                                                                                ChildrenArmedForWake);
-    if (!NT_SUCCESS(ntStatus))
+    if (! NT_SUCCESS(ntStatus))
     {
         goto Exit;
     }
@@ -3448,7 +3471,7 @@ Return Value:
     ntStatus = (parentDmfObject->InternalCallbacksDmf.DeviceResourcesAssign)(DmfModule,
                                                                              ResourcesRaw,
                                                                              ResourcesTranslated);
-    if (!NT_SUCCESS(ntStatus))
+    if (! NT_SUCCESS(ntStatus))
     {
         goto Exit;
     }

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -76,6 +76,12 @@ typedef struct
     // Callback to notify Interface arrival.
     //
     EVT_DMF_DeviceInterfaceTarget_OnPnpNotification* EvtDeviceInterfaceTargetOnPnpNotification;
+    // To maintain compatability with existing drivers, this option tells the 
+    // Module to perform non-standard behavior: When target disables the device interface
+    // close the associated open handle. (WDF does not do this by default.) New drivers 
+    // should not use this option.
+    //
+    BOOLEAN CloseUnderlyingTargetOnDeviceInterfaceDisable;
 } DMF_CONFIG_DeviceInterfaceTarget;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -37,6 +37,12 @@ typedef struct
   // Callback to notify Interface arrival.
   //
   EVT_DMF_DeviceInterfaceTarget_OnPnpNotification* EvtDeviceInterfaceTargetOnPnpNotification;
+  // To maintain compatability with existing drivers, this option tells the 
+  // Module to perform non-standard behavior: When target disables the device interface
+  // close the associated open handle. (WDF does not do this by default.) New drivers 
+  // should not use this option.
+  //
+  BOOLEAN CloseUnderlyingTargetOnDeviceInterfaceDisable;
 } DMF_CONFIG_DeviceInterfaceTarget;
 ````
 Member | Description
@@ -47,6 +53,7 @@ ShareAccess | The Share Access mask used when opening the underlying WDFIOTARGET
 ContinuousRequestTargetModuleConfig | Contains the settings for the underlying RequesetStream.
 EvtDeviceInterfaceTargetOnStateChange | Callback to the Client that indicates the state of the target has changed.
 EvtDeviceInterfaceTargetOnPnpNotification | Callback to the Client that allows the Client to indicate if the target should open.
+CloseUnderlyingTargetOnDeviceInterfaceDisable | *This option should not be used by new drivers.* Setting this flag causes the PreClose() callback to be called everytime the underlying device interface is disabled. WDF does not close open handles when a device interface is disabled. However some legacy drivers close the open handles when the associated remove notification is sent. This option is added to simplyfy porting of such drivers.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_HidTarget.c
+++ b/Dmf/Modules.Library/Dmf_HidTarget.c
@@ -3150,6 +3150,54 @@ Return Value:
     UNREFERENCED_PARAMETER(DmfInterface);
 }
 
+_Function_class_(DMF_ModuleQueryRemove)
+_IRQL_requires_same_
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+NTSTATUS
+DMF_HidTarget_ModuleQueryRemove(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Callback for Module's Query Remove.
+    If the Module is configured to be working in-stack, returns failure, else returns success.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    NTSTATUS.
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONFIG_HidTarget* moduleConfig;
+
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+
+    // If the driver is loaded on the Hidstack, returning failure here prevents HidClass from handling the QueryRemove. 
+    // During QueryRemove Hidclass cancels all input report reads from Client drivers prematurely, thus breaking the input report handling path.
+    // Return failure for in-stack use. (SkipHidDeviceEnumerationSearch means in-stack).
+    //
+    if (moduleConfig->SkipHidDeviceEnumerationSearch)
+    {
+        ntStatus = STATUS_UNSUCCESSFUL;
+    }
+    else
+    {
+        ntStatus = STATUS_SUCCESS;
+    }
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_HidTarget_ModuleQueryRemove returns ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Public Calls by Client
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3187,6 +3235,7 @@ Return Value:
     NTSTATUS ntStatus;
     DMF_MODULE_DESCRIPTOR dmfModuleDescriptor_Hid;
     DMF_CALLBACKS_DMF dmfCallbacksDmf_HidTarget;
+    DMF_CALLBACKS_WDF dmfCallbacksWdf_HidTarget;
     DMF_INTERFACE_TRANSPORT_BusTarget_DECLARATION_DATA BusTargetDeclarationData;
 
     PAGED_CODE();
@@ -3198,6 +3247,9 @@ Return Value:
     dmfCallbacksDmf_HidTarget.DeviceNotificationRegister = DMF_HidTarget_NotificationRegister;
     dmfCallbacksDmf_HidTarget.DeviceNotificationUnregister = DMF_HidTarget_NotificationUnregister;
 
+    DMF_CALLBACKS_WDF_INIT(&dmfCallbacksWdf_HidTarget);
+    dmfCallbacksWdf_HidTarget.ModuleQueryRemove = DMF_HidTarget_ModuleQueryRemove;
+
     DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_Hid,
                                             HidTarget,
                                             DMF_CONTEXT_HidTarget,
@@ -3205,6 +3257,7 @@ Return Value:
                                             DMF_MODULE_OPEN_OPTION_NOTIFY_PrepareHardware);
 
     dmfModuleDescriptor_Hid.CallbacksDmf = &dmfCallbacksDmf_HidTarget;
+    dmfModuleDescriptor_Hid.CallbacksWdf = &dmfCallbacksWdf_HidTarget;
 
     ntStatus = DMF_ModuleCreate(Device,
                                 DmfModuleAttributes,


### PR DESCRIPTION
Merge20201029:
0. Add option to allow Client of DMF_DeviceInterfaceTarget to receive PreClose()/PostOpen() callbacks to ease porting of existing code. (This option should not be used by new code.)
1. Correct BSOD when a duplicate "QueryRemove" message appears.
2. Correct issue where NTSTATUS from Client is lost in a couple of callbacks.
3. Correct issue in HidTarget related to instack removal path.