### PR TITLE
Merge20210421

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.84
+// DMF Release: v1.1.85
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Framework/Modules.Core/Dmf_LiveKernelDump.h
+++ b/Dmf/Framework/Modules.Core/Dmf_LiveKernelDump.h
@@ -61,6 +61,9 @@ typedef struct
     // Guid used to locate the secondary data associated with the minidumps generated from this driver.
     //
     GUID GuidSecondaryData;
+    // When TRUE, the DMF Data tracked by LiveKernelDump module will be marked as Triage Dump Data
+    // which is included in Kernel Triage Dumps if a Bug Check occurs.
+    BOOLEAN IncludeDmfDataInBugCheckTriageDump;
 } DMF_CONFIG_LiveKernelDump;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -1890,14 +1890,14 @@ Return Value:
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Automatic;
 #endif
-    moduleEventCallbacks.EvtModuleOnDeviceNotificationPostOpen = Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_DispatchInput;
-    moduleEventCallbacks.EvtModuleOnDeviceNotificationPreClose = Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_DispatchInput;
     DMF_MODULE_ATTRIBUTES_EVENT_CALLBACKS_INIT(&moduleAttributes,
                                                &moduleEventCallbacks);
+    moduleEventCallbacks.EvtModuleOnDeviceNotificationPostOpen = Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_DispatchInput;
+    moduleEventCallbacks.EvtModuleOnDeviceNotificationPreClose = Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_DispatchInput;
     DMF_DmfModuleAdd(DmfModuleInit,
-                        &moduleAttributes,
-                        WDF_NO_OBJECT_ATTRIBUTES,
-                        &moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput);
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleDeviceInterfaceTargetDispatchInput);
 
     // DeviceInterfaceTarget (PASSIVE_LEVEL)
     // Processes Input Buffers.
@@ -1916,6 +1916,8 @@ Return Value:
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Manual;
 #endif
+    DMF_MODULE_ATTRIBUTES_EVENT_CALLBACKS_INIT(&moduleAttributes,
+                                               &moduleEventCallbacks);
     moduleEventCallbacks.EvtModuleOnDeviceNotificationPostOpen = Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_PassiveInput;
     moduleEventCallbacks.EvtModuleOnDeviceNotificationPreClose = Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_PassiveInput;
     moduleAttributes.PassiveLevel = TRUE;
@@ -1943,6 +1945,8 @@ Return Value:
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;
     moduleConfigDeviceInterfaceTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetMode = ContinuousRequestTarget_Mode_Manual;
 
+    DMF_MODULE_ATTRIBUTES_EVENT_CALLBACKS_INIT(&moduleAttributes,
+                                               &moduleEventCallbacks);
     moduleAttributes.PassiveLevel = TRUE;
     moduleEventCallbacks.EvtModuleOnDeviceNotificationPostOpen = Tests_DeviceInterfaceTarget_OnDeviceArrivalNotification_PassiveOutput;
     moduleEventCallbacks.EvtModuleOnDeviceNotificationPreClose = Tests_DeviceInterfaceTarget_OnDeviceRemovalNotification_PassiveOutput;

--- a/Dmf/Modules.Library/Dmf_CrashDump.h
+++ b/Dmf/Modules.Library/Dmf_CrashDump.h
@@ -33,11 +33,11 @@ Environment:
 #define RINGBUFFER_INDEX_CLIENT_FIRST     (RINGBUFFER_INDEX_SELF + 1)
 
 // Callback function for client driver to inform OS how much space Client Driver needs 
-// to write its data.
+// to write its data.  This is called during BugCheck at IRQL = HIGH_LEVEL so must 
+// be nonpaged and has restrictions on what it may do.
 //
 typedef
 _Function_class_(EVT_DMF_CrashDump_Query)
