### PR TITLE
Merge20211111

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.107
+// DMF Release: v1.1.108
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Framework/DmfIncludes.h
+++ b/Dmf/Framework/DmfIncludes.h
@@ -20,6 +20,17 @@ Environment:
 
 --*/
 
+// Automatically define DMF_USER_MODE if in the UMDF environment.
+// (Previously, UMDF drivers had to explicitly set this setting.)
+//
+#if defined(UMDF_VERSION_MAJOR)
+    // Maintain backward compatibility for drivers that already define DMF_USER_MODE.
+    //
+    #if !defined(DMF_USER_MODE)
+        #define DMF_USER_MODE
+    #endif
+#endif
+
 // NOTE: All non-native WDF platforms require DmfPlatform.h.
 //
 #if defined(DMF_WIN32_MODE) 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
@@ -183,7 +183,11 @@ Tests_BufferQueue_ThreadAction_Enqueue(
     ntStatus = DMF_BufferQueue_Fetch(moduleContext->DmfModuleBufferQueue,
                                      (PVOID*)&clientBuffer,
                                      (PVOID*)&clientBufferContext);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
     DmfAssert(clientBuffer != NULL);
     DmfAssert(clientBufferContext != NULL);
 

--- a/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
+++ b/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
@@ -4914,7 +4914,7 @@ Return Value:
     configComponentFirmwareUpdateTransport->TransportWaitTimeout = transportBindData.TransportWaitTimeout;
     configComponentFirmwareUpdateTransport->TransportPayloadFillAlignment = transportBindData.TransportPayloadFillAlignment;
 
-    // Allocate a Context to keep items for transaction response response specific processing.
+    // Allocate a Context to keep items for transaction response specific processing.
     //
     CONTEXT_ComponentFirmwareUpdateTransaction* componentFirmwareUpdateTransactionContext;
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes,

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -92,12 +92,6 @@ typedef struct
     // Callback to notify Interface arrival.
     //
     EVT_DMF_DeviceInterfaceTarget_OnPnpNotification* EvtDeviceInterfaceTargetOnPnpNotification;
-    // To maintain compatibility with existing drivers, this option tells the 
-    // Module to perform non-standard behavior: When target disables the device interface
-    // close the associated open handle. (WDF does not do this by default.) New drivers 
-    // should not use this option.
-    //
-    BOOLEAN CloseUnderlyingTargetOnDeviceInterfaceDisable;
 } DMF_CONFIG_DeviceInterfaceTarget;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -40,12 +40,6 @@ typedef struct
   // Callback to notify Interface arrival.
   //
   EVT_DMF_DeviceInterfaceTarget_OnPnpNotification* EvtDeviceInterfaceTargetOnPnpNotification;
-  // To maintain compatability with existing drivers, this option tells the 
-  // Module to perform non-standard behavior: When target disables the device interface
-  // close the associated open handle. (WDF does not do this by default.) New drivers 
-  // should not use this option.
-  //
-  BOOLEAN CloseUnderlyingTargetOnDeviceInterfaceDisable;
 } DMF_CONFIG_DeviceInterfaceTarget;
 ````
 Member | Description
@@ -56,7 +50,6 @@ ShareAccess | The Share Access mask used when opening the underlying WDFIOTARGET
 ContinuousRequestTargetModuleConfig | Contains the settings for the underlying RequesetStream.
 EvtDeviceInterfaceTargetOnStateChange | Callback to the Client that indicates the state of the target has changed.
 EvtDeviceInterfaceTargetOnPnpNotification | Callback to the Client that allows the Client to indicate if the target should open.
-CloseUnderlyingTargetOnDeviceInterfaceDisable | *This option should not be used by new drivers.* Setting this flag causes the PreClose() callback to be called everytime the underlying device interface is disabled. WDF does not close open handles when a device interface is disabled. However some legacy drivers close the open handles when the associated remove notification is sent. This option is added to simplyfy porting of such drivers.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_GpioTarget.c
+++ b/Dmf/Modules.Library/Dmf_GpioTarget.c
@@ -810,7 +810,7 @@ Return Value:
     {
         TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Gpio Connection not assigned");
         ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
-        NT_ASSERT(FALSE);
+        DmfAssert(FALSE);
         goto Exit;
     }
 

--- a/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.c
+++ b/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.c
@@ -465,6 +465,7 @@ VOID
 EVT_SystemManagementFramework_ProtocolNotify(
     _In_ DMFINTERFACE DmfInterface,
     _In_ SMFSOC_PROTOCOL_NOTIFY_OPERATION Operation,
+    _In_ USHORT Channel,
     _In_ VOID* Data,
     _In_ size_t DataSize
     )
