### PR TITLE
Merge20210730

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.99
+// DMF Release: v1.1.100
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Framework/DmfCore.c
+++ b/Dmf/Framework/DmfCore.c
@@ -1001,14 +1001,34 @@ Return Value:
             // A new buffer could not be created. Check if the default log is available and set the Module's recorder handle to it 
             // to not miss capturing logs from this Module.
             //
-            recorder = WppRecorderIsDefaultLogAvailable() ? WppRecorderLogGetDefault() : NULL;
+            if (WppRecorderIsDefaultLogAvailable())
+            {
+                recorder = WppRecorderLogGetDefault();
+                // Don't delete it.
+                //
+                DmfObject->UsingDefaultInFlightRecorder = TRUE;
+            }
+            else
+            {
+                recorder = NULL;
+            }
         }
     }
     else
     {
         // The Module's logs will be part of the default log if the Module chose to not have a separate custom buffer.
         //
-        recorder = WppRecorderIsDefaultLogAvailable() ? WppRecorderLogGetDefault() : NULL;
+        if (WppRecorderIsDefaultLogAvailable())
+        {
+            recorder = WppRecorderLogGetDefault();
+            // Don't delete it.
+            //
+            DmfObject->UsingDefaultInFlightRecorder = TRUE;
+        }
+        else
+        {
+            recorder = NULL;
+        }
     }
 
     DmfObject->InFlightRecorder = recorder;
@@ -1544,7 +1564,10 @@ Return Value:
 #if defined(DMF_KERNEL_MODE)
     if (dmfObject->InFlightRecorder != NULL)
     {
-        WppRecorderLogDelete(dmfObject->InFlightRecorder);
+        if (! dmfObject->UsingDefaultInFlightRecorder)
+        {
+            WppRecorderLogDelete(dmfObject->InFlightRecorder);
+        }
         dmfObject->InFlightRecorder = NULL;
     }
 #endif // defined(DMF_KERNEL_MODE)

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -250,6 +250,9 @@ struct _DMF_OBJECT_
     // Stores the Module's In Flight Recorder handle.
     //
     RECORDER_LOG InFlightRecorder;
+    // Indicates that default in-flight recorder is used so it should not be deleted.
+    //
+    BOOLEAN UsingDefaultInFlightRecorder;
     // Client Cleanup Callback (chained).
     //
     PFN_WDF_OBJECT_CONTEXT_CLEANUP ClientEvtCleanupCallback;

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_ScheduledTask.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_ScheduledTask.c
@@ -672,8 +672,7 @@ Tests_ScheduledTask_RunManualTasksEx(
 
             // Schedule deferred execution (Ex version that is correct).
             //
-            ntStatus = DMF_ScheduledTask_ExecuteNowDeferredEx(moduleUnderTest,
-                                                              &moduleContext->TaskContextEx[taskDescriptionIndex]);
+            ntStatus = DMF_ScheduledTask_ExecuteNowDeferredEx(moduleUnderTest);
             DmfAssert(STATUS_SUCCESS == ntStatus);
         }
     }

--- a/Dmf/Modules.Library/Dmf_ScheduledTask.h
+++ b/Dmf/Modules.Library/Dmf_ScheduledTask.h
@@ -89,7 +89,8 @@ typedef struct
     // The Client Driver function that will perform work one time in a work item.
     //
     EVT_DMF_ScheduledTask_Callback* EvtScheduledTaskCallback;
-    // Client context for above callback.
+    // Client context for above callback used by the timer and by
+    // DMF_ScheduledTask__ExecuteNowDeferredEx Method.
     //
     VOID* CallbackContext;
     // Indicates if the operation should be done every time driver loads or only a
@@ -137,8 +138,7 @@ DMF_ScheduledTask_ExecuteNowDeferred(
 
 NTSTATUS
 DMF_ScheduledTask_ExecuteNowDeferredEx(
-    _In_ DMFMODULE DmfModule,
-    _In_opt_ VOID* CallbackContext
+    _In_ DMFMODULE DmfModule
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library/Dmf_ScheduledTask.md
+++ b/Dmf/Modules.Library/Dmf_ScheduledTask.md
@@ -23,7 +23,8 @@ typedef struct
   // The Client Driver function that will perform work one time in a work item.
   //
   EVT_DMF_ScheduledTask_Callback* EvtScheduledTaskCallback;
-  // Client context for above callback.
+  // Client context for above callback used by the timer and by
+  // DMF_ScheduledTask__ExecuteNowDeferredEx Method.
   //
   VOID* CallbackContext;
   // Indicates if the operation should be done every time driver loads or only a
@@ -245,13 +246,13 @@ CallbackContext | This is a Client specific context that is passed to the Client
 ````
 NTSTATUS
 DMF_ScheduledTask_ExecuteNowDeferredEx(
-  _In_ DMFMODULE DmfModule,
-  _In_opt_ VOID* CallbackContext
+  _In_ DMFMODULE DmfModule
   );
 ````
 
 This Method causes the deferred code to execute one time (at a later time). The deferred code will execute shortly
-after this call completes. The callback's return value **is** honored using this Method.
+after this call completes. The callback's return value **is** honored using this Method. The callback is passed
+the context specified in Module config.
 
 ##### Returns
 
@@ -261,7 +262,6 @@ NTSTATUS. Fails if the Request cannot be added to the queue.
 Parameter | Description
 ----|----
 DmfModule | An open DMF_ScheduledTask Module handle.
-CallbackContext | This is a Client specific context that is passed to the Client's deferred execution callback.
 
 ##### Remarks
 

--- a/Dmf/Modules.Library/Dmf_Stack.c
+++ b/Dmf/Modules.Library/Dmf_Stack.c
@@ -118,6 +118,7 @@ Return Value:
     moduleBufferQueueConfigList.SourceSettings.BufferSize = moduleConfig->StackElementSize;
     moduleBufferQueueConfigList.SourceSettings.EnableLookAside = TRUE;
     moduleBufferQueueConfigList.SourceSettings.BufferContextSize = 0;
+    moduleBufferQueueConfigList.SourceSettings.PoolType = NonPagedPoolNx;
     moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
     DMF_DmfModuleAdd(DmfModuleInit,
                      &moduleAttributes,


### PR DESCRIPTION
Merge20210730
1. Don't delete WWP recorder if not created.
2. Remove context from DMF_ScheduledTask_ExecuteNowDefferedEx() to clean up contract. Legacy version is unchanged.
3. Correct verifier issue caused by DMF_Stack using NonPagedPool instead of NonPagedPoolNx.