### PR TITLE
Merge202111206:

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.108
+// DMF Release: v1.1.109
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -217,9 +217,9 @@ Function)](#section-11-public-calls-by-client-includes-module-create-function)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_MODULE_DESCRIPTOR 111](#dmf_module_descriptor)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_ENTRYPOINTS_DMF 113](#dmf_entrypoints_dmf)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CALLBACKS_DMF 113](#dmf_entrypoints_dmf)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_ENTRYPOINTS_WDF 114](#dmf_entrypoints_wdf)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CALLBACKS_WDF 114](#dmf_entrypoints_wdf)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Module WDF Callbacks 116](#module-wdf-callbacks)
 
@@ -305,9 +305,9 @@ Function)](#section-11-public-calls-by-client-includes-module-create-function)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DECLARE_DMF_MODULE_NO_CONFIG](#declare_dmf_module_no_config)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_ENTRYPOINTS_DMF_INIT 164](#dmf_entrypoints_dmf_init)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CALLBACKS_DMF_INIT 164](#dmf_entrypoints_dmf_init)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_ENTRYPOINTS_WDF_INIT 165](#dmf_entrypoints_wdf_init)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CALLBACKS_WDF_INIT 165](#dmf_entrypoints_wdf_init)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_MODULE_DESCRIPTOR_INIT 166](#dmf_module_descriptor_init)
 
@@ -4163,17 +4163,17 @@ specifically for the Module: DMF_MODULE_DESCRIPTOR_INIT()
   **TransportMethod**         | Indicates the Module's Transport Method. When this member is set, the Module may be instantiated by a Client as a Transport Module.
   **InFlightRecorderSize**    | Indicates the size of the Module's custom IFR buffer if set to a non-zero value. By default, IFR traces will go to a common buffer for all Modules if this value is zero.
 
-### DMF_ENTRYPOINTS_DMF
+### DMF_CALLBACKS_DMF
 
 This structure contains all the DMF specific callbacks the Module
 supports.
 
 Always use this function to initialize the structure before updating it
-specifically for the Module: DMF_ENTRYPOINTS_DMF_INIT()
+specifically for the Module: DMF_CALLBACKS_DMF_INIT()
 
   **Member**                        | **Description**
   ----------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  **Size**                          | Indicates the size of this structure. It is initialized by **DMF_ENTRYPOINTS_DMF_INIT()**.
+  **Size**                          | Indicates the size of this structure. It is initialized by **DMF_CALLBACKS_DMF_INIT()**.
   **ModuleInstanceDestroy**         | The callback function that is called when the Module is destroyed. Generally, it is not necessary for a Module to support this callback. In some rare cases, if an allocation or some resource is acquired in the Module's Create function, then this callback can be used to release that allocation or resource.
   **DeviceResourcesAssign**         | DMF calls this callback to allow the Module to retrieve the Client's Driver's resources.
   **DeviceNotificationRegister**    | DMF calls this callback to allow the Module to register for notification of an event that will tell the Module its required dependencies are available or not available.
@@ -4182,17 +4182,17 @@ specifically for the Module: DMF_ENTRYPOINTS_DMF_INIT()
   **DeviceClose**                   | DMF calls this callback to close the Module. Generally speaking, the Module uses this callback to do the inverse of what it did in the **DeviceOpen** callback.
   **ChildModulesAdd**               | DMF calls this callback so that the Module can tell DMF about the Child Module(s) it needs to create.
 
-### DMF_ENTRYPOINTS_WDF
+### DMF_CALLBACKS_WDF
 
 This structure contains all the WDF specific callbacks the Module
 supports.
 
 Always use this function to initialize the structure before updating it
-specifically for the Module: DMF_ENTRYPOINTS_WDF_INIT()
+specifically for the Module: DMF_CALLBACKS_WDF_INIT()
 
   **Member**                              | **Description**
   ----------------------------------------| -----------------------------------------------------------------------------------------------
-  **Size**                                | Indicates the size of this structure. It is initialized by **DMF_ENTRYPOINTS_WDF_INIT()**.
+  **Size**                                | Indicates the size of this structure. It is initialized by **DMF_CALLBACKS_WDF_INIT()**.
   **ModulePrepareHardware**               | Routes **EvtDevicePrepareHardware** to the Module. (WDFDEVICE)
   **ModuleReleaseHardware**               | Routes **EvtDeviceReleaseHardware** to the Module. (WDFDEVICE)
   **ModuleD0Entry**                       | Routes **EvtDeviceD0Entry** to the Module. (WDFDEVICE)
@@ -6052,14 +6052,14 @@ None
 
 -   If a Module has a Config, use **DECLARE_DMF_MODULE()** instead.
 
-### DMF_ENTRYPOINTS_DMF_INIT
+### DMF_CALLBACKS_DMF_INIT
 ```
 VOID
-DMF_ENTRYPOINTS_DMF_INIT(
+DMF_CALLBACKS_DMF_INIT(
     _Out_ PDMF_ENTRYPOINTS_DMF EntryPointsDmf
     )
 ```
-This function initializes a **DMF_ENTRYPOINTS_DMF** structure.
+This function initializes a **DMF_CALLBACKS_DMF** structure.
 
 #### Parameters
   Parameter | Description
@@ -6078,14 +6078,14 @@ None
 -   After initializing this structure, set the DMF callbacks the Module
     supports.
 
-### DMF_ENTRYPOINTS_WDF_INIT
+### DMF_CALLBACKS_WDF_INIT
 ```
 VOID
-DMF_ENTRYPOINTS_WDF_INIT(
+DMF_CALLBACKS_WDF_INIT(
     _Out_ PDMF_ENTRYPOINTS_WDF EntryPointsWdf
     )
 ```
-This function initializes a **DMF_ENTRYPOINTS_WDF** structure.
+This function initializes a **DMF_CALLBACKS_WDF** structure.
 
 #### Parameters
   Parameter | Description
@@ -7846,8 +7846,8 @@ Modules.
   ----------------------------------------      |  -----------------------------------------------------------------------------------------------------------------------------
   **[DECLARE_DMF_MODULE]**                      |  Modules use this macro in the Module's .h file to define the name of the Module as well as functions associated with the Module. Use this macro only if the Module **has** a Module Config structure that Clients use to configure the Module.
   **[DECLARE_DMF_MODULE_NO_CONFIG]**            |  Modules use this macro in the Module's .h file to define the name of the Module as well as functions associated with the Module. Use this macro only if the Module **does not have** a Module Config structure that Clients use to configure the Module
-  **DMF_ENTRYPOINTS_DMF_INIT**                  |  Modules use this macro to declare what DMF callbacks the Module supports, if any. If the Module does not support DMF callbacks this call is not necessary.
-  **DMF_ENTRYPOINTS_WDF_INIT**                  |  Modules use this macro to declare what WDF callbacks the Module supports, if any. If the Module does not support WDF callbacks this call is not necessary.
+  **DMF_CALLBACKS_DMF_INIT**                  |  Modules use this macro to declare what DMF callbacks the Module supports, if any. If the Module does not support DMF callbacks this call is not necessary.
+  **DMF_CALLBACKS_WDF_INIT**                  |  Modules use this macro to declare what WDF callbacks the Module supports, if any. If the Module does not support WDF callbacks this call is not necessary.
   **[DMF_MODULE_DESCRIPTOR_INIT]**              |  Modules use this macro to initialize the Module's descriptor, **DMF_MODULE_DESCRIPTOR**. Only Modules that **have no contex**t use this call.
   **[DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE]** |  Modules use this macro to initialize the Module's descriptor, **DMF_MODULE_DESCRIPTOR**. Only Modules that **have a context** use this call.
   **DMF_CONFIG_GET**                            |  Modules use this function to retrieve the Module's Config information set by the Client.

--- a/Dmf/Framework/DmfGeneric.c
+++ b/Dmf/Framework/DmfGeneric.c
@@ -352,7 +352,7 @@ Return Value:
 
     // This is needed for cases where Module Opens, Close and Opens again.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
@@ -476,7 +476,7 @@ Return Value:
 
     // NOTE: Client Drivers have the option of closing modules at any time.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     // NOTE: This code is not totally symmetrical with DMF_Generic_ModulePrepareHardware because there is
     //       no corresponding DMF_Module_ResourcesAssign on the way down.
@@ -566,7 +566,7 @@ Return Value:
 
     // NOTE: Modules can be closed in D0Exit.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     device = DMF_ParentDeviceGet(DmfModule);
 
@@ -697,7 +697,7 @@ Return Value:
 
     // NOTE: Modules can be closed in D0Exit.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     ntStatus = STATUS_SUCCESS;
 
@@ -739,7 +739,7 @@ Return Value:
 
     // NOTE: Client Drivers have the option of closing modules at any time.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     ntStatus = STATUS_SUCCESS;
 
@@ -789,7 +789,7 @@ Return Value:
 
     // NOTE: Client Drivers have the option of closing modules at any time.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     device = DMF_ParentDeviceGet(DmfModule);
 
@@ -879,7 +879,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     // Tell Client Driver this dispatch is still unhandled.
     //
@@ -932,7 +932,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     // Tell Client Driver this dispatch is still unhandled.
     //
@@ -1001,7 +1001,7 @@ Return Value:
     //
     if (dmfDeviceContext->IsFilterDevice == FALSE)
     {
-        DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+        DMF_HandleValidate_IsAvailable(dmfObject);
     }
 
     // Tell Client Driver this dispatch is still unhandled.
@@ -1106,7 +1106,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 }
@@ -1146,7 +1146,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 }
@@ -1190,7 +1190,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 
@@ -1233,7 +1233,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 
@@ -1275,7 +1275,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 
@@ -1313,7 +1313,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 }
@@ -1356,7 +1356,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 
@@ -1449,7 +1449,7 @@ Return Value:
     // It is possible for a Module to be created but not open if the Module uses a
     // notification to open but the notification has not happened yet.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 }
