### PR TITLE
Merge20211217

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,7 +4,7 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.110
+// DMF Release: v1.1.111
 //
 
 // eof: DmfVersion.h

--- a/Dmf/Documentation/Driver Module Framework.md
+++ b/Dmf/Documentation/Driver Module Framework.md
@@ -303,6 +303,8 @@ Function)](#section-11-public-calls-by-client-includes-module-create-function)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DECLARE_DMF_MODULE 162](#declare_dmf_module)
 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DECLARE_DMF_MODULE_EX](#declare_dmf_module_ex)
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DECLARE_DMF_MODULE_NO_CONFIG](#declare_dmf_module_no_config)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CALLBACKS_DMF_INIT 164](#dmf_entrypoints_dmf_init)
@@ -334,6 +336,8 @@ Function)](#section-11-public-calls-by-client-includes-module-create-function)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_ModuleRequestCompleteOrForward](#dmf_modulerequestcompleteorforward)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_[ModuleName]_TransportMethod](#dmf_modulename_transportmethod)
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DMF_CONFIG_[ModuleName]_DEFAULT](#dmf_config_modulename_default)
 
 [Feature Module Access API 181](#feature-module-access-api)
 
@@ -6030,6 +6034,55 @@ None
 //
 DECLARE_DMF_MODULE(OsrFx2)
 ```
+### DECLARE_DMF_MODULE_EX
+```
+DECLARE_DMF_MODULE_EX(ModuleName)
+```
+This macro declares the Module's publicly available functions and
+macros. [Always use this macro in the Module's .h file].
+This macro is used for Module that [have] a Config.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
+  **ModuleName**  | The name of the Module.
+  
+#### Returns
+
+None
+
+#### Remarks
+
+-   When a Module needs to provide non-zero initialization for its Config structure,
+it should declare itself with **DECLARE_DMF_MODULE_EX()** rather than **DECLARE_DMF_MODULE()**.
+It must have also defined **DMF_CONFIG_[ModuleName]_DEFAULT()** to perform the initialization.
+
+#### Example
+```
+// Set default values in DMF_CONFIG_BufferPool.
+// This is called by DECLARE_DMF_MODULE_EX().
+//
+__forceinline
+VOID
+DMF_CONFIG_BufferPool_DEFAULT(
+    _Inout_ DMF_CONFIG_BufferPool* ModuleConfig
+    )
+{
+    // NonPagedPool has a non-zero value on ARM (and other) platforms.
+    //
+    ModuleConfig->Mode.SourceSettings.PoolType = NonPagedPool;
+}
+
+// This macro declares the following functions:
+// DMF_BufferPool_ATTRIBUTES_INIT()
+// DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT()
+// DMF_BufferPool_Create()
+//
+// DMF_CONFIG_BufferPool_DEFAULT() must be declared above.
+//
+DECLARE_DMF_MODULE_EX(BufferPool)
+```
 ### DECLARE_DMF_MODULE_NO_CONFIG
 ```
 DECLARE_DMF_MODULE_NO_CONFIG(ModuleName)
@@ -6654,6 +6707,41 @@ is returned.
 
 -   This Method is similar to a Device IO Control handler in that the
     caller and callee must use a predefined interface.
+
+### DMF_CONFIG_[ModuleName]_DEFAULT
+```
+__forceinline
+VOID
+DMF_CONFIG_[ModuleName]_DEFAULT(
+    _Inout_ DMF_CONFIG_[ModuleName]* ModuleConfig
+    )
+```
+This callback is implemented by Modules that need to initialize their Config structures
+with non-zero values. Equivalently, this callback is implemented by Modules declared with
+**DECLARE_DMF_MODULE_EX()** rather than **DECLARE_DMF_MODULE()**.
+
+#### Parameters
+
+  Parameter | Description
+  ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
+  **DMF_CONFIG_[ModuleName]\* ModuleConfig**  | A pointer to the Module's Config structure.
+
+#### Returns
+
+None
+
+#### Remarks
+
+-   DMF zeroes the Config structure before calling this Method.
+
+-   This callback may initialize the Config structure with any appropriate default values it needs.
+    The Client will then have the opportunity to override the
+    Module's defaults before the Module Create function is called.
+
+-   This callback is called as part of Module creation and - like **DMF_[ModuleName]_Create()** -
+    should not allocate resources of any type.
+
+-   See **DECLARE_DMF_MODULE_EX()** for example usage.
 
 Feature Module Access API
 =========================

--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -3134,37 +3134,13 @@ Return Value:
 {
     BOOLEAN returnValue;
 
-    switch (PoolType)
+    if ((PoolType & PagedPool) != 0)
     {
-        case NonPagedPool:
-        case NonPagedPoolMustSucceed:
-        case NonPagedPoolCacheAligned:
-        case NonPagedPoolCacheAlignedMustS:
-        case NonPagedPoolSession:
-        case NonPagedPoolMustSucceedSession:
-        case NonPagedPoolCacheAlignedSession:
-        case NonPagedPoolCacheAlignedMustSSession:
-#if (!defined(_ARM_) && !defined(_ARM64_)) || (!defined(POOL_NX_OPTIN_AUTO))
-        // If POOL_NX_OPTION_AUTO is defined, it means that NonPagedPoolNx = NonPagedPool.
-        // So, don't include this case as it is a duplicate. This is the case for ARM and ARM64.
-        //
-        // NOTE: The condition has the OR so that the check is compatible with EWDK that does
-        //       not support POOL_NX_OPTIN_AUTO.
-        //
-        case NonPagedPoolNx:
-        case NonPagedPoolNxCacheAligned:
-#endif
-        case NonPagedPoolSessionNx:
-        {
-            returnValue = FALSE;
-            break;
-        }
-
-        default:
-        {
-            returnValue = TRUE;
-            break;
-        }
+        returnValue = TRUE;
+    }
+    else
+    {
+        returnValue = FALSE;
     }
 
     return returnValue;

--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -87,7 +87,10 @@ typedef struct
     EVT_DMF_MODULE_OnDeviceNotificationPreClose* EvtModuleOnDeviceNotificationPreClose;
 } DMF_MODULE_EVENT_CALLBACKS;
 
-#define DECLARE_DMF_MODULE(ModuleName)                                                          \
+// DECLARE_DMF_MODULE_EX() allows the Module author to set default values for the Module
+// Config. DECLARE_DMF_MODULE() initializes the Module Config with RtlZeroMemory().
+//
+#define DECLARE_DMF_MODULE_EX(ModuleName)                                                       \
                                                                                                 \
 WDF_DECLARE_CUSTOM_TYPE(DMF_##ModuleName);                                                      \
                                                                                                 \
@@ -121,9 +124,23 @@ DMF_CONFIG_##ModuleName##_AND_ATTRIBUTES_INIT(                                  
 {                                                                                               \
     RtlZeroMemory(ModuleConfig,                                                                 \
                   sizeof(DMF_CONFIG_##ModuleName##));                                           \
+    DMF_CONFIG_##ModuleName##_DEFAULT(ModuleConfig);                                            \
     DMF_##ModuleName##_ATTRIBUTES_INIT(ModuleAttributes);                                       \
     ModuleAttributes->ModuleConfigPointer = ModuleConfig;                                       \
 }                                                                                               \
+
+// DECLARE_DMF_MODULE() in terms of DECLARE_DMF_MODULE_EX() with empty initializer.
+//
+#define DECLARE_DMF_MODULE(ModuleName)                                                          \
+__forceinline                                                                                   \
+VOID                                                                                            \
+DMF_CONFIG_##ModuleName##_DEFAULT(                                                              \
+    _Inout_ DMF_CONFIG_##ModuleName##* ModuleConfig                                             \
+    )                                                                                           \
+{                                                                                               \
+    UNREFERENCED_PARAMETER(ModuleConfig);                                                       \
+}                                                                                               \
+DECLARE_DMF_MODULE_EX(ModuleName)
 
 #define DECLARE_DMF_MODULE_NO_CONFIG(ModuleName)                                                \
                                                                                                 \

--- a/Dmf/Modules.Library/Dmf_BufferPool.h
+++ b/Dmf/Modules.Library/Dmf_BufferPool.h
@@ -133,12 +133,29 @@ typedef struct
     } Mode;
 } DMF_CONFIG_BufferPool;
 
+// Callback to set default (non-zero) values in DMF_CONFIG_BufferPool
+// referenced by DECLARE_DMF_MODULE_EX().
+// NOTE: This callback is called by DMF not by Clients directly.
+//
+__forceinline
+VOID
+DMF_CONFIG_BufferPool_DEFAULT(
+    _Inout_ DMF_CONFIG_BufferPool* ModuleConfig
+    )
+{
+    // NonPagedPoolNx is non-zero on all platforms.
+    //
+    ModuleConfig->Mode.SourceSettings.PoolType = NonPagedPoolNx;
+}
+
 // This macro declares the following functions:
 // DMF_BufferPool_ATTRIBUTES_INIT()
 // DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT()
 // DMF_BufferPool_Create()
 //
-DECLARE_DMF_MODULE(BufferPool)
+// DMF_CONFIG_BufferPool_DEFAULT() must be declared above.
+//
+DECLARE_DMF_MODULE_EX(BufferPool)
 
 // Module Methods
 //

--- a/Dmf/Modules.Library/Dmf_BufferQueue.h
+++ b/Dmf/Modules.Library/Dmf_BufferQueue.h
@@ -46,12 +46,40 @@ typedef struct
     EVT_DMF_BufferQueue_ReuseCleanup* EvtBufferQueueReuseCleanup;
 } DMF_CONFIG_BufferQueue;
 
+// Callback to set default (non-zero) values in DMF_CONFIG_BufferQueue
+// referenced by DECLARE_DMF_MODULE_EX().
+// NOTE: This callback is called by DMF not by Clients directly.
+//
+__forceinline
+VOID
+DMF_CONFIG_BufferQueue_DEFAULT(
+    _Inout_ DMF_CONFIG_BufferQueue* ModuleConfig
+    )
+{
+    DMF_CONFIG_BufferPool moduleConfigBufferPool;
+    DMF_MODULE_ATTRIBUTES moduleAttributes;
+
+    // This Module's Config reuses (contains) BufferPool's Config. Thus
+    // it is necessary to make sure it is properly initialized using its
+    // necessary default values.
+    //
+    DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+                                              &moduleAttributes);
+
+    // After initializing BufferPool's Config copy Settings from that 
+    // Config to this Module's Config.
+    //
+    ModuleConfig->SourceSettings = moduleConfigBufferPool.Mode.SourceSettings;
+}
+
 // This macro declares the following functions:
 // DMF_BufferQueue_ATTRIBUTES_INIT()
 // DMF_CONFIG_BufferQueue_AND_ATTRIBUTES_INIT()
 // DMF_BufferQueue_Create()
 //
