### PR TITLE
Merge20210505

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.86
+// DMF Release: v1.1.87
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -1116,7 +1116,6 @@ Return Value:
     FuncEntry(DMF_TRACE);
 
     // For SAL.
-    // (To be honest, I think it should have been _InOut_.
     //
     if (DmfModule != NULL)
     {
@@ -1453,6 +1452,17 @@ Exit:
             // Remember it is Dynamic Module so it can be automatically closed prior to destruction.
             //
             dmfObject->DynamicModuleImmediate = TRUE;
+
+            // Since it is a Dynamic Module, Open or register for Notification as specified by the Module's
+            // Open Option.
+            //
+            ntStatus = DMF_Module_OpenOrRegisterNotificationOnCreate(dmfModule);
+            if (!NT_SUCCESS(ntStatus))
+            {
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleCollectionPostCreate fails: ntStatus=%!STATUS!", ntStatus);
+                goto Exit;
+            }
+
             // Give Client the resultant Module Handle:
             // PostOpen callback may need to compare contents of the address of the Module it
             // passed with the Module handle passed in the callback. So, set this now before 
@@ -1462,15 +1472,6 @@ Exit:
             if (DmfModule != NULL)
             {
                 *DmfModule = dmfModule;
-            }
-            // Since it is a Dynamic Module, Open or register for Notification as specified by the Module's
-            // Open Option.
-            //
-            ntStatus = DMF_Module_OpenOrRegisterNotificationOnCreate(dmfModule);
-            if (!NT_SUCCESS(ntStatus))
-            {
-                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleCollectionPostCreate fails: ntStatus=%!STATUS!", ntStatus);
-                goto Exit;
             }
         }
         else

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -180,10 +180,13 @@ Tests_DeviceInterfaceTarget_BufferOutput(
     )
 {
     GUID guid;
+    ContinuousRequestTarget_BufferDisposition bufferDisposition;
 
     UNREFERENCED_PARAMETER(ClientBufferContextOutput);
     UNREFERENCED_PARAMETER(DmfModule);
     UNREFERENCED_PARAMETER(CompletionStatus);
+
+    bufferDisposition = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndContinueStreaming;
 
     DMF_DeviceInterfaceTarget_GuidGet(DmfModule,
                                       &guid);
@@ -191,8 +194,11 @@ Tests_DeviceInterfaceTarget_BufferOutput(
     DmfAssert(NT_SUCCESS(CompletionStatus) ||
               (CompletionStatus == STATUS_CANCELLED) ||
               (CompletionStatus == STATUS_INVALID_DEVICE_STATE));
-    if (OutputBufferSize != sizeof(DWORD))
+    if (OutputBufferSize != sizeof(DWORD) &&
+        CompletionStatus != STATUS_INVALID_DEVICE_STATE)
     {
+        // Request can be completed with InformationSize of 0 by framework.
+        //
         DmfAssert(FALSE);
     }
     if (NT_SUCCESS(CompletionStatus))
@@ -202,7 +208,17 @@ Tests_DeviceInterfaceTarget_BufferOutput(
             DmfAssert(FALSE);
         }
     }
-    return ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndContinueStreaming;
+
+    // If IoTarget is closing but streaming has not been stopped, ContinuousRequestTarget will continue to send the request
+    // back to the closing IoTarget if we don't stop streaming here.
+    //
+    if (! NT_SUCCESS(CompletionStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Completed Request CompletionStatus=%!STATUS!", CompletionStatus);
+        bufferDisposition = ContinuousRequestTarget_BufferDisposition_ContinuousRequestTargetAndStopStreaming;
+    }
+
+    return bufferDisposition;
 }
 
 #pragma code_seg("PAGE")
@@ -308,9 +324,10 @@ Tests_DeviceInterfaceTarget_SendCompletion(
     moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceTarget*)ClientRequestContext;
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DI: RECEIVE sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p", 
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DI: RECEIVE sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p CompletionStatus=%!STATUS!", 
                 sleepIoctlBuffer->TimeToSleepMilliseconds,
-                InputBuffer);
+                InputBuffer,
+                CompletionStatus);
 
     DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
                        (VOID*)sleepIoctlBuffer);