@@ -1961,7 +1961,7 @@ Return Value:
 
     // This is needed for cases where Module Opens, Close and Opens again.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     // This is called during PrepareHardware when the flag is used.
     //
@@ -2010,7 +2010,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s]", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s] ntStatus=%!STATUS!", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName, STATUS_SUCCESS);
 
@@ -2051,7 +2051,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p dmfObject=0x%p [%s]", DmfModule, dmfObject, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s]", dmfObject, dmfObject->ClientModuleInstanceName);
 }

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -628,11 +628,6 @@ DMF_HandleValidate_IsCreatedOrClosed(
     );
 
 VOID
-DMF_HandleValidate_IsCreatedOrOpenedOrClosed(
-    _In_ DMF_OBJECT* DmfObject
-    );
-
-VOID
 DMF_HandleValidate_IsAvailable(
     _In_ DMF_OBJECT* DmfObject
     );

--- a/Dmf/Framework/DmfIncludes_USER_MODE.h
+++ b/Dmf/Framework/DmfIncludes_USER_MODE.h
@@ -137,6 +137,7 @@ Environment:
 #include <ndisguid.h>
 #include <strsafe.h>
 #include <ndisguid.h>
+#include <errno.h>
 
 // Turn this on to debug asserts in UMDF.
 // Normal assert() causes a crash in UMDF which causes UMDF to just disable the driver

--- a/Dmf/Framework/DmfInternal.c
+++ b/Dmf/Framework/DmfInternal.c
@@ -154,7 +154,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleReleaseHardware != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleReleaseHardware)(DmfModule,
@@ -286,7 +286,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleD0ExitPreInterruptsDisabled != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleD0ExitPreInterruptsDisabled)(DmfModule,
@@ -329,7 +329,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksWdf->ModuleD0Exit != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksWdf->ModuleD0Exit)(DmfModule,
@@ -1385,7 +1385,7 @@ Return Value:
     // NOTE: In the case where there is no handler, allow "Opened".
     // NOTE: In the cases where Modules are Opened, Closed and Opened again, allow "Closed" state.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksDmf->DeviceResourcesAssign != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksDmf->DeviceResourcesAssign)(DmfModule,
@@ -1432,7 +1432,7 @@ Return Value:
 
     // NOTE: In the cases where Modules are Opened, Closed and Opened again, allow "Closed" state.
     //
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationRegister != NULL);
     ntStatus = (dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationRegister)(DmfModule);