-_IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 EVT_DMF_CrashDump_Query(_In_ DMFMODULE DmfModule,
@@ -46,24 +46,47 @@ EVT_DMF_CrashDump_Query(_In_ DMFMODULE DmfModule,
 
 // Callback function for client driver to write its own data after the system is crashed.
 // Note that this callback is only applicable to the RINGBUFFER_INDEX_SELF instance. Other instances
-// are used by User-mode and cannot use this callback.
+// are used by User-mode and cannot use this callback. This is called during BugCheck 
+// at IRQL = HIGH_LEVEL so must be nonpaged and has restrictions on what it may do.
 //
 typedef
 _Function_class_(EVT_DMF_CrashDump_Write)
-_IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 EVT_DMF_CrashDump_Write(_In_ DMFMODULE DmfModule,
                         _Out_ VOID** OutputBuffer,
                         _In_ ULONG* OutputBufferLength);
 
-// Client uses this structure to configure the Module specific parameters.
+// Callback for marking memory regions which should be included in the kernel minidump.
+// This is called during BugCheck at IRQL = HIGH_LEVEL so must be nonpaged and
+// has restrictions on what it may do.  The bugcheck code and parameters
+// are provided so the callback may choose to only add data when certain Bug Checks occur.
 //
+typedef
+_Function_class_(EVT_DMF_CrashDump_StoreTriageDumpData)
+_IRQL_requires_same_
+VOID
+EVT_DMF_CrashDump_StoreTriageDumpData(_In_ DMFMODULE DmfModule,
+                                      _In_ ULONG BugCheckCode,
+                                      _In_ ULONG_PTR BugCheckParameter1,
+                                      _In_ ULONG_PTR BugCheckParameter2,
+                                      _In_ ULONG_PTR BugCheckParameter3,
+                                      _In_ ULONG_PTR BugCheckParameter4);
+
 typedef struct
 {
-    // The identifier of this component. It will be in the Bug Check data.
+    // Number of triage dump data entries to allocate. This must be
+    // set before using DMF_CrashDumpDataAdd.
+    ULONG TriageDumpDataArraySize;
+    // Callback for adding triage dump ranges during BugCheck processing.
+    // This is optional, even if passing a TriageDumpDataArraySize since
+    // buffers can be added prior to a BugCheck occurring.
     //
-    UCHAR* ComponentName;
+    EVT_DMF_CrashDump_StoreTriageDumpData* EvtCrashDumpStoreTriageDumpData;
+} CrashDump_TriageDumpData;
+
+typedef struct
+{
     // GUID for this driver's Ring Buffer data.
     //
     GUID RingBufferDataGuid;
@@ -88,6 +111,21 @@ typedef struct
     // Number of Data Sources for other clients.
     //
     ULONG DataSourceCount;
+} CrashDump_SecondaryData;
+
+// Client uses this structure to configure the Module specific parameters.
+//
+typedef struct
+{
+    // The identifier of this component. It will be in the Bug Check data.
+    //
+    UCHAR* ComponentName;
+    // Secondary (Blob) data callback configuration.
+    //
+    CrashDump_SecondaryData SecondaryData;
+    // TriageDumpData callback configuration.
+    //
+    CrashDump_TriageDumpData TriageDumpData;
 } DMF_CONFIG_CrashDump;
 
 // This macro declares the following functions:
@@ -107,6 +145,22 @@ DMF_CrashDump_DataSourceWriteSelf(
     _In_ UCHAR* Buffer,
     _In_ ULONG BufferLength
     );
+
+#if !defined(DMF_USER_MODE)
+
+#if IS_WIN10_19H1_OR_LATER
+
+_IRQL_requires_same_
+NTSTATUS
+DMF_CrashDump_TriageDumpDataAdd(
+    _In_ DMFMODULE DmfModule,
+    _In_ UCHAR* Data,
+    _In_ ULONG DataLength
+    );
+
+#endif // IS_WIN10_19H1_OR_LATER
+
+#endif // defined(DMF_USER_MODE)
 
 // eof: Dmf_CrashDump.h
 //

--- a/DmfSamples/NonPnp1/sys/README.md
+++ b/DmfSamples/NonPnp1/sys/README.md
@@ -4,8 +4,10 @@ This sample shows how to write a Non-PnP driver (Control driver) using DMF. Non-
 After loading the driver, the application communicates with the driver to perform actions in Kernel-mode. Afterward, the application
 unloads the driver. (This sample also contains such an application, although it is not explained in detail as the driver is.)
 
+This sample also shows how to use DMF_CrashDump. It shows how to write both to the Secondary dump as well as the Triage Dump.
+
 Non-PnP drivers usually expose a symbolic link and an IOCTL interface. Thus, this sample driver instantiates a Module that exposes
-a symbolic link and an IOCTL interface. The driver itself simply instantiates the Module. When the application communciates with the
+a symbolic link and an IOCTL interface. The driver itself simply instantiates the Module. When the application communicates with the
 driver, the requests are handled directly by the Module.
 
 *Note: DMF Modules are agnostic about type of the Client Driver that instantiates them. Therefore, the important part of this


### PR DESCRIPTION
1. Add support for new Triage Data Dumps.  (Dmf_LiveKernelDump and Dmf_CrashDump). Also, fix a bug in Dmf_CrashDump that caused BSOD if two instances are created.
2. Correct bug in Dmf_Tests_DeviceInterfaceTarget.
3. Remove Remove Cancel path from Dmf_HidTarget since there is a bug in stack . We will revisit this later and possibly add back as an option.