--- a/Dmf/Modules.Library/Dmf_BufferPool.c
+++ b/Dmf/Modules.Library/Dmf_BufferPool.c
@@ -1570,10 +1570,6 @@ Return Value:
 
     bufferPoolEntry = BufferPool_BufferPoolEntryGetFromClientBuffer(ClientBuffer);
 
-    // For consistency, the Module from which the pool was created must be passed in.
-    //
-    DmfAssert(bufferPoolEntry->CreatedByDmfModule == DmfModule);
-
     DmfAssert(bufferPoolEntry->ClientBufferContext == (UCHAR*)(bufferPoolEntry->SentinelData) + BufferPool_SentinelSize);
 
     DmfAssert(ClientBufferContext != NULL);

--- a/Dmf/Modules.Library/Dmf_BufferQueue.h
+++ b/Dmf/Modules.Library/Dmf_BufferQueue.h
@@ -20,16 +20,30 @@ Environment:
 
 #pragma once
 
+// Callback called by DMF_BufferQueue_Reuse so Client
+// can finalize buffers before being sent back to Producer.
+//
+typedef
+_Function_class_(EVT_DMF_BufferQueue_ReuseCleanup)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_BufferQueue_ReuseCleanup(_In_ DMFMODULE DmfModule,
+                                 _In_ VOID* ClientBuffer,
+                                 _In_ VOID* ClientBufferContext);
+
 // Client uses this structure to configure the Module specific parameters.
 //
 typedef struct
 {
     // BufferQueue has a source and sink list.
     // Source is configured by Client using these settings. 
+    // Sink is configured internally.
     //
     BufferPool_SourceSettings SourceSettings;
-    // Sink is configured internally. 
+    // Optional callback for Client to finalize buffer before reuse.
     //
+    EVT_DMF_BufferQueue_ReuseCleanup* EvtBufferQueueReuseCleanup;
 } DMF_CONFIG_BufferQueue;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_BufferQueue.md
+++ b/Dmf/Modules.Library/Dmf_BufferQueue.md
@@ -25,12 +25,15 @@ typedef struct
   BufferPool_SourceSettings SourceSettings;
   // Sink is configured internally.
   //
+  // Optional callback for client to finalize buffer before reuse
+  //
+  EVT_DMF_BufferQueue_ReuseCleanup* EvtBufferQueueReuseCleanup;
 } DMF_CONFIG_BufferQueue;
 ````
 Member | Description.
 ----|----
 SourceSettings | Indicates the settings for a producer list. Since the producer list is internally implemented as a DMF_BufferPool source-mode list, kindly refer to the [DMF_BufferPool](Dmf_BufferPool.md) for details of this structure.
-
+EvtBufferQueueReuseCleanup |  The Client may register this callback to do any cleanup needed before the buffer is being flushed / reused.
 -----------------------------------------------------------------------------------------------------------------------------------
 
 #### Module Enumeration Types
@@ -41,7 +44,30 @@ SourceSettings | Indicates the settings for a producer list. Since the producer 
 
 #### Module Callbacks
 
-* None
+##### EVT_DMF_BufferQueue_ReuseCleanup
+````
+_Function_class_(EVT_DMF_BufferQueue_ReuseCleanup)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_BufferQueue_ReuseCleanup(_In_ DMFMODULE DmfModule,
+                                 _In_ VOID* ClientBuffer,
+                                 _In_ VOID* ClientBufferContext);
+````
+
+This callback is called when this Module is about to reuse a work buffer. Before the Module puts the work
+buffer back in its DMF_BufferQueue Producer list for reuse, the module presents it to the Client via this callback.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_BufferQueue Module handle.
+ClientWorkBuffer | This buffer contains the work that needs to be done in this callback. This buffer is owned by Client until this function returns.
+ClientWorkBufferContext | An optional context associated with ClientWorkBuffer.
+
+##### Remarks
+
+* Use callback to free or reference count decrement resources associated with buffers.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
@@ -1574,20 +1574,25 @@ Return Value:
         // ContinuousRequestTarget
         // -----------------------
         //
