### PR TITLE
Fixed spelling in I/O queue hook example snippet

### DIFF
--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -966,7 +966,7 @@ callbacks.]
 There is one more set of important callbacks that must be hooked: The
 **WDFQUEUE** callbacks for the default queue:
 ```
-WDF_IO_QUEUE_Config_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
+WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
 queueConfig.PowerManaged = WdfTrue;
 queueConfig.EvtIoDeviceControl = DmfSampleEvtIoDeviceControl;
 queueConfig.EvtIoInternalDeviceControl = DmfSampleEvtIoDeviceControl;


### PR DESCRIPTION
Changed nonexistent case-sensitive `WDF_IO_QUEUE_Config_INIT_DEFAULT_QUEUE` to `WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE` in the sample snippet of the documentation.