### PR TITLE
Fixed udeDeviceInformation assignment in UdeClient_CreateAndPlugUsbDevice

### DIFF
--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -1219,8 +1219,8 @@ Return Value:
 
     // Save for access via Method.
     //
-    udeDeviceInformation->PlugInPortType = moduleConfig->PlugInPortType;
-    udeDeviceInformation->PlugInPortNumber = moduleConfig->PlugInPortNumber;
+    udeDeviceInformation->PlugInPortType = PortType;
+    udeDeviceInformation->PlugInPortNumber = PlugInPortNumber;
 
     ntStatus = UdecxUsbDevicePlugIn(usbDevice,
                                     &pluginOptions);


### PR DESCRIPTION
`UdeClient_CreateAndPlugUsbDevice` always assigns the module context values for Port type and number, which will always be zero when `DMF_UdeClient_DeviceInformationGet` is used after device creation.