@@ -1479,7 +1479,7 @@ Return Value:
 
     FuncEntryArguments(DMF_TRACE, "DmfModule=0x%p [%s]", DmfModule, dmfObject->ClientModuleInstanceName);
 
-    DMF_HandleValidate_IsCreatedOrOpenedOrClosed(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     DmfAssert(dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationUnregister != NULL);
     (dmfObject->ModuleDescriptor.CallbacksDmf->DeviceNotificationUnregister)(DmfModule);

--- a/Dmf/Framework/DmfTrace.h
+++ b/Dmf/Framework/DmfTrace.h
@@ -69,6 +69,10 @@ Environment:
 // USEPREFIX(TraceInformation, "%!STDPREFIX! [%!FUNC!] ");
 // USEPREFIX(TraceVerbose, "%!STDPREFIX! [%!FUNC!] ");
 // USEPREFIX(FuncExitNoReturn, "%!STDPREFIX! [%!FUNC!] <--");
+// CUSTOM_TYPE(SMFX_MACHINE_EXCEPTION, ItemEnum(StateMachine_MachineException));
+// CUSTOM_TYPE(SMFX_TRANSITION_TYPE, ItemEnum(StateMachine_TransitionType));
+// CUSTOM_TYPE(COMPONENT_FIRMWARE_UPDATE_V2_EVENT, ItemEnum(ComponentFirmwareUpdateV2EventId));
+// CUSTOM_TYPE(COMPONENT_FIRMWARE_UPDATE_V2_STATE, ItemEnum(ComponentFirmwareUpdateV2StateId));
 // end_wpp
 
 #if !defined(DMF_WDF_DRIVER)

--- a/Dmf/Framework/DmfValidate.c
+++ b/Dmf/Framework/DmfValidate.c
@@ -469,37 +469,6 @@ Return Value:
 }
 
 VOID
-DMF_HandleValidate_IsCreatedOrOpenedOrClosed(
-    _In_ DMF_OBJECT* DmfObject
-    )
-/*++
-
-Routine Description:
-
-    Verifies that a DMF_OBJECT Module State is Created, Opened or Closed.
-
-    NOTE: This call is only meant for debug purposes.
-
-Arguments:
-
-    DmfObject - The DMF Object to validate.
-
-Return Value:
-
-    None. Failure causes an assert to trigger.
-
---*/
-{
-    UNREFERENCED_PARAMETER(DmfObject);
-
-    DmfAssert(DmfObject != NULL);
-    DmfAssert(DMF_OBJECT_SIGNATURE == DmfObject->Signature);
-    DmfAssert((ModuleState_Created == DmfObject->ModuleState) ||
-              (ModuleState_Opened == DmfObject->ModuleState) ||
-              (ModuleState_Closed == DmfObject->ModuleState));
-}
-
-VOID
 DMF_HandleValidate_IsAvailable(
     _In_ DMF_OBJECT* DmfObject
     )

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferPool.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferPool.c
@@ -590,24 +590,29 @@ Tests_BufferPool_WorkThread(
     {
     case TEST_ACTION_AQUIRE:
         ntStatus = Tests_BufferPool_ThreadAction_BufferAquire(dmfModule);
+        // It can fail if device will be removed.
+        //
         break;
     case TEST_ACTION_RETURN:
         ntStatus = Tests_BufferPool_ThreadAction_BufferReturn(dmfModule);
+        DmfAssert(NT_SUCCESS(ntStatus) ||
+                  DMF_Thread_IsStopPending(DmfModuleThread));
         break;
     case TEST_ACTION_ENUMERATE:
         ntStatus = Tests_BufferPool_ThreadAction_BufferEnumerate(dmfModule);
+        DmfAssert(NT_SUCCESS(ntStatus) ||
+                  DMF_Thread_IsStopPending(DmfModuleThread));
         break;
     case TEST_ACTION_COUNT:
         ntStatus = Tests_BufferPool_ThreadAction_BufferCount(dmfModule);
+        DmfAssert(NT_SUCCESS(ntStatus) ||
+                  DMF_Thread_IsStopPending(DmfModuleThread));
         break;
     default:
         ntStatus = STATUS_UNSUCCESSFUL;
         DmfAssert(FALSE);
         break;
     }
-
-    DmfAssert(NT_SUCCESS(ntStatus) ||
-              DMF_Thread_IsStopPending(DmfModuleThread));
 
     // Repeat the test, until stop is signaled.
     //

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_BufferQueue.c
@@ -242,23 +242,25 @@ Tests_BufferQueue_ThreadAction_EnqueueAtHead(
     ntStatus = DMF_BufferQueue_Fetch(moduleContext->DmfModuleBufferQueue,
                                      (PVOID*)&clientBuffer,
                                      (PVOID*)&clientBufferContext);
-    DmfAssert(NT_SUCCESS(ntStatus));
-    DmfAssert(clientBuffer != NULL);
-    DmfAssert(clientBufferContext != NULL);
+    if (NT_SUCCESS(ntStatus))
+    {
+        DmfAssert(clientBuffer != NULL);
+        DmfAssert(clientBufferContext != NULL);
 
-    // Populate the buffer with test data.
-    //
-    TestsUtility_FillWithSequentialData(clientBuffer,
-                                        BUFFER_SIZE);
+        // Populate the buffer with test data.
+        //
+        TestsUtility_FillWithSequentialData(clientBuffer,
+                                            BUFFER_SIZE);
 
-    clientBufferContext->Signature = CLIENT_CONTEXT_SIGNATURE;
-    clientBufferContext->CheckSum = TestsUtility_CrcCompute(clientBuffer,
-                                                            BUFFER_SIZE);
+        clientBufferContext->Signature = CLIENT_CONTEXT_SIGNATURE;
+        clientBufferContext->CheckSum = TestsUtility_CrcCompute(clientBuffer,
+                                                                BUFFER_SIZE);
 
-    // Add this buffer to the queue.
-    //
-    DMF_BufferQueue_EnqueueAtHead(moduleContext->DmfModuleBufferQueue,
-                                  clientBuffer);
+        // Add this buffer to the queue.
+        //
+        DMF_BufferQueue_EnqueueAtHead(moduleContext->DmfModuleBufferQueue,
+                                      clientBuffer);
+    }
 
 Exit:
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -264,7 +264,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(
                                                            IOCTL_Tests_IoctlHandler_SLEEP,
                                                            timeoutMs,
                                                            &bytesWritten);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     // TODO: Get time and compare with send time.
     //
 
@@ -289,7 +292,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Synchronous(
                                                            IOCTL_Tests_IoctlHandler_SLEEP,
                                                            timeoutMs,
                                                            &bytesWritten);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     // TODO: Get time and compare with send time.
     //
 }
@@ -395,7 +401,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     RtlZeroMemory(sleepIoctlBuffer,
                   sizeof(Tests_IoctlHandler_Sleep));
@@ -428,12 +437,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Asynchronous(
                                               timeoutMs,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
-
-    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
-                                  (VOID**)&sleepIoctlBuffer,
-                                  NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
 
     // Reduce traffic to reduce CPU usage and make debugging easier.
     //
@@ -478,7 +485,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(MINIMUM_SLEEP_TIME_MS, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -500,7 +510,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                                 moduleContext,
                                                 &DmfRequestId);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -536,7 +549,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -555,7 +571,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                                 moduleContext,
                                                 &DmfRequestId);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -578,14 +597,6 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
         //
         goto Exit;
     }
