### PR TITLE
Merge20210921

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.102
+// DMF Release: v1.1.103
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -6487,10 +6487,10 @@ None
 
 -   Proper use of this programming pattern makes it possible for a Client to call a Module's Methods without having to worry about the state of the Module's resources.
 
-### DMF_ModuleIsDynamic
+### DMF_IsModuleDynamic
 ```
-VOID
-DMF_ModuleIsDynamic(
+BOOLEAN
+DMF_IsModuleDynamic(
     _In_ DMFMODULE DmfModule
     )
 ```
@@ -6510,7 +6510,7 @@ FALSE indicates the given Module has not been instantiated as a Dynamic Module.
 
 #### Remarks
 
--  Dynamic Modules cannot use WDF callbacks. So, Modules that can be instantiated as Dynamic use this function to determine if WDF callbacks should be set.
+-  Dynamic Modules cannot use WDF Plug and Play callbacks. So, Modules that can be instantiated as Dynamic use this function to determine if WDF callbacks should be set.
 
 ### DMF_ModuleIsInFilterDriver
 ```
@@ -7352,6 +7352,53 @@ None.
 
 #### Remarks
 
+### DMF_Utility_TemperatureInDeciKelvin
+````
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin(
+    _In_ INT64 Celcius,
+    _Out_ UINT64* DeciKelvin
+    );
+````
+
+Converts Celsius temperature into deci-Kelvin.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ---------------------------------------------------------------
+  Celcius | Temperature in Celcius
+  DeciKelvin | Temperature in DeciKelvin
+
+#### Returns
+
+NTSTATUS
+
+#### Remarks
+
+### DMF_Utility_TemperatureInDeciKelvin32
+````
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin32(
+    _In_ INT32 Celcius,
+    _Out_ UINT32* DeciKelvin
+    );
+````
+
+Converts Celsius temperature into deci-Kelvin.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ---------------------------------------------------------------
+  Celcius | Temperature in Celcius
+  DeciKelvin | Temperature in DeciKelvin
+
+#### Returns
+
+NTSTATUS
+
+#### Remarks
 
 ### DMF_Utility_UserModeAccessCreate
 ```

--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1519,6 +1519,18 @@ DMF_Utility_TransferList(
     _In_ LIST_ENTRY* SourceList
     );
 
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin(
+    _In_ INT64 Celcius,
+    _Out_ UINT64* DeciKelvin
+    );
+
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin32(
+    _In_ INT32 Celcius,
+    _Out_ UINT32* DeciKelvin
+    );
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // LIST_ENTRY functions for User-Mode. (These are copied as-is from Wdm.h.

--- a/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
+++ b/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
@@ -96,6 +96,10 @@ Environment:
 //
 #define IS_WIN10_19H1_OR_LATER (NTDDI_WIN10_19H1 && (NTDDI_VERSION >= NTDDI_WIN10_19H1))
 
+// Check that the Windows version is 21H1 or EARLIER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_21H1_OR_EARLIER (!(NTDDI_WIN10_MN && (NTDDI_VERSION > NTDDI_WIN10_MN)))
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // All include files needed by all Modules and the Framework.
@@ -121,6 +125,7 @@ Environment:
 #include <wdm.h>
 #include <ntddk.h>
 #include <ntstatus.h>
+#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #include <ntintsafe.h>
 // TODO: Add this after Dmf_Registry supports this definition properly.
 // #define NTSTRSAFE_LIB

--- a/Dmf/Framework/DmfIncludes_USER_MODE.h
+++ b/Dmf/Framework/DmfIncludes_USER_MODE.h
@@ -120,6 +120,8 @@ Environment:
 #include <windows.h>
 #include <stdio.h>
 #include <wdf.h>
+#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
+#include <intsafe.h>
 #include <Objbase.h>
 // NOTE: This file includes poclass.h. Do not include that again
 //       otherwise, redefinition errors will occur.