-DECLARE_DMF_MODULE(BufferQueue)
+// DMF_CONFIG_BufferQueue_DEFAULT() must be declared above.
+//
+DECLARE_DMF_MODULE_EX(BufferQueue)
 
 // Module Methods
 //

--- a/Dmf/Modules.Library/Dmf_QueuedWorkItem.h
+++ b/Dmf/Modules.Library/Dmf_QueuedWorkItem.h
@@ -44,12 +44,36 @@ typedef struct
     DMF_CONFIG_BufferQueue BufferQueueConfig;
 } DMF_CONFIG_QueuedWorkItem;
 
+// Callback to set default (non-zero) values in DMF_CONFIG_QueuedWorkItem
+// referenced by DECLARE_DMF_MODULE_EX().
+// NOTE: This callback is called by DMF not by Clients directly.
+//
+__forceinline
+VOID
+DMF_CONFIG_QueuedWorkItem_DEFAULT(
+    _Inout_ DMF_CONFIG_QueuedWorkItem* ModuleConfig
+    )
+{
+    DMF_MODULE_ATTRIBUTES moduleAttributes;
+
+    // This Module's Config reuses (contains) BufferQueue's Config. Thus
+    // it is necessary to make sure it is properly initialized using its
+    // necessary default values.
+    //
+    DMF_CONFIG_BufferQueue_AND_ATTRIBUTES_INIT(&ModuleConfig->BufferQueueConfig,
+                                               &moduleAttributes);
+    // This Module's Config has no specific default non-zero values.
+    //
+}
+
 // This macro declares the following functions:
 // DMF_QueuedWorkItem_ATTRIBUTES_INIT()
 // DMF_CONFIG_QueuedWorkItem_AND_ATTRIBUTES_INIT()
 // DMF_QueuedWorkItem_Create()
 //
-DECLARE_DMF_MODULE(QueuedWorkItem)
+// DMF_CONFIG_QueuedWorkItem_DEFAULT() must be declared above.
+//
+DECLARE_DMF_MODULE_EX(QueuedWorkItem)
 
 // Module Methods
 //


### PR DESCRIPTION
1. Add ability for Module authors to set non-zero default values in a Module's Config. DECLARE_DMF_MODULE_EX()
2. Update default Config for DMF_BufferPool, DMF_BufferQueue and DMF_QueuedWorkitem.
3. Allow User-mode Clients of DMF_DeviceInterfaceTarget to fail the Open of a device interface instance.
4. Update the check for Paged Pool type to be simpler.