-
-    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                MAXIMUM_SLEEP_TIME_MS);
-
-    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
-                                  (VOID**)&sleepIoctlBuffer,
-                                  NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
 
     /////////////////////////////////////////////////////////////////////////////////////
     // Cancel the request after waiting the same time sent in timeout. 
@@ -595,7 +606,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
                                                                 MAXIMUM_SLEEP_TIME_MS);
@@ -614,7 +628,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                                 moduleContext,
                                                 &DmfRequestId);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -636,25 +653,20 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
         goto Exit;
     }
 
-    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                MAXIMUM_SLEEP_TIME_MS);
-
-    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
-                                  (VOID**)&sleepIoctlBuffer,
-                                  NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
-
     /////////////////////////////////////////////////////////////////////////////////////
     // Cancel the request immediately after sending it. It may or may not be canceled.
     //
 
-    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                MAXIMUM_SLEEP_TIME_MS);
-
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
 
     sleepIoctlBuffer->TimeToSleepMilliseconds = timeToSleepMilliseconds;
     bytesWritten = 0;
@@ -670,7 +682,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                                 moduleContext,
                                                 &DmfRequestId);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -681,25 +696,20 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
     requestCanceled = DMF_DeviceInterfaceTarget_Cancel(DmfModuleDeviceInterfaceTarget,
                                                        DmfRequestId);
 
-    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(0, 
-                                                                MAXIMUM_SLEEP_TIME_MS);
-
-    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
-                                  (VOID**)&sleepIoctlBuffer,
-                                  NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
-
     /////////////////////////////////////////////////////////////////////////////////////
     // Cancel the request before it is normally completed. It should always cancel.
     //
 
-    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(MINIMUM_SLEEP_TIME_MS, 
-                                                                MAXIMUM_SLEEP_TIME_MS);
-
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    timeToSleepMilliseconds = TestsUtility_GenerateRandomNumber(MINIMUM_SLEEP_TIME_MS, 
+                                                                MAXIMUM_SLEEP_TIME_MS);
 
     sleepIoctlBuffer->TimeToSleepMilliseconds = timeToSleepMilliseconds;
     bytesWritten = 0;
