### PR TITLE
Merge20210118

### DIFF
--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -441,6 +441,19 @@ Return Value:
         goto Exit;
     }
 
+    // Create a spin lock to protect the Module's reference count.
+    // (Reference count must be accessible from both PASSIVE_LEVEL and DISPATCH_LEVEL
+    // code so the Module's synchronization locks cannot be used because they can 
+    // be either waitlocks or spinlocks.)
+    //
+    ntStatus = WdfSpinLockCreate(&attributes,
+                                 &DmfObject->ReferenceCountLock);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "ReferenceCountLock create fails.");
+        goto Exit;
+    }
+
 Exit:
 
     return ntStatus;

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -159,6 +159,9 @@ struct _DMF_OBJECT_
     // Reference counter for DMF Object references.
     //
     volatile LONG ReferenceCount;
+    // Spin Lock to protect Module's reference count.
+    //
+    WDFSPINLOCK ReferenceCountLock;
     // Associated WDF Device.
     //
     WDFDEVICE ParentDevice;


### PR DESCRIPTION
Fix issue with framework using Module's lock to synchronize internal ReferenceCount.

Module's can be instantiated using either PASSIVE or DISPATCH level settings. However, the framework was using the Module's locks for synchronizing the ReferenceCount. This does not work in cases where a Module instantiated as PASSIVE  has Methods called from DISPATCH level that access the ReferenceCount.

The Module's reference count needs its own private lock which is a spinlock so it can be accessed from both PASSVIVE and DISPATCH levels.

DMF_ModuleReference() may be called from either PASSIVE or DISPATCH levels. This fix allows for that.