+        DMF_CONFIG_ContinuousRequestTarget moduleConfigContinuousRequestTarget;
 
         // Store ContinuousRequestTarget callbacks from config into DeviceInterfaceMultipleTarget context for redirection.
         //
         moduleContext->EvtContinuousRequestTargetBufferInput = moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput;
         moduleContext->EvtContinuousRequestTargetBufferOutput = moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput;
 
+        DMF_CONFIG_ContinuousRequestTarget_AND_ATTRIBUTES_INIT(&moduleConfigContinuousRequestTarget,
+                                                               &moduleAttributes);
+        // Copy ContinuousRequestTarget Config from Client's Module Config.
+        //
+        RtlCopyMemory(&moduleConfigContinuousRequestTarget,
+                      &moduleConfig->ContinuousRequestTargetModuleConfig,
+                      sizeof(moduleConfig->ContinuousRequestTargetModuleConfig));
         // Replace ContinuousRequestTarget callbacks in config with DeviceInterfaceMultipleTarget callbacks.
         //
-        moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = DeviceInterfaceMultipleTarget_Stream_BufferInput;
-        moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = DeviceInterfaceMultipleTarget_Stream_BufferOutput;
+        moduleConfigContinuousRequestTarget.EvtContinuousRequestTargetBufferInput = DeviceInterfaceMultipleTarget_Stream_BufferInput;
+        moduleConfigContinuousRequestTarget.EvtContinuousRequestTargetBufferOutput = DeviceInterfaceMultipleTarget_Stream_BufferOutput;
 