@@ -478,6 +479,7 @@ Arguments:
 
     DmfInterface - Interface handle.
     Operation - Provides information on the type of data is sent from transport.
+    Channel - Channel this operation is targeting.
     Data - Data to be reported.
     DataSize - Size of Data.
 
@@ -495,6 +497,7 @@ Return Value:
 
     protocolData->EVT_SystemManagementFramework_ProtocolNotify(DmfInterface,
                                                                Operation,
+                                                               Channel,
                                                                Data,
                                                                DataSize);
 

--- a/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
+++ b/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
@@ -64,6 +64,16 @@ typedef struct
 //
 typedef enum
 {
+    SmfSoCSensorChannelInvalidInstanceId = 0,
+    // These sensors will be used to query CPU and System energy counter.
+    // Channel type is SMF_SOC_ENERGY_INPUT_TYPE.
+    //
+    SmfSoCSensorChannelSocEnergyInputCpuPowerId = 1,
+    SmfSoCSensorChannelSocEnergyInputSystemPowerId = 2,
+    // This sensor will be used to query Prochot status.
+    // Channel type is SMF_SOC_POWER_INPUT_TYPE.
+    //
+    SmfSoCSensorChannelSocPowerInputProcHotStatusId = 4,
     // These type contains the version number of the module.
     // Channel type is SMF_GENERIC_TYPE.
     //
@@ -73,9 +83,10 @@ typedef enum
     // Channel type is SMF_GENERIC_TYPE.
     //
     SmfSoCSensorChannelCpuTemperatureAverageId = 112,
-    // These sensor are reported as is to the framework.
+    // These sensors are reported as is to the framework.
     // Channel type is SMF_TEMPERATURE_SENSOR_TYPE.
     //
+    SmfSoCSensorChannelCpuTemperatureId =  102,
     SmfSoCSensorChannelCpuTemperature0Id = 180,
     SmfSoCSensorChannelCpuTemperature1Id = 181,
     SmfSoCSensorChannelCpuTemperature2Id = 182,
@@ -85,7 +96,12 @@ typedef enum
     SmfSoCSensorChannelCpuTemperature6Id = 186,
     SmfSoCSensorChannelCpuTemperature7Id = 187,
     SmfSoCSensorChannelCpuTemperature8Id = 188,
-    SmfSoCSensorChannelCpuTemperature9Id = 189
+    SmfSoCSensorChannelCpuTemperature9Id = 189,
+    // These sensors are reported as is to the framework.
+    // Channel type is SMF_SILICON_TELEMETRY_INPUT_TYPE.
+    //
+    SmfSoCSensorChanneCpuTelemetryBitsId = 199,
+    SmfSoCSensorChanneGpuTelemetryBitsId = 299
 } SMFSOC_SENSORCHANNEL;
 
 // Enumeration used to expose Control Channels to SMF.
@@ -216,6 +232,7 @@ VOID
 EVT_DMF_INTERFACE_SystemManagementFramework_ProtocolNotify(
     _In_ DMFINTERFACE DmfInterface,
     _In_ SMFSOC_PROTOCOL_NOTIFY_OPERATION Operation,
+    _In_ USHORT Channel,
     _In_ VOID* Data,
     _In_ size_t DataSize
     );

--- a/Dmf/Modules.Library/Dmf_SpiTarget.c
+++ b/Dmf/Modules.Library/Dmf_SpiTarget.c
@@ -704,7 +704,7 @@ Return Value:
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "No resources found");
         ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
-        NT_ASSERT(FALSE);
+        DmfAssert(FALSE);
         goto Exit;
     }
 
@@ -751,7 +751,7 @@ Return Value:
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "No SPI Resources assigned");
         ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
-        NT_ASSERT(FALSE);
+        DmfAssert(FALSE);
         goto Exit;
     }
 

--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -1219,8 +1219,8 @@ Return Value:
 
     // Save for access via Method.
     //
-    udeDeviceInformation->PlugInPortType = moduleConfig->PlugInPortType;
-    udeDeviceInformation->PlugInPortNumber = moduleConfig->PlugInPortNumber;
+    udeDeviceInformation->PlugInPortType = PortType;
+    udeDeviceInformation->PlugInPortNumber = PlugInPortNumber;
 
     ntStatus = UdecxUsbDevicePlugIn(usbDevice,
                                     &pluginOptions);