--- a/Dmf/Framework/DmfUtility.c
+++ b/Dmf/Framework/DmfUtility.c
@@ -727,5 +727,179 @@ Return Value:
     }
 }  
 
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin(
+    _In_ INT64 Celcius,
+    _Out_ UINT64* DeciKelvin
+    )
+/*++
+
+Routine Description:
+
+    Converts Celsius temperature into deci-Kelvin.
+
+Arguments:
+
+    Celcius - Temperature in Celcius
+    DeciKelvin - Temperature in DeciKelvin
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    LONGLONG productResult;
+    LONGLONG sumResult;
+
+    // This converts Celcius to DeciCelcius.
+    //
+    const LONGLONG multiplier = 10;
+    // This converts DeciCelcius to DeciKelvin
+    //
+    const LONGLONG addend = 2731;
+
+    // deciKelvin = (Celcius * 10) + 2731
+
+#if defined(DMF_USER_MODE)
+
+    HRESULT hResult;
+
+    hResult = Long64Mult(Celcius,
+                         multiplier,
+                         &productResult);
+    if (hResult != S_OK)
+    {
+        ntStatus = STATUS_UNSUCCESSFUL;
+        goto Exit;
+    }
+
+    hResult = Long64Add(productResult,
+                        addend,
+                        &sumResult);
+    if (hResult != S_OK)
+    {
+        ntStatus = STATUS_UNSUCCESSFUL;
+        goto Exit;
+    }
+
+    *DeciKelvin = (UINT64)sumResult;
+    ntStatus = STATUS_SUCCESS;
+
+#elif defined(DMF_KERNEL_MODE)
+
+    ntStatus = RtlLong64Mult(Celcius,
+                             multiplier,
+                             &productResult);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = RtlLong64Add(productResult,
+                            addend,
+                            &sumResult);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    *DeciKelvin = (UINT64)sumResult;
+
+#endif
+
+Exit:
+
+    return ntStatus;
+}
+
+NTSTATUS
+DMF_Utility_TemperatureInDeciKelvin32(
+    _In_ INT32 Celcius,
+    _Out_ UINT32* DeciKelvin
+    )
+/*++
+
+Routine Description:
+
+    Converts Celsius temperature into deci-Kelvin.
+
+Arguments:
+
+    Celcius - Temperature in Celcius
+    DeciKelvin - Temperature in DeciKelvin
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    INT productResult;
+    INT sumResult;
+
+    // This converts Celcius to DeciCelcius.
+    //
+    const INT multiplier = 10;
+    // This converts DeciCelcius to DeciKelvin
+    //
+    const INT addend = 2731;
+
+    // deciKelvin = (Celcius * 10) + 2731
+
+#if defined(DMF_USER_MODE)
+
+    HRESULT hResult;
+
+    hResult = Int32Mult(Celcius,
+                        multiplier,
+                        &productResult);
+    if (hResult != S_OK)
+    {
+        ntStatus = STATUS_UNSUCCESSFUL;
+        goto Exit;
+    }
+
+    hResult = Int32Add(productResult,
+                       addend,
+                       &sumResult);
+    if (hResult != S_OK)
+    {
+        ntStatus = STATUS_UNSUCCESSFUL;
+        goto Exit;
+    }
+
+    *DeciKelvin = (UINT64)sumResult;
+    ntStatus = STATUS_SUCCESS;
+
+#elif defined(DMF_KERNEL_MODE)
+
+    ntStatus = RtlInt32Mult(Celcius,
+                            multiplier,
+                            &productResult);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = RtlInt32Add(productResult,
+                           addend,
+                           &sumResult);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    *DeciKelvin = (UINT32)sumResult;
+
+#endif
+
+Exit:
+
+    return ntStatus;
+}
+
 // eof: DmfUtility.c
 //

--- a/Dmf/Modules.Library.Tests/TestsUtility.c
+++ b/Dmf/Modules.Library.Tests/TestsUtility.c
@@ -102,12 +102,6 @@ Return Value:
     return random;
 }
 
-#if defined(DMF_USER_MODE)
-    // Same as DDK definition.
-    //
-    #define BYTE_MAX    (0xFF)
-#endif
-
 _IRQL_requires_same_
 VOID
 TestsUtility_FillWithSequentialData(

--- a/Dmf/Modules.Library/Dmf_Registry.c
+++ b/Dmf/Modules.Library/Dmf_Registry.c
@@ -5030,6 +5030,9 @@ Return Value:
     for (ULONG callbackIndex = 0; callbackIndex < scheduledTaskCallbackContext->NumberOfCallbacks; callbackIndex++)
     {
         // Create and open a Registry Module, do the registry work, close and destroy the Registry Module.
+        // NOTE: This callback cannot call any deferred Methods because the Module is immediately destroyed
+        //       when the callback finishes. For example, do not call DMF_Registry_TreeWriteDeferred() from 
+        //       inside the callback.
         //
         ntStatus = DMF_Registry_CallbackWork(device,
                                              scheduledTaskCallbackContext->Callbacks[callbackIndex]);

--- a/Dmf/Modules.Library/Dmf_Registry.md
+++ b/Dmf/Modules.Library/Dmf_Registry.md
@@ -150,6 +150,10 @@ Parameter | Description
 ----|----
 DmfModule | An open DMF_Registry Module handle.
 
+##### Remarks
+
+* IMPORTANT: Do not call any deferred Methods from this callback as the caller destroys DmfModule upon return.
+
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### EVT_DMF_Registry_KeyEnumerationCallback
 ````


### PR DESCRIPTION
1. Correct bug in DMF_BufferPool where system time is used instead of interrupt time. This can cause bugs if user changes system time while Methods that use timers are called (DMF_BufferPool_PutWithTimer()).
2. Add temperature functions.
3. Make clarification in DMF_Registry comments and fix error in documentation for DMF_IsModuleDynamic.
4. Add  macro that checks for latest version of Windows.