-        DMF_ContinuousRequestTarget_ATTRIBUTES_INIT(&moduleAttributes);
-        moduleAttributes.ModuleConfigPointer = &moduleConfig->ContinuousRequestTargetModuleConfig;
-        moduleAttributes.SizeOfModuleSpecificConfig = sizeof(moduleConfig->ContinuousRequestTargetModuleConfig);
         moduleAttributes.PassiveLevel = moduleContext->PassiveLevel;
         ntStatus = DMF_ContinuousRequestTarget_Create(device,
                                                       &moduleAttributes,

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -2130,20 +2130,25 @@ Return Value:
         // ContinuousRequestTarget
         // -----------------------
         //
+        DMF_CONFIG_ContinuousRequestTarget moduleConfigContinuousRequestTarget;
 
         // Store ContinuousRequestTarget callbacks from config into DeviceInterfaceTarget context for redirection.
         //
         moduleContext->EvtContinuousRequestTargetBufferInput = moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput;
         moduleContext->EvtContinuousRequestTargetBufferOutput = moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput;
 
+        DMF_CONFIG_ContinuousRequestTarget_AND_ATTRIBUTES_INIT(&moduleConfigContinuousRequestTarget,
+                                                               &moduleAttributes);
+        // Copy ContinuousRequestTarget Config from Client's Module Config.
+        //
+        RtlCopyMemory(&moduleConfigContinuousRequestTarget,
+                      &moduleConfig->ContinuousRequestTargetModuleConfig,
+                      sizeof(moduleConfig->ContinuousRequestTargetModuleConfig));
         // Replace ContinuousRequestTarget callbacks in config with DeviceInterfaceTarget callbacks.
         //
-        moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferInput = DeviceInterfaceTarget_Stream_BufferInput;
-        moduleConfig->ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = DeviceInterfaceTarget_Stream_BufferOutput;
+        moduleConfigContinuousRequestTarget.EvtContinuousRequestTargetBufferInput = DeviceInterfaceTarget_Stream_BufferInput;
+        moduleConfigContinuousRequestTarget.EvtContinuousRequestTargetBufferOutput = DeviceInterfaceTarget_Stream_BufferOutput;
 
-        DMF_ContinuousRequestTarget_ATTRIBUTES_INIT(&moduleAttributes);
-        moduleAttributes.ModuleConfigPointer = &moduleConfig->ContinuousRequestTargetModuleConfig;
-        moduleAttributes.SizeOfModuleSpecificConfig = sizeof(moduleConfig->ContinuousRequestTargetModuleConfig);
         moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
         DMF_DmfModuleAdd(DmfModuleInit,
                          &moduleAttributes,

--- a/Dmf/Modules.Library/Dmf_HidTarget.h
+++ b/Dmf/Modules.Library/Dmf_HidTarget.h
@@ -43,6 +43,19 @@ EVT_DMF_HidTarget_DeviceSelectionCallback(_In_ DMFMODULE DmfModule,
                                           _In_ PHIDP_PREPARSED_DATA PreparsedHidData,
                                           _In_ HID_COLLECTION_INFORMATION* HidCollectionInformation);
 
+// Client Driver callback function to be called from Asynchronous Send Completion routine.
+//
+typedef
+_Function_class_(EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion(_In_ DMFMODULE DmfModule,
+                                                       _In_ VOID* ClientRequestContext,
+                                                       _In_reads_(OutputBufferBytesRead) VOID* OutputBuffer,
+                                                       _In_ size_t OutputBufferBytesRead,
+                                                       _In_ NTSTATUS CompletionStatus);
+
 // Client uses this structure to configure the Module specific parameters.
 //
 typedef struct
@@ -125,6 +138,16 @@ DMF_HidTarget_FeatureGet(
     _In_ ULONG BufferSize,
     _In_ ULONG OffsetOfDataToCopy,
     _In_ ULONG NumberOfBytesToCopy
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_HidTarget_FeatureGetAsynchronous(
+    _In_ DMFMODULE DmfModule,
+    _In_ UCHAR ReportId,
+    _In_ EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion* EvtContinuousRequestTargetSingleAsynchronousRequest,
+    _In_opt_ VOID* HidFeatureGetCompletionCallbackClientContext
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library/Dmf_HidTarget.md
+++ b/Dmf/Modules.Library/Dmf_HidTarget.md
@@ -146,6 +146,37 @@ PreparsedHidData | Allows the Client to access the HID API to determine more HID
 HidCollectionInformation | Allows the Client to access the HID API to determine more HID specific information about the given WDFIOTARGET.
 
 -----------------------------------------------------------------------------------------------------------------------------------
+##### EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion
+````
+_Function_class_(EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion(
+    _In_ DMFMODULE DmfModule,
+    _In_ VOID* ClientRequestContext,
+    _In_reads_(OutputBufferBytesRead) VOID* OutputBuffer,
+    _In_ size_t OutputBufferBytesRead,
+    _In_ NTSTATUS CompletionStatus
+    );
+````
+
+Client Driver callback function to be called from GetFeature Asynchronous Completion routine.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_HidTarget Module handle.
+ClientRequestContext | Client's context which was set as a request context while calling DMF_HidTarget_FeatureGetAsynchronous.
+OutputBuffer | Output Buffer which has the feature get report response.
+OutputBufferBytesRead | Size of OutputBuffer
+CompletionStatus | Request completion status.
+
+-----------------------------------------------------------------------------------------------------------------------------------
 
 #### Module Methods
 
@@ -244,6 +275,36 @@ Buffer | The Client buffer that will receive data associated with FeatureId.
 BufferSize | The size of Buffer in bytes.
 OffsetOfDataToCopy | The offset in Buffer where received data is written.
 NumberOfBytesToCopy | The number of bytes that should be received.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_HidTarget_FeatureGetAsynchronous
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_HidTarget_FeatureGetAsynchronous(
+    _In_ DMFMODULE DmfModule,
+    _In_ UCHAR ReportId,
+    _In_ EVT_DMF_HidTarget_FeatureGetAsynchronousSendCompletion* EvtClientHidFeatureGetCompletionCallback,
+    _In_opt_ VOID* HidFeatureGetCompletionCallbackClientContext
+    );
+````
+
+Allows the Client to send a "Get Feature" command to the HID device connected the instance of this Module asynchronously.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | This Module's handle.
+ReportId | Feature report Id to call Get Feature on.
+EvtClientHidFeatureGetCompletionCallback | Callback to be called on completion routine.
+HidFeatureGetCompletionCallbackClientContext | Client context sent in callback.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.h
+++ b/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.h
@@ -47,6 +47,18 @@ EVT_DMF_ThreadedBufferQueue_Callback(_In_ DMFMODULE DmfModule,
                                      _In_ VOID* ClientWorkBufferContext,
                                      _Out_ NTSTATUS* NtStatus);
 
+// Callback called by DMF_ThreadedBufferQueue_Reuse so Client
+// can finalize buffers before being sent back to Producer.
+//
+typedef
+_Function_class_(EVT_DMF_ThreadedBufferQueue_ReuseCleanup)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_ThreadedBufferQueue_ReuseCleanup(_In_ DMFMODULE DmfModule,
+                                         _In_ VOID* ClientBuffer,
+                                         _In_ VOID* ClientBufferContext);
+
 // Client uses this structure to configure the Module specific parameters.
 //
 typedef struct
@@ -63,6 +75,10 @@ typedef struct
     // Optional callback that does work after looping but before thread ends.
     //
     EVT_DMF_Thread_Function* EvtThreadedBufferQueuePost;
+    // Optional callback allows Client to deallocate / dereference any
+    // buffer-attached resources.
+    //
+    EVT_DMF_ThreadedBufferQueue_ReuseCleanup* EvtThreadedBufferQueueReuseCleanup;
 } DMF_CONFIG_ThreadedBufferQueue;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.md
+++ b/Dmf/Modules.Library/Dmf_ThreadedBufferQueue.md
@@ -31,6 +31,10 @@ typedef struct
   // Optional callback that does work after looping but before thread ends.
   //
   EVT_DMF_Thread_Function* EvtThreadedBufferQueuePost;
+  // Optional callback allows Client to deallocate / dereference any
+  // buffer-attached resources.
+  //
+  EVT_DMF_ThreadedBufferQueue_ReuseCleanup* EvtThreadedBufferQueueReuseCleanup;
 } DMF_CONFIG_ThreadedBufferQueue;
 ````
 Member | Description
@@ -39,6 +43,7 @@ BufferQueueConfig | Client sets up the configuration of the internal DMF_BufferQ
 EvtThreadedBufferQueuePre | This function performs work on behalf of the Client before this Module's main ThreadedBufferQueue function executes.
 EvtThreadedBufferQueueWork | This function performs work on behalf of the Client when this Module determines there is work to be done.
 EvtThreadedBufferQueuePost | This function performs work on behalf of the Client after this Module's main ThreadedBufferQueue function executes.
+EvtThreadedBufferQueueReuseCleanup | The Client may register this callback to do any cleanup needed before the buffer is being flushed / reused.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -102,6 +107,30 @@ ClientWorkBuffer | This buffer contains the work that needs to be done in this c
 ClientWorkBufferSize | The size of ClientWorkBuffer for validation purposes.
 ClientWorkBufferContext | An optional context associated with ClientWorkBuffer.
 NtStatus | The NTSTATUS value to return to the function that initially populated the work buffer.
+
+##### EVT_DMF_BufferQueue_ReuseCleanup
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_ThreadedBufferQueue_ReuseCleanup(_In_ DMFMODULE DmfModule,
+                                         _In_ VOID* ClientBuffer,
+                                         _In_ VOID* ClientBufferContext);
+````
+
+This callback is called when this Module is about to reuse a work buffer. Before the Module puts the work
+buffer back in its DMF_BufferQueue's Producer list for reuse, the Module presents it to the Client via this callback.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_ThreadedBufferQueue Module handle.
+ClientWorkBuffer | This buffer contains the work that needs to be done in this callback. This buffer is owned by Client until this function returns.
+ClientWorkBufferContext | An optional context associated with ClientWorkBuffer.
+
+##### Remarks
+
+* Use callback to free or reference count decrement resources associated with buffers.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
0. Correct bug in Dmf_DveiceInterfceMultipleTarget when underlying target disappears and reappears. (This is an important fix.)
1. Add Method to Dmf_BufferQueue to allow Client to free resources allocated per Client buffer.
2. Update Dmt_ThreadedBufferQueue to give Client access to new Dmf_BufferQueue clean up Method.
3. Correct issues in Dmf_ContinuousRequestTarget when failures occur during Stream Start (now does proper clean up).
4. Correct bug in DMF Core when DMF_Module_OpenOrRegisterNotificationOnCreate() fails.
5. Update unit tests to correct bugs in certain execution scenarios.
6. Update Dmf_HidTarget to support asynchronous Feature Get.