--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -600,7 +600,13 @@ Return Value:
                              EndpointConfig->QueueDispatchType);
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&queueAttributes,
                                             CONTEXT_UdeClient_EndpointQueue);
-    queueConfig.EvtIoInternalDeviceControl = UdeClient_EvtEndpointDeviceIoControl;
+    if (queueConfig.DispatchType < WdfIoQueueDispatchManual)
+    {
+        // This callback is only relevant for non-Manual queues otherwise WdfIoQueueCreate
+        // fails.
+        //
+        queueConfig.EvtIoInternalDeviceControl = UdeClient_EvtEndpointDeviceIoControl;
+    }
     ntStatus = WdfIoQueueCreate(device,
                                 &queueConfig,
                                 &queueAttributes,
@@ -804,11 +810,11 @@ Return Value:
     }
     else if (UsbDeviceConfig->UsbDeviceEndpointType == UdecxEndpointTypeSimple)
     {
-        // Atleast 1 endpoint configuration is needed for Simple EndpointType.
+        // At least 1 endpoint configuration is needed for Simple EndpointType.
         //
         if (UsbDeviceConfig->SimpleEndpointCount == 0)
         {
-            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Simple Endpoint Type Required atleast 1 endpoint");
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Simple Endpoint Type Required at least 1 endpoint");
 
              ntStatus = STATUS_INVALID_PARAMETER;
              goto Exit;
@@ -839,11 +845,24 @@ Return Value:
                     goto Exit;
                 }
 
-                // DeviceIoControl Callback is mandatory.
+                // DeviceIoControl Callback is mandatory for dispatch types
+                // WdfIoQueueDispatchSequential and WdfIoQueueDispatchParallel.
                 //
-                if (endpointConfig->EvtEndpointDeviceIoControl == NULL)
+                if ((endpointConfig->QueueDispatchType < WdfIoQueueDispatchManual) &&
+                    (endpointConfig->EvtEndpointDeviceIoControl == NULL))
                 {
                     TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "No Endpoint DeviceIoControl Callback configured on Endpoint Configuration[%d]", endpointIndex);
+
+                    ntStatus = STATUS_INVALID_PARAMETER;
+                    goto Exit; 
+                }
+
+                // EvtEndpointReady Callback is mandatory for dispatch type WdfIoQueueDispatchManual.
+                //
+                if ((endpointConfig->QueueDispatchType == WdfIoQueueDispatchManual) &&
+                    (endpointConfig->EvtEndpointReady == NULL))
+                {
+                    TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "No Endpoint EvtEndpointReady Callback configured on Endpoint Configuration[%d]", endpointIndex);
 
                     ntStatus = STATUS_INVALID_PARAMETER;
                     goto Exit; 

--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -95,7 +95,7 @@ typedef struct _CONTEXT_UdeClient_Endpoint
     // Configuration for this endpoint.
     //
     UdeClient_CONFIG_Endpoint EndpointConfig;
-    // Device endpoint is attached to.
+    // Device the endpoint is located on.
     //
     UDECXUSBDEVICE UdecxUsbDevice;
 } CONTEXT_UdeClient_Endpoint;
@@ -567,7 +567,7 @@ Routine Description:
 Arguments:
 
     DmfModule - This Module's handle.
-    UdecxUsbDevice - Device to which endpoints are attached so it can be
+    UdecxUsbDevice - Device on which endpoints are located so it can be
                      retrieve using a Method given the endpoint.
     EndpointInit - Endpoint Init associated with the Usb device.
     EndpointConfig - Endpoint Configuration.
@@ -1840,7 +1840,7 @@ Arguments:
 
     DmfModule - This Module's handle.
     Endpoint - The given endpoint.
-    UdecxUsbDevice - The device to which the endpoint is attached.
+    UdecxUsbDevice - The device on which the endpoint is located.
     Address - The given endpoint's assigned address.
 
 Return Value:

--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -1840,6 +1840,7 @@ Arguments:
 
     DmfModule - This Module's handle.
     Endpoint - The given endpoint.
+    UdecxUsbDevice - The device to which the endpoint is attached.
     Address - The given endpoint's assigned address.
 
 Return Value:

--- a/Dmf/Modules.Library/Dmf_UdeClient.c
+++ b/Dmf/Modules.Library/Dmf_UdeClient.c
@@ -567,6 +567,8 @@ Routine Description:
 Arguments:
 
     DmfModule - This Module's handle.