@@ -715,7 +725,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_AsynchronousCancel(
                                                 moduleContext,
                                                 &DmfRequestId);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -773,6 +786,7 @@ Tests_DeviceInterfaceTarget_ThreadAction_Dynamic(
     // Create a parent object for the Module Under Test.
     // Size does not matter because it is just used for parent object.
     //
+    memory = NULL;
     WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
     objectAttributes.ParentObject = DmfModule;
     ntStatus = WdfMemoryCreate(&objectAttributes,
@@ -789,7 +803,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Dynamic(
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
                                   (VOID**)&sleepIoctlBuffer,
                                   NULL);
-    DmfAssert(NT_SUCCESS(ntStatus));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
 
     RtlZeroMemory(sleepIoctlBuffer,
                   sizeof(Tests_IoctlHandler_Sleep));
@@ -839,8 +856,6 @@ Tests_DeviceInterfaceTarget_ThreadAction_Dynamic(
                                                 &moduleAttributes,
                                                 &objectAttributes,
                                                 &dynamicDeviceInterfaceTarget);
-
-    DmfAssert(NT_SUCCESS(ntStatus));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -869,7 +884,10 @@ Tests_DeviceInterfaceTarget_ThreadAction_Dynamic(
                                               timeoutMs,
                                               Tests_DeviceInterfaceTarget_SendCompletion,
                                               moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) ||
+              (ntStatus == STATUS_CANCELLED) ||
+              (ntStatus == STATUS_INVALID_DEVICE_STATE) ||
+              (ntStatus == STATUS_DELETE_PENDING));
 
     timeToWaitMs = TestsUtility_GenerateRandomNumber(0, 
                                                      MAXIMUM_SLEEP_TIME_MS);
@@ -880,12 +898,14 @@ Tests_DeviceInterfaceTarget_ThreadAction_Dynamic(
                                         0,
                                         timeToWaitMs);
 
-    // Delete the Dynamic Module by deleting its parent to execute the hardest path.
-    //
-    WdfObjectDelete(memory);
-
 Exit:
-    ;
+
+    if (memory != NULL)
+    {
+        // Delete the Dynamic Module by deleting its parent to execute the hardest path.
+        //
+        WdfObjectDelete(memory);
+    }
 }
 #pragma code_seg()
 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -198,8 +198,8 @@ Tests_DeviceInterfaceTarget_BufferOutput(
         CompletionStatus != STATUS_INVALID_DEVICE_STATE)
     {
         // Request can be completed with InformationSize of 0 by framework.
+        // This can happen during suspend/resume of machine.
         //
-        DmfAssert(FALSE);
     }
     if (NT_SUCCESS(CompletionStatus))
     {
@@ -1509,16 +1509,30 @@ Return Value:
 --*/
 {
     DMFMODULE dmfModuleParent;
+    NTSTATUS ntStatus;
+    WDFIOTARGET ioTarget;
 
     PAGED_CODE();
 
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
 
-    WDFIOTARGET ioTarget;
-    DMF_DeviceInterfaceTarget_Get(DmfModule,
-                                  &ioTarget);
-    WdfIoTargetPurge(ioTarget,
-                     WdfIoTargetPurgeIoAndWait);
+    ntStatus = DMF_ModuleReference(DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = DMF_DeviceInterfaceTarget_Get(DmfModule,
+                                             &ioTarget);
+    if (NT_SUCCESS(ntStatus))
+    {
+        WdfIoTargetPurge(ioTarget,
+                         WdfIoTargetPurgeIoAndWait);
+    }
+
+    DMF_ModuleDereference(DmfModule);
+
+Exit:
 
     // Stop the threads. Streaming is automatically stopped.
     //
@@ -1685,6 +1699,7 @@ Return Value:
 --*/
 {
     DMFMODULE dmfModuleParent;
+    NTSTATUS ntStatus;
 
     PAGED_CODE();
 
@@ -1692,10 +1707,25 @@ Return Value:
 
 #if !defined(TEST_SIMPLE)
     WDFIOTARGET ioTarget;
-    DMF_DeviceInterfaceTarget_Get(DmfModule,
-                                  &ioTarget);
-    WdfIoTargetPurge(ioTarget,
-                     WdfIoTargetPurgeIoAndWait);
+
+    ntStatus = DMF_ModuleReference(DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = DMF_DeviceInterfaceTarget_Get(DmfModule,
+                                             &ioTarget);
+    if (NT_SUCCESS(ntStatus))
+    {
+        WdfIoTargetPurge(ioTarget,
+                         WdfIoTargetPurgeIoAndWait);
+    }
+
+    DMF_ModuleDereference(DmfModule);
+
+Exit:
+
     // Stop streaming.
     //
     DMF_DeviceInterfaceTarget_StreamStop(DmfModule);
@@ -1732,16 +1762,30 @@ Return Value:
 --*/
 {
     DMFMODULE dmfModuleParent;
+    NTSTATUS ntStatus;
+    WDFIOTARGET ioTarget;
 
     PAGED_CODE();
 
     dmfModuleParent = DMF_ParentModuleGet(DmfModule);
 
-    WDFIOTARGET ioTarget;
-    DMF_DeviceInterfaceTarget_Get(DmfModule,
-                                  &ioTarget);
-    WdfIoTargetPurge(ioTarget,
-                     WdfIoTargetPurgeIoAndWait);
+    ntStatus = DMF_ModuleReference(DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    ntStatus = DMF_DeviceInterfaceTarget_Get(DmfModule,
+                                             &ioTarget);
+    if (NT_SUCCESS(ntStatus))
+    {
+        WdfIoTargetPurge(ioTarget,
+                         WdfIoTargetPurgeIoAndWait);
+    }
+
+    DMF_ModuleDereference(DmfModule);
+
+Exit:
 
     // Stop streaming.
     //

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
@@ -43,7 +43,10 @@ Environment:
 #define PDO_ENABLE_KERNELMODE
 #define PDO_ENABLE_USERMODE
 
-// Remove PDOs slowly or fast only.
+#define NO_FAST_REMOVE
+#if defined(FAST_REMOVE)
+
+// Remove PDOs slowly.
 //
 #define PDO_SLOW_TIMEOUT_ONLY
 #define NO_PDO_FAST_TIMEOUT_ONLY
@@ -51,6 +54,19 @@ Environment:
 #define MINIMUM_PDO_TIMEOUT_SECONDS     (5)
 #define FAST_PDO_TIMEOUT_SECONDS        (60)
 #define SLOW_PDO_TIMEOUT_SECONDS        (3600)  // 60 minutes for PnPDTest
+
+#else
+
+// Remove PDOs fast.
+//
+#define NO_PDO_SLOW_TIMEOUT_ONLY
+#define PDO_FAST_TIMEOUT_ONLY
+
+#define MINIMUM_PDO_TIMEOUT_SECONDS     (5)
+#define FAST_PDO_TIMEOUT_SECONDS        (30)
+#define SLOW_PDO_TIMEOUT_SECONDS        (3600)
+
+#endif
 
 typedef enum _TEST_ACTION
 {

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_Pdo.c
@@ -44,7 +44,7 @@ Environment:
 #define PDO_ENABLE_USERMODE
 
 #define NO_FAST_REMOVE
-#if defined(FAST_REMOVE)
+#if !defined(FAST_REMOVE)
 
 // Remove PDOs slowly.
 //

--- a/Dmf/Modules.Library/Dmf_AcpiTarget.c
+++ b/Dmf/Modules.Library/Dmf_AcpiTarget.c
@@ -127,6 +127,7 @@ Return Value:
         parametersBufferSize += (FunctionCustomArgumentsBufferSize - sizeof(ULONG));
     }
 
+    #pragma warning( suppress : 4996 )
     parametersBuffer = (ACPI_EVAL_INPUT_BUFFER_COMPLEX*)ExAllocatePoolWithTag(PagedPool,
                                                                               parametersBufferSize,
                                                                               MemoryTag);
@@ -340,6 +341,7 @@ Return Value:
 
     do
     {
+        #pragma warning( suppress : 4996 )
         outputBuffer = (PACPI_EVAL_OUTPUT_BUFFER)ExAllocatePoolWithTag(PagedPool,
                                                                        outputBufferLength,
                                                                        Tag);

--- a/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
+++ b/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
@@ -1474,7 +1474,7 @@ Return Value:
 
 Exit:
 
-    FuncExit(DMF_TRACE, ntStatus="%!STATUS!", ntStatus);
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
 
     return ntStatus;
 }
@@ -1551,7 +1551,7 @@ Return Value:
 
 Exit:
 
-    FuncExit(DMF_TRACE, ntStatus="%!STATUS!", ntStatus);
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
 
     return ntStatus;
 }

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.h
@@ -277,12 +277,6 @@ DMF_ContinuousRequestTarget_Start(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
-DMF_ContinuousRequestTarget_Stop(
-    _In_ DMFMODULE DmfModule
-    );
-
-_IRQL_requires_max_(PASSIVE_LEVEL)
-VOID
 DMF_ContinuousRequestTarget_StopAndWait(
     _In_ DMFMODULE DmfModule
     );

--- a/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
+++ b/Dmf/Modules.Library/Dmf_ContinuousRequestTarget.md
@@ -555,31 +555,6 @@ DmfModule | An open DMF_ContinuousRequestTarget Module handle.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
-##### DMF_ContinuousRequestTarget_Stop
-
-````
-_IRQL_requires_max_(DISPATCH_LEVEL)
-VOID
-DMF_ContinuousRequestTarget_Stop(
-  _In_ DMFMODULE DmfModule
-  );
-````
-
-Stops streaming. The pending requests are canceled and no new Requests will be sent to the underlying WDFIOTARGET.
-
-##### Returns
-
-None
-
-##### Parameters
-Parameter | Description
-----|----
-DmfModule | An open DMF_ContinuousRequestTarget Module handle.
-
-##### Remarks
-
------------------------------------------------------------------------------------------------------------------------------------
-
 ##### DMF_ContinuousRequestTarget_StopAndWait
 
 ````

--- a/Dmf/Modules.Library/Dmf_CrashDump.c
+++ b/Dmf/Modules.Library/Dmf_CrashDump.c
@@ -3334,6 +3334,7 @@ Return Value:
 
     // Allocate space for the Data Sources.
     //
+    #pragma warning( suppress : 4996 )
     moduleContext->DataSource = (DATA_SOURCE *)ExAllocatePoolWithTag(NonPagedPoolNx,
                                                                      sizeof(DATA_SOURCE) * moduleContext->DataSourceCount,
                                                                      MemoryTag);
@@ -3349,6 +3350,7 @@ Return Value:
 
     // Allocate space for the Bug Check Callback Records.
     //
+    #pragma warning( suppress : 4996 )
     moduleContext->BugCheckCallbackRecordRingBuffer = (KBUGCHECK_REASON_CALLBACK_RECORD *)ExAllocatePoolWithTag(NonPagedPoolNx,
                                                                                                           sizeof(KBUGCHECK_REASON_CALLBACK_RECORD) * moduleContext->DataSourceCount,
                                                                                                           MemoryTag);

--- a/Dmf/Modules.Library/Dmf_File.h
+++ b/Dmf/Modules.Library/Dmf_File.h
@@ -57,5 +57,13 @@ DMF_File_ReadEx(
     _Out_opt_ size_t* BufferLength
     );
 
+_Must_inspect_result_
+NTSTATUS
+DMF_File_Write(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFSTRING FileName,
+    _In_ WDFMEMORY FileContentMemory
+    );
+
 // eof: Dmf_File.h
 //

--- a/Dmf/Modules.Library/Dmf_File.md
+++ b/Dmf/Modules.Library/Dmf_File.md
@@ -143,6 +143,38 @@ BufferLength | Optional pointer to the length of the read data.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_DMF_File_Write
+
+````
+_Must_inspect_result_
+NTSTATUS
+DMF_File_Write(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFSTRING FileName,
+    _In_ WDFMEMORY FileContentMemory
+    );
+````
+
+    Writes the contents of a wdf memory to a file.
+    This function will try to create the file if it doesn't exists and overwrite current file.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_File Module handle.
+FileName  | Name of the file.
+FileContentMemory | Buffer handle of buffer holding data to write.
+
+##### Remarks
+
+*
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
 #### Module Children
 
 * None

--- a/Dmf/Modules.Library/Dmf_HidPortableDeviceButtons.c
+++ b/Dmf/Modules.Library/Dmf_HidPortableDeviceButtons.c
@@ -264,26 +264,6 @@ g_HidPortableDeviceButtons_HidReportDescriptor[] =
     0xC0                             // END_COLLECTION
 };
 
-// HID Device Descriptor with just one report representing the Portable Device Buttons.
-//
-static
-const
-HID_DESCRIPTOR
-g_HidPortableDeviceButtons_HidDescriptor =
-{
-    0x09,     // Length of HID descriptor
-    0x21,     // Descriptor type == HID  0x21
-    0x0100,   // HID spec release
-    0x00,     // Country code == English
-    0x01,     // Number of HID class descriptors
-    {
-        0x22,   // Descriptor type
-        // Total length of report descriptor.
-        //
-        (USHORT) sizeof(g_HidPortableDeviceButtons_HidReportDescriptor)
-    }
-};
-
 _Function_class_(EVT_VHF_ASYNC_OPERATION)
 VOID
 HidPortableDeviceButtons_GetFeature(
@@ -742,8 +722,6 @@ Return Value:
     virtualHidDeviceMsModuleConfig.ProductId = moduleConfig->ProductId;
     virtualHidDeviceMsModuleConfig.VersionNumber = 0x0001;
 
-    virtualHidDeviceMsModuleConfig.HidDescriptor = &g_HidPortableDeviceButtons_HidDescriptor;
-    virtualHidDeviceMsModuleConfig.HidDescriptorLength = sizeof(g_HidPortableDeviceButtons_HidDescriptor);
     virtualHidDeviceMsModuleConfig.HidReportDescriptor = g_HidPortableDeviceButtons_HidReportDescriptor;
     virtualHidDeviceMsModuleConfig.HidReportDescriptorLength = sizeof(g_HidPortableDeviceButtons_HidReportDescriptor);
 

--- a/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
+++ b/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
@@ -59,6 +59,19 @@ typedef struct
     USHORT ChannelInstance;
 } SMFSOCPLUGIN_CAPABILITIES;
 
+// Redefined here temporarily.
+//
+typedef struct
+{
+    // This flag identifies if the data in the structure is valid. This is needed as all physical channels of
+    // a single interface driver share same IRPs.
+    //
+    BOOLEAN IsValid;
+    // Data value.
+    //
+    INT32 DataValue;
+} SMFSOCPLUGIN_DATA;
+
 // Enumeration used to expose Sensor Channels to SMF.
 // Only one channel - SmfSoCSensorChannelCpuTemperatureAverageId -  is used for control, the others are optional and only for reporting.
 //

--- a/Dmf/Modules.Library/Dmf_Registry.c
+++ b/Dmf/Modules.Library/Dmf_Registry.c
@@ -1497,6 +1497,7 @@ Return Value:
 
         // Allocate a buffer for the full path name.
         //
+        #pragma warning( suppress : 4996 )
         fullPathName = (PWCHAR)ExAllocatePoolWithTag(PagedPool,
                                                      fullPathNameSize,
                                                      MemoryTag);
@@ -2063,6 +2064,7 @@ Return Value:
 
                 // Allocate a buffer for the path name.
                 //
+                #pragma warning( suppress : 4996 )
                 keyInformationBuffer = (PKEY_BASIC_INFORMATION)ExAllocatePoolWithTag(PagedPool,
                                                                                      resultLength,
                                                                                      MemoryTag);
@@ -2816,6 +2818,7 @@ Return:
     // Allocate space for the deferred operation. If it cannot be allocated an error code
     // is returned and the operation is not deferred.
     //
+    #pragma warning( suppress : 4996 )
     deferredContext = (REGISTRY_DEFERRED_CONTEXT*)ExAllocatePoolWithTag(PagedPool,
                                                                         sizeof(REGISTRY_DEFERRED_CONTEXT),
                                                                         MemoryTag);

--- a/Dmf/Modules.Library/Dmf_VirtualEyeGaze.c
+++ b/Dmf/Modules.Library/Dmf_VirtualEyeGaze.c
@@ -409,24 +409,6 @@ g_VirtualEyeGaze_HidReportDescriptor[] =
     HID_END_COLLECTION_EX()
 };
 
-// This is the default HID descriptor returned by the mini driver
-// in response to IOCTL_HID_GET_DEVICE_DESCRIPTOR. The size
-// of report descriptor is currently the size of g_DefaultReportDescriptor.
-//
-HID_DESCRIPTOR
-g_VirtualEyeGaze_HidDescriptor = 
-{
-    0x09,   // length of HID descriptor
-    0x21,   // descriptor type == HID  0x21
-    0x0100, // hid spec release
-    0x00,   // country code == Not Specified
-    0x01,   // number of HID class descriptors
-    {                                       //DescriptorList[0]
-        0x22,                               //report descriptor type 0x22
-        sizeof(g_VirtualEyeGaze_HidReportDescriptor)   //total length of report descriptor
-    }
-};
-
 _Function_class_(EVT_VHF_ASYNC_OPERATION)
 _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
@@ -687,8 +669,6 @@ Return Value:
     virtualHidDeviceVhfModuleConfig.ProductId = moduleConfig->ProductId;
     virtualHidDeviceVhfModuleConfig.VersionNumber = 0x0001;
 
-    virtualHidDeviceVhfModuleConfig.HidDescriptor = &g_VirtualEyeGaze_HidDescriptor;
-    virtualHidDeviceVhfModuleConfig.HidDescriptorLength = sizeof(g_VirtualEyeGaze_HidDescriptor);
     virtualHidDeviceVhfModuleConfig.HidReportDescriptor = g_VirtualEyeGaze_HidReportDescriptor;
     virtualHidDeviceVhfModuleConfig.HidReportDescriptorLength = sizeof(g_VirtualEyeGaze_HidReportDescriptor);
 

--- a/Dmf/Modules.Library/Dmf_VirtualHidAmbientColorSensor.c
+++ b/Dmf/Modules.Library/Dmf_VirtualHidAmbientColorSensor.c
@@ -303,26 +303,6 @@ g_VirtualHidAmbientColorSensor_HidReportDescriptor[] =
     HID_END_COLLECTION,
 };
 
-// HID Device Descriptor with just one report representing the keyboard.
-//
-static
-const
-HID_DESCRIPTOR
-g_VirtualHidAmbientColorSensor_HidDescriptor =
-{
-    0x09,     // Length of HID descriptor
-    0x21,     // Descriptor type == HID  0x21
-    0x0100,   // HID spec release
-    0x33,     // Country code == English
-    0x01,     // Number of HID class descriptors
-    {
-      0x22,   // Descriptor type
-      // Total length of report descriptor.
-      //
-      (USHORT) sizeof(g_VirtualHidAmbientColorSensor_HidReportDescriptor)
-    }
-};
-
 #include <pshpack1.h>
 typedef struct _VirtualHidAmbientColorSensor_INPUT_REPORT
 {
@@ -667,8 +647,6 @@ Return Value:
     virtualHidDeviceVhfModuleConfig.ProductId = moduleConfig->ProductId;
     virtualHidDeviceVhfModuleConfig.VersionNumber = 0x0001;
 
-    virtualHidDeviceVhfModuleConfig.HidDescriptor = &g_VirtualHidAmbientColorSensor_HidDescriptor;
-    virtualHidDeviceVhfModuleConfig.HidDescriptorLength = sizeof(g_VirtualHidAmbientColorSensor_HidDescriptor);
     virtualHidDeviceVhfModuleConfig.HidReportDescriptor = g_VirtualHidAmbientColorSensor_HidReportDescriptor;
     virtualHidDeviceVhfModuleConfig.HidReportDescriptorLength = sizeof(g_VirtualHidAmbientColorSensor_HidReportDescriptor);
 

--- a/Dmf/Modules.Library/Dmf_VirtualHidAmbientLightSensor.c
+++ b/Dmf/Modules.Library/Dmf_VirtualHidAmbientLightSensor.c
@@ -281,26 +281,6 @@ g_VirtualHidAmbientLightSensor_HidReportDescriptor[] =
     HID_END_COLLECTION,
 };
 
-// HID Device Descriptor with just one report representing the keyboard.
-//
-static
-const
-HID_DESCRIPTOR
-g_VirtualHidAmbientLightSensor_HidDescriptor =
-{
-    0x09,     // Length of HID descriptor
-    0x21,     // Descriptor type == HID  0x21
-    0x0100,   // HID spec release
-    0x33,     // Country code == English
-    0x01,     // Number of HID class descriptors
-    {
-      0x22,   // Descriptor type
-      // Total length of report descriptor.
-      //
-      (USHORT) sizeof(g_VirtualHidAmbientLightSensor_HidReportDescriptor)
-    }
-};
-
 #include <pshpack1.h>
 typedef struct _VirtualHidAmbientLightSensor_INPUT_REPORT
 {
@@ -643,8 +623,6 @@ Return Value:
     virtualHidDeviceVhfModuleConfig.ProductId = moduleConfig->ProductId;
     virtualHidDeviceVhfModuleConfig.VersionNumber = 0x0001;
 
-    virtualHidDeviceVhfModuleConfig.HidDescriptor = &g_VirtualHidAmbientLightSensor_HidDescriptor;
-    virtualHidDeviceVhfModuleConfig.HidDescriptorLength = sizeof(g_VirtualHidAmbientLightSensor_HidDescriptor);
     virtualHidDeviceVhfModuleConfig.HidReportDescriptor = g_VirtualHidAmbientLightSensor_HidReportDescriptor;
     virtualHidDeviceVhfModuleConfig.HidReportDescriptorLength = sizeof(g_VirtualHidAmbientLightSensor_HidReportDescriptor);
 

--- a/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.h
+++ b/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.h
@@ -1170,8 +1170,6 @@ typedef struct
     USHORT VendorId;
     USHORT ProductId;
     USHORT VersionNumber;
-    const HID_DESCRIPTOR* HidDescriptor;
-    ULONG HidDescriptorLength;
     const UCHAR* HidReportDescriptor;
     ULONG HidReportDescriptorLength;
     HID_DEVICE_ATTRIBUTES HidDeviceAttributes;

--- a/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.md
+++ b/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.md
@@ -27,8 +27,6 @@ typedef struct
   USHORT VendorId;
   USHORT ProductId;
   USHORT VersionNumber;
-  const HID_DESCRIPTOR* HidDescriptor;
-  ULONG HidDescriptorLength;
   const UCHAR* HidReportDescriptor;
   ULONG HidReportDescriptorLength;
   HID_DEVICE_ATTRIBUTES HidDeviceAttributes;
@@ -50,8 +48,6 @@ Member | Description
 VendorId | The vendor id of the virtual HID device.
 ProductId | The product id of the virtual HID device.
 VersionNumber | The version number of the virtual HID device.
-HidDescriptor | The HID device descriptor of the Virtual Hid device.
-HidDescriptorLength | The size in bytes of HidDescriptor.
 HidReportDescriptor | The HID report descriptor of the Virtual Hid device.
 HidDeviceAttributes | The HID device attributes of the Virtual Hid device.
 IoctlCallback_IOCTL_HID_SET_FEATURE | VHF callback for IOCTL_HID_SET_FEATURE.

--- a/Dmf/Modules.Library/Dmf_VirtualHidKeyboard.c
+++ b/Dmf/Modules.Library/Dmf_VirtualHidKeyboard.c
@@ -119,26 +119,6 @@ g_VirtualHidKeyboard_HidReportDescriptor[] =
     0xc0,                /* END_COLLECTION */
 };
 
-// HID Device Descriptor with just one report representing the keyboard.
-//
-static
-const
-HID_DESCRIPTOR
-g_VirtualHidKeyboard_HidDescriptor =
-{
-    0x09,     // Length of HID descriptor
-    0x21,     // Descriptor type == HID  0x21
-    0x0100,   // HID spec release
-    0x33,     // Country code == English
-    0x01,     // Number of HID class descriptors
-    {
-      0x22,   // Descriptor type
-      // Total length of report descriptor.
-      //
-      (USHORT) sizeof(g_VirtualHidKeyboard_HidReportDescriptor)
-    }
-};
-
 /*
     Keyboard Report Format:
     ._______________________________________________________________________________________________________________________
@@ -688,8 +668,6 @@ Return Value:
         virtualHidDeviceVhfModuleConfig.ProductId = moduleConfig->ProductId;
         virtualHidDeviceVhfModuleConfig.VersionNumber = 0x0001;
 
-        virtualHidDeviceVhfModuleConfig.HidDescriptor = &g_VirtualHidKeyboard_HidDescriptor;
-        virtualHidDeviceVhfModuleConfig.HidDescriptorLength = sizeof(g_VirtualHidKeyboard_HidDescriptor);
         virtualHidDeviceVhfModuleConfig.HidReportDescriptor = g_VirtualHidKeyboard_HidReportDescriptor;
         virtualHidDeviceVhfModuleConfig.HidReportDescriptorLength = sizeof(g_VirtualHidKeyboard_HidReportDescriptor);
 

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
@@ -495,12 +495,14 @@
     <None Include="..\..\Modules.Library\Dmf_Doorbell.md">
       <Filter>Documentation\Modules\Task Execution</Filter>
     </None>
-    <None Include="..\..\Modules.Library\Dmf_Stack.md" />
+    <None Include="..\..\Modules.Library\Dmf_Stack.md">
+      <Filter>Documentation\Modules\Data Structures</Filter>
+    </None>
     <None Include="..\..\Modules.Library\Dmf_GpioTarget.md">
-      <Filter>Headers\Modules\Targets</Filter>
+      <Filter>Documentation\Modules\Targets</Filter>
     </None>
     <None Include="..\..\Modules.Library\Dmf_SpiTarget.md">
-      <Filter>Headers\Modules\Targets</Filter>
+      <Filter>Documentation\Modules\Targets</Filter>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Merge20211206
1. Fix regression in DMF_ContinuousRequestTarget which can cause 0x9F bug check. **This regression was introduced in Release LKG v1.1.106. Any drivers compiled using DMF_ContinousRequestTarget in  v1.1.106 to v1.1.108 (either directly or indirectly) should be recompiled with version v1.1.109.**
2. Remove unused fields in DMF_VirtualHidDeviceVhf Module Config. (Non-functional change).
3. Make associated changes related to (2) in other Modules. (Non-functional change).
4. Non-functional changes to some asserts that incorrectly did not include "closing" state.
5. Remove improper assert.
6. Add DMF_File_Write() Method.
7. Correct issues in unit test driver.