### PR TITLE
Merge20211209

### DIFF
--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -7779,6 +7779,8 @@ ways to DMF. These include:
 
 -   Rajesh Gururaj
 
+-   Ayodeji Ige
+
 -   Anoop Kurungod
 
 -   Sergii Liashenko

--- a/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
+++ b/Dmf/Modules.Library/Dmf_ComponentFirmwareUpdate.c
@@ -2112,7 +2112,6 @@ Return Value:
     CONTEXT_ComponentFirmwareUpdateTransport* componentFirmwareUpdateTransportContext;
 
     const UINT numberOfUlongsInOffer = 4;
-    const ULONG offerSize = sizeof(ULONG) * numberOfUlongsInOffer;
     const BYTE outputToken = FWUPDATE_DRIVER_TOKEN;
 
     WDF_OBJECT_ATTRIBUTES objectAttributes;


### PR DESCRIPTION
1. Fix BSOD in DMF_DeviceInterfaceMulitpleTarget. It happens when the underlying WDFIOTARGET fails to open during "Remove Cancel" path.
2. Correct issue in DMF_ComponentFirmwareUpdate.c. Strict compiler settings will fail with unused local variables that are set.
3. Update list of contributors in documentation.