+    UdecxUsbDevice - Device to which endpoints are attached so it can be
+                     retrieve using a Method given the endpoint.
     EndpointInit - Endpoint Init associated with the Usb device.
     EndpointConfig - Endpoint Configuration.
     Endpoint - The newly created Endpoint.
@@ -1760,57 +1762,6 @@ Exit:
 
 #pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
-VOID
-DMF_UdeClient_DeviceEndpointInformationGet(
-    _In_ DMFMODULE DmfModule,
-    _In_ UDECXUSBENDPOINT Endpoint,
-    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
-    _Out_opt_ UCHAR* Address
-    )
-/*++
-
-Routine Description:
-
-    Get the address from a given endpoint.
-
-Arguments:
-
-    DmfModule - This Module's handle.
-    Endpoint - The given endpoint.
-    Address - The given endpoint's assigned address.
-
-Return Value:
-
-    None
-
---*/
-{
-    UdeClient_CONFIG_Endpoint* endpointConfig;
-    CONTEXT_UdeClient_Endpoint* endpointContext;
-
-    PAGED_CODE();
-
-    FuncEntry(DMF_TRACE);
-
-    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
-                                 UdeClient);
-
-    endpointContext = UdeClientEndpointContextGet(Endpoint);
-    endpointConfig = &endpointContext->EndpointConfig;
-
-    if (Address != NULL)
-    {
-        *Address = endpointConfig->EndpointAddress;
-    }
-    if (UdecxUsbDevice != NULL)
-    {
-        *UdecxUsbDevice = endpointContext->UdecxUsbDevice;
-    }
-}
-#pragma code_seg()
-
-#pragma code_seg("PAGE")
-_IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UdeClient_DeviceEndpointCreate(
@@ -1873,6 +1824,59 @@ Exit:
 #pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
+DMF_UdeClient_DeviceEndpointInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
+    _Out_opt_ UCHAR* Address
+    )
+/*++
+
+Routine Description:
+
+    Get the address from a given endpoint.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    Endpoint - The given endpoint.
+    Address - The given endpoint's assigned address.
+
+Return Value:
+
+    None
+
+--*/
+{
+    UdeClient_CONFIG_Endpoint* endpointConfig;
+    CONTEXT_UdeClient_Endpoint* endpointContext;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 UdeClient);
+
+    endpointContext = UdeClientEndpointContextGet(Endpoint);
+    endpointConfig = &endpointContext->EndpointConfig;
+
+    if (Address != NULL)
+    {
+        *Address = endpointConfig->EndpointAddress;
+    }
+    if (UdecxUsbDevice != NULL)
+    {
+        *UdecxUsbDevice = endpointContext->UdecxUsbDevice;
+    }
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
 DMF_UdeClient_DeviceInformationGet(
     _In_ DMFMODULE DmfModule,
     _In_ UDECXUSBDEVICE UdecxUsbDevice,
@@ -1910,9 +1914,12 @@ Return Value:
     udeDeviceInformation = UdeClient_UdeDeviceInformation(UdecxUsbDevice);
     *PortType = udeDeviceInformation->PlugInPortType;
     *PortNumber = udeDeviceInformation->PlugInPortNumber;
+
+    FuncExitVoid(DMF_TRACE);
 }
 #pragma code_seg()
 
+#pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
@@ -1963,6 +1970,7 @@ Exit:
 }
 #pragma code_seg()
 
+#pragma code_seg("PAGE")
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 DMF_UdeClient_DeviceSignalFunctionWake(
@@ -2009,7 +2017,6 @@ Return Value:
     }
 
     FuncExitVoid(DMF_TRACE);
-
 }
 #pragma code_seg()
 

--- a/Dmf/Modules.Library/Dmf_UdeClient.h
+++ b/Dmf/Modules.Library/Dmf_UdeClient.h
@@ -280,15 +280,6 @@ DMF_UdeClient_DeviceCreateAndPlugIn(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
-VOID
-DMF_UdeClient_DeviceEndpointInformationGet(
-    _In_ DMFMODULE DmfModule,
-    _In_ UDECXUSBENDPOINT Endpoint,
-    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
-    _Out_opt_ UCHAR* Address
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UdeClient_DeviceEndpointCreate(
@@ -297,6 +288,15 @@ DMF_UdeClient_DeviceEndpointCreate(
     _In_ PUDECXUSBENDPOINT_INIT EndpointInit,
     _In_ UdeClient_CONFIG_Endpoint* ConfigEndpoint,
     _Out_ UDECXUSBENDPOINT* Endpoint
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceEndpointInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
+    _Out_opt_ UCHAR* Address
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library/Dmf_UdeClient.h
+++ b/Dmf/Modules.Library/Dmf_UdeClient.h
@@ -147,6 +147,7 @@ _IRQL_requires_same_
 VOID
 EVT_DMF_UdeClient_Endpoint_Ready(
     _In_ DMFMODULE DmfModule,
+    _In_ WDFQUEUE Queue,
     _In_ UDECXUSBENDPOINT Endpoint,
     _In_ WDFCONTEXT Context
     );

--- a/Dmf/Modules.Library/Dmf_UdeClient.h
+++ b/Dmf/Modules.Library/Dmf_UdeClient.h
@@ -160,7 +160,7 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Queue Dispatch Type.
     //
     WDF_IO_QUEUE_DISPATCH_TYPE QueueDispatchType;
-    // DeviceIOControl callback.
+    // DeviceIOControl callback. (mandatory with QueueDispatchType < WdfIoQueueDispatchManual endpoints.)
     //
     EVT_DMF_UdeClient_Endpoint_DeviceIoControl* EvtEndpointDeviceIoControl;
     // Endpoint Reset callbacks. This is Mandatory.
@@ -172,7 +172,7 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Purge callbacks. This is Optional.
     //
     EVT_DMF_UdeClient_Endpoint_Purge* EvtEndpointPurge;
-    // Endpoint data available callback (used with manual queues).
+    // Endpoint data available callback (mandatory with WdfIoQueueDispatchManual endpoints).
     //
     EVT_DMF_UdeClient_Endpoint_Ready* EvtEndpointReady;
     // Context passed to EvtEndpointReady.

--- a/Dmf/Modules.Library/Dmf_UdeClient.h
+++ b/Dmf/Modules.Library/Dmf_UdeClient.h
@@ -138,6 +138,19 @@ EVT_DMF_UdeClient_Endpoint_Purge(
     _In_ UDECXUSBENDPOINT Endpoint
     );
 
+// Queue Ready callback (required for manual dispatch endpoints).
+//
+typedef
+_Function_class_(EVT_DMF_UdeClient_Endpoint_Ready)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_UdeClient_Endpoint_Ready(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _In_ WDFCONTEXT Context
+    );
+
 typedef struct _UdeClient_CONFIG_Endpoint
 {
     // Endpoint Address to used.
@@ -158,6 +171,12 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Purge callbacks. This is Optional.
     //
     EVT_DMF_UdeClient_Endpoint_Purge* EvtEndpointPurge;
+    // Endpoint data available callback (used with manual queues).
+    //
+    EVT_DMF_UdeClient_Endpoint_Ready* EvtEndpointReady;
+    // Context passed to EvtEndpointReady.
+    //
+    WDFCONTEXT EndPointReadyContext;
 } UdeClient_CONFIG_Endpoint;
 
 typedef struct _UdeClient_CONFIG_UsbDevice
@@ -261,10 +280,11 @@ DMF_UdeClient_DeviceCreateAndPlugIn(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
-DMF_UdeClient_DeviceEndpointAddressGet(
+DMF_UdeClient_DeviceEndpointInformationGet(
     _In_ DMFMODULE DmfModule,
     _In_ UDECXUSBENDPOINT Endpoint,
-    _Out_ UCHAR* Address
+    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
+    _Out_opt_ UCHAR* Address
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -272,6 +292,7 @@ _Must_inspect_result_
 NTSTATUS
 DMF_UdeClient_DeviceEndpointCreate(
     _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBDEVICE UdecxUsbDevice,
     _In_ PUDECXUSBENDPOINT_INIT EndpointInit,
     _In_ UdeClient_CONFIG_Endpoint* ConfigEndpoint,
     _Out_ UDECXUSBENDPOINT* Endpoint

--- a/Dmf/Modules.Library/Dmf_UdeClient.h
+++ b/Dmf/Modules.Library/Dmf_UdeClient.h
@@ -260,6 +260,14 @@ DMF_UdeClient_DeviceCreateAndPlugIn(
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceEndpointAddressGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _Out_ UCHAR* Address
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UdeClient_DeviceEndpointCreate(
@@ -267,6 +275,15 @@ DMF_UdeClient_DeviceEndpointCreate(
     _In_ PUDECXUSBENDPOINT_INIT EndpointInit,
     _In_ UdeClient_CONFIG_Endpoint* ConfigEndpoint,
     _Out_ UDECXUSBENDPOINT* Endpoint
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBDEVICE UdecxUsbDevice,
+    _Out_ UDE_CLIENT_PLUGIN_PORT_TYPE* PortType,
+    _Out_ ULONG* PortNumber
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -379,6 +379,32 @@ PortNumber | Port Number to be used while PlugIn this Usb Device.
 UdecxUsbDevice | A handle to a framework device object that represents the newly created Virtual USB Device.
 
 -----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_UdeClient_DeviceEndpointAddressGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceEndpointAddressGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _Out_ UCHAR* Address
+    );
+````
+
+Get the address from a given endpoint.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_UdeClient Module handle.
+Endpoint | The given endpoint.
+Address | Address of the given endpoint.
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_UdeClient_DeviceEndpointCreate
 
 ````
@@ -406,6 +432,34 @@ DmfModule | An open DMF_UdeClient Module handle.
 EndpointInit | An opaque structure that represent an initialization configuration for Endpoint.
 EndpointConfig | Endpoint configuration.
 Endpoint | A handle to a framework device object that represents the newly created Endpoint.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_UdeClient_DeviceInformationGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBDEVICE UdecxUsbDevice,
+    _Out_ UDE_CLIENT_PLUGIN_PORT_TYPE* PortType,
+    _Out_ ULONG* PortNumber
+    );
+````
+
+Gets port and port type information from a give UdecxUsbDevice.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_UdeClient Module handle.
+UdecxUsbDevice | A handle to a framework device object that represents the Virtual USB Device.
+PortType | Type of port given UdecxDevice is plugged into.
+PortNumber | Port number the given UdecxDevice is plugged into or zero if not plugged in.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_UdeClient_DevicePlugOutAndDelete

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -41,6 +41,12 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Purge callbacks. This is Optional.
     //
     EVT_DMF_UdeClient_Endpoint_Purge* EvtEndpointPurge;
+    // Endpoint data available callback (used with manual queues).
+    //
+    EVT_DMF_UdeClient_Endpoint_Ready* EvtEndpointReady;
+    // Context passed to EvtEndpointReady.
+    //
+    WDFCONTEXT EndPointReadyContext;
 } UdeClient_CONFIG_Endpoint;
 
 typedef struct _UdeClient_CONFIG_UsbDevice
@@ -321,6 +327,7 @@ Parameter | Description
 ----|----
 DmfModule | An open DMF_UdeClient Module handle.
 Endpoint | A handle to a framework device object that represents an Endpoint on a Virtual USB Device.
+
 -----------------------------------------------------------------------------------------------------------------------------------
 ##### EVT_DMF_UdeClient_Endpoint_Purge
 ````
@@ -342,6 +349,30 @@ Parameter | Description
 ----|----
 DmfModule | An open DMF_UdeClient Module handle.
 Endpoint | A handle to a framework device object that represents an Endpoint on a Virtual USB Device.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### EVT_DMF_UdeClient_Endpoint_Ready
+````
+typedef
+_Function_class_(EVT_DMF_UdeClient_Endpoint_Ready)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_UdeClient_Endpoint_Ready(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _In_ WDFCONTEXT Context
+    );
+````
+Callback which indicates that a request is present on the WDFQUEUE associated with the given endpoint.
+NOTE: This callback is required for endpoints with a manual dispatch type.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_UdeClient Module handle.
+Endpoint | The given endpoint.
+Context | Context set in by the Client in the Endpoint Config.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 #### Module Methods
@@ -413,6 +444,7 @@ _Must_inspect_result_
 NTSTATUS
 DMF_UdeClient_DeviceEndpointCreate(
     _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBDEVICE UdecxUsbDevice,
     _In_ PUDECXUSBENDPOINT_INIT EndpointInit,
     _In_ UdeClient_CONFIG_Endpoint* EndpointConfig,
     _Out_ UDECXUSBENDPOINT* Endpoint
@@ -429,6 +461,7 @@ NTSTATUS
 Parameter | Description
 ----|----
 DmfModule | An open DMF_UdeClient Module handle.
+UdecxUsbDevice | The device on which the endpoint is located.
 EndpointInit | An opaque structure that represent an initialization configuration for Endpoint.
 EndpointConfig | Endpoint configuration.
 Endpoint | A handle to a framework device object that represents the newly created Endpoint.

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -469,6 +469,34 @@ EndpointConfig | Endpoint configuration.
 Endpoint | A handle to a framework device object that represents the newly created Endpoint.
 
 -----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_UdeClient_DeviceEndpointInformationGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+DMF_UdeClient_DeviceEndpointInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UDECXUSBENDPOINT Endpoint,
+    _Out_opt_ UDECXUSBDEVICE* UdecxUsbDevice,
+    _Out_opt_ UCHAR* Address
+    )
+````
+
+Gets information about a given endpoint.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_UdeClient Module handle.
+Endpoint | The given endpoint.
+UdecxUsbDevice | The device to which the endpoint is attached.
+Address | The address of the endpoint.
+
+-----------------------------------------------------------------------------------------------------------------------------------
 ##### DMF_UdeClient_DeviceInformationGet
 
 ````

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -29,7 +29,7 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Queue Dispatch Type.
     //
     WDF_IO_QUEUE_DISPATCH_TYPE QueueDispatchType;
-    // DeviceIOControl callback.
+    // DeviceIOControl callback. (mandatory with QueueDispatchType < WdfIoQueueDispatchManual endpoints.)
     //
     EVT_DMF_UdeClient_Endpoint_DeviceIoControl* EvtEndpointDeviceIoControl;
     // Endpoint Reset callbacks. This is Mandatory.
@@ -41,7 +41,7 @@ typedef struct _UdeClient_CONFIG_Endpoint
     // Endpoint Purge callbacks. This is Optional.
     //
     EVT_DMF_UdeClient_Endpoint_Purge* EvtEndpointPurge;
-    // Endpoint data available callback (used with manual queues).
+    // Endpoint data available callback (mandatory with WdfIoQueueDispatchManual endpoints).
     //
     EVT_DMF_UdeClient_Endpoint_Ready* EvtEndpointReady;
     // Context passed to EvtEndpointReady.

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -360,6 +360,7 @@ _IRQL_requires_same_
 VOID
 EVT_DMF_UdeClient_Endpoint_Ready(
     _In_ DMFMODULE DmfModule,
+    _In_ WDFQUEUE Queue,
     _In_ UDECXUSBENDPOINT Endpoint,
     _In_ WDFCONTEXT Context
     );
@@ -371,6 +372,7 @@ NOTE: This callback is required for endpoints with a manual dispatch type.
 Parameter | Description
 ----|----
 DmfModule | An open DMF_UdeClient Module handle.
+Queue | The queue associated with the given endpoint.
 Endpoint | The given endpoint.
 Context | Context set in by the Client in the Endpoint Config.
 

--- a/Dmf/Modules.Library/Dmf_UdeClient.md
+++ b/Dmf/Modules.Library/Dmf_UdeClient.md
@@ -493,7 +493,7 @@ Parameter | Description
 ----|----
 DmfModule | An open DMF_UdeClient Module handle.
 Endpoint | The given endpoint.
-UdecxUsbDevice | The device to which the endpoint is attached.
+UdecxUsbDevice | The device on which the endpoint is located.
 Address | The address of the endpoint.
 
 -----------------------------------------------------------------------------------------------------------------------------------

--- a/Dmf/Solution/DmfU/DmfU.vcxproj
+++ b/Dmf/Solution/DmfU/DmfU.vcxproj
@@ -96,8 +96,8 @@
     <ClCompile>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)'  == ''">
       </WppScanConfigurationData>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions) </PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <CompileAs>CompileAsCpp</CompileAs>
       <ShowIncludes>false</ShowIncludes>

--- a/Dmf/Solution/DmfUFramework/DmfUFramework.vcxproj
+++ b/Dmf/Solution/DmfUFramework/DmfUFramework.vcxproj
@@ -96,8 +96,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)'  == ''">..\..\Framework\DmfTrace.h</WppScanConfigurationData>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <CompileAs>CompileAsCpp</CompileAs>
       <ShowIncludes>false</ShowIncludes>

--- a/Dmf/Solution/DmfUModules.Library.Tests/DmfUModules.Library.Tests.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library.Tests/DmfUModules.Library.Tests.vcxproj
@@ -95,8 +95,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)'  == ''">..\..\Framework\DmfTrace.h</WppScanConfigurationData>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <CompileAs>CompileAsCpp</CompileAs>
       <ShowIncludes>false</ShowIncludes>

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
@@ -146,7 +146,7 @@
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp17</LanguageStandard>
     </ClCompile>
     <ClCompile Condition="'$(Platform)'=='ARM64'">
-      <AdditionalOptions Condition="'$(_NT_TARGET_VERSION)'=='$(_NT_TARGET_VERSION_WIN10_CO)'" >/d2guardsignret %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(_NT_TARGET_VERSION)'=='$(_NT_TARGET_VERSION_WIN10_CO)'">/d2guardsignret %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalDependencies);hid.lib;setupapi.lib;cfgmgr32.lib;</AdditionalDependencies>
@@ -165,7 +165,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
     <Link>
-      <AdditionalOptions Condition="'$(_NT_TARGET_VERSION)'=='$(_NT_TARGET_VERSION_WIN10_CO)'" >/guard:delayloadsignret %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(_NT_TARGET_VERSION)'=='$(_NT_TARGET_VERSION_WIN10_CO)'">/guard:delayloadsignret %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -177,9 +177,11 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_BufferPool.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_BufferQueue.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_Doorbell.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_GpioTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_HashTable.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_IoctlHandler.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_RingBuffer.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_SpiTarget.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_Stack.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_String.h" />
     <ClInclude Include="..\..\Modules.Library\DmfModules.Library.h" />
@@ -223,9 +225,11 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_BufferPool.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_BufferQueue.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_Doorbell.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_GpioTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_HashTable.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_IoctlHandler.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_RingBuffer.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_SpiTarget.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_Stack.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_String.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_AlertableSleep.c" />
@@ -268,9 +272,11 @@
     <None Include="..\..\Modules.Library\Dmf_BufferPool.md" />
     <None Include="..\..\Modules.Library\Dmf_BufferQueue.md" />
     <None Include="..\..\Modules.Library\Dmf_Doorbell.md" />
+    <None Include="..\..\Modules.Library\Dmf_GpioTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_HashTable.md" />
     <None Include="..\..\Modules.Library\Dmf_IoctlHandler.md" />
     <None Include="..\..\Modules.Library\Dmf_RingBuffer.md" />
+    <None Include="..\..\Modules.Library\Dmf_SpiTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_Stack.md" />
     <None Include="..\..\Modules.Library\Dmf_String.md" />
     <None Include="..\..\Modules.Library\Dmf_AlertableSleep.md" />

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
@@ -96,8 +96,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)'  == ''">..\..\Framework\DmfTrace.h</WppScanConfigurationData>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <CompileAs>CompileAsCpp</CompileAs>
       <ShowIncludes>false</ShowIncludes>

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
@@ -243,6 +243,12 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_Doorbell.h">
       <Filter>Headers\Modules\Task Execution</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_SpiTarget.h">
+      <Filter>Headers\Modules\Targets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_GpioTarget.h">
+      <Filter>Headers\Modules\Targets</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Modules.Library\Dmf_CmApi.c">
@@ -365,6 +371,12 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_Doorbell.c">
       <Filter>Modules\Task Execution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_GpioTarget.c">
+      <Filter>Modules\Targets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_SpiTarget.c">
+      <Filter>Modules\Targets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\Modules.Library\Dmf_SymbolicLinkTarget.md">
@@ -482,6 +494,13 @@
     </None>
     <None Include="..\..\Modules.Library\Dmf_Doorbell.md">
       <Filter>Documentation\Modules\Task Execution</Filter>
+    </None>
+    <None Include="..\..\Modules.Library\Dmf_Stack.md" />
+    <None Include="..\..\Modules.Library\Dmf_GpioTarget.md">
+      <Filter>Headers\Modules\Targets</Filter>
+    </None>
+    <None Include="..\..\Modules.Library\Dmf_SpiTarget.md">
+      <Filter>Headers\Modules\Targets</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/Dmf/Solution/DmfUModules.Template/DmfUModules.Template.vcxproj
+++ b/Dmf/Solution/DmfUModules.Template/DmfUModules.Template.vcxproj
@@ -69,8 +69,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)'  == ''">..\..\Framework\DmfTrace.h</WppScanConfigurationData>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions);DMF_USER_MODE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <CompileAs>CompileAsCpp</CompileAs>
       <ShowIncludes>false</ShowIncludes>


### PR DESCRIPTION
Merge20211111
1. Update DMF_UdeClient to correct issues with Manual dispatch type endpoints.
2. Correct bug in DMF_DeviceInterfaceTarget when device interface is disabled. Also, update unit tests to test disable/enable of device interface targets.
3. Add DMF_GpioTarget and DMF_SpiTarget to User-mode Library (they are already in Kernel-mode Library).
4. DMF_USER_MODE is now automatically defined based on UMDF settings. Thus, it is no longer necessary for Client User-mode drivers to define DMF_USER_MODE as it was in the past. 