### PR TITLE
Merge20220308

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.116
+// DMF Release: v1.1.117
 //
 
-#define DMF_VERSION 0x01010074
+#define DMF_VERSION 0x01010075
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -85,6 +85,18 @@ typedef
 VOID
 EVT_DMF_MODULE_OnDeviceNotificationClose(_In_ DMFMODULE DmfModule);
 
+typedef struct _DMF_TIME_FIELDS
+{
+    UINT16 Year;
+    UINT16 Month;
+    UINT16 Day;
+    UINT16 Hour;
+    UINT16 Minute;
+    UINT16 Second;
+    UINT16 Milliseconds;
+    UINT16 Weekday;
+} DMF_TIME_FIELDS;
+
 // It means the Generic function is not overridden.
 //
 #define USE_GENERIC_CALLBACK      NULL
@@ -1531,6 +1543,24 @@ BOOLEAN
 DMF_Utility_IsEqualGUID(
     _In_ GUID* Guid1,
     _In_ GUID* Guid2
+    );
+
+_Must_inspect_result_
+_IRQL_requires_same_
+VOID
+DMF_Utility_SystemTimeCurrentGet(
+    _Out_ PLARGE_INTEGER CurrentSystemTime
+    );
+#if defined(DMF_USER_MODE)
+#define KeQuerySystemTime DMF_Utility_SystemTimeCurrentGet
+#endif
+
+_Must_inspect_result_
+_IRQL_requires_same_
+BOOLEAN
+DMF_Utility_LocalTimeToUniversalTimeConvert(
+    _In_ DMF_TIME_FIELDS* LocalTimeFields,
+    _Out_ DMF_TIME_FIELDS* UtcTimeFields
     );
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
+++ b/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
@@ -104,13 +104,29 @@ Environment:
 //
 #define IS_WIN10_20H1_OR_LATER (NTDDI_WIN10_VB && (NTDDI_VERSION >= NTDDI_WIN10_VB))
 
+// Check that the Windows version is 20H2 or EARLIER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_20H2_OR_EARLIER (!(NTDDI_WIN10_MN && (NTDDI_VERSION > NTDDI_WIN10_MN)))
+
+// Check that the Windows version is 20H2 or LATER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_20H2_OR_LATER (NTDDI_WIN10_MN && (NTDDI_VERSION >= NTDDI_WIN10_MN))
+
 // Check that the Windows version is 21H1 or EARLIER. The supported versions are defined in sdkddkver.h.
 //
-#define IS_WIN10_21H1_OR_EARLIER (!(NTDDI_WIN10_MN && (NTDDI_VERSION > NTDDI_WIN10_MN)))
+#define IS_WIN10_21H1_OR_EARLIER (!(NTDDI_WIN10_FE && (NTDDI_VERSION > NTDDI_WIN10_FE)))
 
 // Check that the Windows version is 21H1 or LATER. The supported versions are defined in sdkddkver.h.
 //
-#define IS_WIN10_21H1_OR_LATER (NTDDI_WIN10_MN && (NTDDI_VERSION >= NTDDI_WIN10_MN))
+#define IS_WIN10_21H1_OR_LATER (NTDDI_WIN10_FE && (NTDDI_VERSION >= NTDDI_WIN10_FE))
+
+// Check that the Windows version is 21H2 or EARLIER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_21H2_OR_EARLIER (!(NTDDI_WIN10_CO && (NTDDI_VERSION > NTDDI_WIN10_CO)))
+
+// Check that the Windows version is 21H2 or LATER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_21H2_OR_LATER (NTDDI_WIN10_CO && (NTDDI_VERSION >= NTDDI_WIN10_CO))
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/Dmf/Modules.Library/DMF_String.h
+++ b/Dmf/Modules.Library/DMF_String.h
@@ -79,6 +79,8 @@ DMF_String_AnsiStringInitialize(
 //
 #define RtlInitAnsiString DMF_String_AnsiStringInitialize
 
+#define RtlStringCbPrintfA sprintf_s
+
 #endif
 
 typedef

--- a/Dmf/Modules.Library/DMF_UefiOperation.c
+++ b/Dmf/Modules.Library/DMF_UefiOperation.c
@@ -8,7 +8,7 @@ Module Name:
 
 Abstract:
 
-    This Module provides UEFI basic operations
+    This Module provides UEFI basic operations.
 
 Environment:
 
@@ -37,6 +37,8 @@ DMF_MODULE_DECLARE_NO_CONTEXT(UefiOperation)
 // This Module has no Config.
 //
 DMF_MODULE_DECLARE_NO_CONFIG(UefiOperation)
+
+#define MemoryTag 'MUEF'
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // DMF Module Support Code
@@ -217,12 +219,215 @@ Return Value:
 // Module Methods
 //
 
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_UefiOperation_FirmwareEnvironmentVariableAllocateGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UNICODE_STRING* Name,
+    _In_ LPGUID Guid,
+    _Out_ VOID** VariableBuffer,
+    _Inout_ ULONG* VariableBufferSize,
+    _Out_ WDFMEMORY* VariableBufferHandle,
+    _Out_opt_ ULONG* Attributes
+    )
+/*++
+
+Routine Description:
+
+    Get the UEFI variable data to certain UEFI Guid and name in both User-mode and Kernel-mode.
+    Allocates the required memory size and the client is responsible to free the memory.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    Name - Name of UEFI variable to read data from.
+    Guid - GUID of UEFI variable to read data from.
+    VariableBuffer - Buffer that will store the data that is read from the UEFI variable.
+    VariableBufferSize - As input, it passes the desired size that needs to be read.
+                         As output, it sends back the actual size that was read from UEFI.
+    VariableBufferHandle - WDF memory handle for the allocated memory
+    Attributes - Location to which the routine writes the attributes of the specified environment variable.
+                 (Optional argument, only used in Kernel-mode)
+
+Return Value:
+
+    STATUS_SUCCESS if successful.
+    Other NTSTATUS if there is an error.
+
+--*/
+{
+    NTSTATUS ntStatus;
+    WDF_OBJECT_ATTRIBUTES objectAttributes;
+    VOID* localBuffer;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 UefiOperation);
+
+    WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+
+#if !defined(DMF_USER_MODE)
+    // Get the variable length
+    //
+    ntStatus = ExGetFirmwareEnvironmentVariable(Name,
+                                                Guid,
+                                                NULL,
+                                                VariableBufferSize,
+                                                Attributes);
+    if ((!NT_SUCCESS(ntStatus)) &&
+        (ntStatus != STATUS_BUFFER_TOO_SMALL))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR,
+                    DMF_TRACE,
+                    "ExGetFirmwareEnvironmentVariable fails to read %S %!STATUS!",
+                    Name->Buffer,
+                    ntStatus);
+        goto Exit;
+    }
+
+    // Allocate memory for exact variable size.
+    //
+    ntStatus = WdfMemoryCreate(&objectAttributes,
+                               NonPagedPoolNx,
+                               MemoryTag,
+                               *VariableBufferSize,
+                               VariableBufferHandle,
+                               (VOID**)&localBuffer);
+
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR,
+                    DMF_TRACE,
+                    "WdfMemoryCreate fails: ntStatus=%!STATUS!",
+                    ntStatus);
+        goto Exit;
+    }
+
+    RtlZeroMemory(localBuffer,
+                  *VariableBufferSize);
+
+    // Read the variable.
+    //
+    ntStatus = ExGetFirmwareEnvironmentVariable(Name,
+                                                Guid,
+                                                localBuffer,
+                                                VariableBufferSize,
+                                                Attributes);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR,
+                    DMF_TRACE,
+                    "ExGetFirmwareEnvironmentVariable fails: ntStatus=%!STATUS!",
+                    ntStatus);
+        ntStatus = STATUS_UNSUCCESSFUL;
+        WdfObjectDelete(VariableBufferHandle);
+        goto Exit;
+    }
+
+    *VariableBuffer = localBuffer;
+
+#else // !defined(DMF_USER_MODE).
+
+// Initial Memory Allocation Attempt Size (in Bytes).
+//
+#define INITIAL_MEMORY_ALLOCATION_SIZE_BYTES 16
+
+// Maximum Memory Allocation Retries upto 1 MB.
+// 
+#define MAXIMUM_MEMORY_ALLOCATION_ATTEMPTS (1024 * 1024)
+
+// Macro to check if ntStatus is equal to WIN32's Error Code (ERROR_INSUFFICIENT_BUFFER).
+//
+#define IS_ERROR_INSUFFICIENT_BUFFER(ntStatus) ((ntStatus & 0xFF) == ERROR_INSUFFICIENT_BUFFER)
+
+    *VariableBufferSize = INITIAL_MEMORY_ALLOCATION_SIZE_BYTES;
+    BOOLEAN allocateMoreMemory;
+
+    do {
+
+        allocateMoreMemory = FALSE;
+
+        // Allocate memory for exact variable size.
+        //
+        ntStatus = WdfMemoryCreate(&objectAttributes,
+                                   NonPagedPoolNx,
+                                   MemoryTag,
+                                   *VariableBufferSize,
+                                   VariableBufferHandle,
+                                   (VOID**)&localBuffer);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR,
+                        DMF_TRACE,
+                        "WdfMemoryCreate fails: ntStatus=%!STATUS!",
+                        ntStatus);
+            goto Exit;
+        }
+
+        RtlZeroMemory(localBuffer,
+                      *VariableBufferSize);
+
+        ntStatus = DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(DmfModule,
+                                                                      Name,
+                                                                      Guid,
+                                                                      localBuffer,
+                                                                      VariableBufferSize,
+                                                                      Attributes);
+
+        if (IS_ERROR_INSUFFICIENT_BUFFER(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR,
+                        DMF_TRACE,
+                        "DMF_UefiOperation_FirmwareEnvironmentVariableGetEx fails: ntStatus=%!STATUS!",
+                        ntStatus);
+
+            // Increase memory allocation size by double and try.
+            //
+            *VariableBufferSize = *VariableBufferSize << 1;
+            if (*VariableBufferSize <= MAXIMUM_MEMORY_ALLOCATION_ATTEMPTS)
+            {
+                TraceEvents(TRACE_LEVEL_ERROR,
+                            DMF_TRACE,
+                            "Retrying with more buffer size...");
+                allocateMoreMemory = TRUE;
+            }
+            WdfObjectDelete(*VariableBufferHandle);
+        }
+    } while (allocateMoreMemory);
+
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR,
+                    DMF_TRACE,
+                    "DMF_UefiOperation_FirmwareEnvironmentVariableGetEx fails: ntStatus=%!STATUS!",
+                    ntStatus);
+        WdfObjectDelete(*VariableBufferHandle);
+        goto Exit;
+    }
+
+    *VariableBuffer = localBuffer;
+
+#endif // !defined(DMF_USER_MODE).
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+    return ntStatus;
+}
+#pragma code_seg()
+
 #if defined(DMF_USER_MODE)
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS 
 DMF_UefiOperation_FirmwareEnvironmentVariableGet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,
@@ -237,6 +442,7 @@ Routine Description:
 
 Arguments:
 
+    DmfModule - This Module's handle.
     Name - Name of UEFI variable to read data from.
     Guid - GUID of UEFI variable to read data from.
     VariableBuffer - Buffer that will store the data that is read from the UEFI variable.
@@ -255,6 +461,9 @@ Return Value:
     DWORD size;
 
     FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 UefiOperation);
 
     result = UefiOperation_ProcessPrivilegeSet(TRUE,
                                                SE_SYSTEM_ENVIRONMENT_NAME);
@@ -294,6 +503,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,
@@ -308,6 +518,7 @@ Routine Description:
 
 Arguments:
 
+    DmfModule - This Module's handle.
     Name - Name of UEFI variable to read data from.
     Guid - GUID of UEFI variable to read data from.
     VariableBuffer - Buffer that will store the data that is read from the UEFI variable.
@@ -328,6 +539,10 @@ Return Value:
     PAGED_CODE();
 
     FuncEntry(DMF_TRACE);
+
+    // NOTE: In this Method, DmfModule can be NULL to support this call before WdfDeviceCreate() has been called.
+    //
+    UNREFERENCED_PARAMETER(DmfModule);
 
 #if !defined(DMF_USER_MODE)
     ntStatus = ExGetFirmwareEnvironmentVariable(Name,
@@ -380,7 +595,8 @@ Return Value:
 
     variableName[numberOfElementsToCopy] = L'\0';
 
-    ntStatus = DMF_UefiOperation_FirmwareEnvironmentVariableGet((LPCTSTR)variableName,
+    ntStatus = DMF_UefiOperation_FirmwareEnvironmentVariableGet(DmfModule,
+                                                                (LPCTSTR)variableName,
                                                                 (LPCTSTR)guidString,
                                                                 VariableBuffer,
                                                                 VariableBufferSize);
@@ -400,6 +616,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS 
 DMF_UefiOperation_FirmwareEnvironmentVariableSet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _In_reads_(VariableBufferSize) VOID* VariableBuffer,
@@ -414,6 +631,7 @@ Routine Description:
 
 Arguments:
 
+    DmfModule - This Module's handle.
     Name - Name of UEFI variable to write data to.
     Guid - GUID of UEFI variable to write data to.
     VariableBuffer - Buffer that stores the data that is to be written to the UEFI variable.
@@ -431,6 +649,9 @@ Return Value:
     BOOL result;
 
     FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 UefiOperation);
 
     hresult = UefiOperation_ProcessPrivilegeSet(TRUE,
                                                 SE_SYSTEM_ENVIRONMENT_NAME);
@@ -469,6 +690,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableSetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _In_reads_bytes_opt_(VariableBufferSize) VOID* VariableBuffer,
@@ -483,6 +705,7 @@ Routine Description:
 
 Arguments:
 
+    DmfModule - This Module's handle.
     Name - Name of UEFI variable to write data to. 
     Guid - GUID of UEFI variable to write data to.
     VariableBuffer - Buffer that stores the data that is to be written to the UEFI variable.
@@ -502,6 +725,9 @@ Return Value:
     PAGED_CODE();
 
     FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 UefiOperation);
 
 #if !defined(DMF_USER_MODE)
     ntStatus = ExSetFirmwareEnvironmentVariable(Name,
@@ -549,7 +775,8 @@ Return Value:
 
     variableName[numberOfElementsToCopy] = L'\0';
 
-    ntStatus = DMF_UefiOperation_FirmwareEnvironmentVariableSet((LPCTSTR)variableName,
+    ntStatus = DMF_UefiOperation_FirmwareEnvironmentVariableSet(DmfModule,
+                                                                (LPCTSTR)variableName,
                                                                 (LPCTSTR)guidString,
                                                                 VariableBuffer,
                                                                 VariableBufferSize);

--- a/Dmf/Modules.Library/DMF_UefiOperation.h
+++ b/Dmf/Modules.Library/DMF_UefiOperation.h
@@ -27,12 +27,26 @@ DECLARE_DMF_MODULE_NO_CONFIG(UefiOperation)
 // Module Methods
 //
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_UefiOperation_FirmwareEnvironmentVariableAllocateGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UNICODE_STRING* Name,
+    _In_ LPGUID Guid,
+    _Out_ VOID** VariableBuffer,
+    _Inout_ ULONG* VariableBufferSize,
+    _Inout_ WDFMEMORY* VariableBufferHandle,
+    _Out_opt_ ULONG* Attributes
+    );
+
 #if defined(DMF_USER_MODE)
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS 
 DMF_UefiOperation_FirmwareEnvironmentVariableGet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,
@@ -45,6 +59,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,
@@ -58,6 +73,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableSet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _In_reads_(VariableBufferSize) VOID* VariableBuffer,
@@ -70,6 +86,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableSetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _In_reads_bytes_opt_(VariableBufferSize) VOID* VariableBuffer,

--- a/Dmf/Modules.Library/DMF_UefiOperation.md
+++ b/Dmf/Modules.Library/DMF_UefiOperation.md
@@ -38,6 +38,43 @@ This Module provides UEFI basic operations. It allows clients to do data reading
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
+##### DMF_UefiOperation_FirmwareEnvironmentVariableAllocateGet
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_UefiOperation_FirmwareEnvironmentVariableAllocateGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ UNICODE_STRING* Name,
+    _In_ LPGUID Guid,
+    _Out_ VOID** VariableBuffer,
+    _Inout_ ULONG* VariableBufferSize,
+    _Out_ WDFMEMORY* VariableBufferHandle,
+    _Out_opt_ ULONG* Attributes
+    );
+````
+
+Allows the Client to get the UEFI variable data from certain UEFI Guid and name in both User-mode and Kernel-mode.
+This API allocates required memory automatically and the client is responsible to free the memory.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | This Module's handle.
+Name | Name of UEFI variable to read data from.
+Guid | GUID of UEFI variable to read data from.
+VariableBuffer | Buffer that will store the data that is read from the UEFI variable.
+VariableBufferSize | As input, it pass the desired size that needs to be read. As output, it send back the actual size that was read from UEFI.
+VariableBufferHandle | WDF Memory Handle for the client
+Attributes | Location to which the routine writes the attributes of the specified environment variable.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
 ##### DMF_UefiOperation_FirmwareEnvironmentVariableGet
 
 ````
@@ -46,6 +83,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _Out_writes_(*VariableBufferSize) VOID* VariableBuffer,
@@ -63,10 +101,11 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
+DmfModule | This Module's handle.
 Name | Name of UEFI variable to read data from.
 Guid | GUID of UEFI variable to read data from.
 VariableBuffer | Buffer that will store the data that is read from the UEFI variable.
-VariableBufferSize | As input, it pass the desired size that needs to be read (suggest use the one return from DMF_UefiOperation_GetFirmwareEnvironmentVariableSize). As output, it send back the actual size that was read from UEFI.
+VariableBufferSize | As input, it pass the desired size that needs to be read. As output, it send back the actual size that was read from UEFI.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -77,6 +116,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,
@@ -94,6 +134,7 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
+DmfModule | This Module's handle.
 Name | Name of UEFI variable to read data from.
 Guid | GUID of UEFI variable to read data from.
 VariableBuffer | Buffer that will store the data that is read from the UEFI variable.
@@ -109,6 +150,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableSet(
+    _In_ DMFMODULE DmfModule,
     _In_ LPCTSTR Name,
     _In_ LPCTSTR Guid,
     _In_reads_(VariableBufferSize) VOID* VariableBuffer,
@@ -126,6 +168,7 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
+DmfModule | This Module's handle.
 Name | Name of UEFI variable to write data to. 
 Guid | GUID of UEFI variable to write data to.
 VariableBuffer | Buffer that stores the data that is to be written to the UEFI variable.
@@ -140,6 +183,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableSetEx(
+    _In_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _In_reads_bytes_opt_(VariableBufferSize) VOID* VariableBuffer,
@@ -157,6 +201,7 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
+DmfModule | This Module's handle.
 Name | Name of UEFI variable to write data to. 
 Guid | GUID of UEFI variable to write data to.
 VariableBuffer | Buffer that stores the data that is to be written to the UEFI variable.

--- a/Dmf/Modules.Library/Dmf_Doorbell.c
+++ b/Dmf/Modules.Library/Dmf_Doorbell.c
@@ -84,7 +84,6 @@ EVT_WDF_WORKITEM Doorbell_WorkItemHandler;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-#pragma code_seg("PAGE")
 _Function_class_(EVT_WDF_WORKITEM)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -112,8 +111,6 @@ Return Value:
     DMFMODULE dmfModule;
     DMF_CONFIG_Doorbell* moduleConfig;
     DMF_CONTEXT_Doorbell* moduleContext;
-
-    PAGED_CODE();
 
     FuncEntry(DMF_TRACE);
 
@@ -152,7 +149,6 @@ Return Value:
 
     FuncExitVoid(DMF_TRACE);
 }
-#pragma code_seg()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // WDF Module Callbacks


### PR DESCRIPTION
1. Correct BSOD regression in DMF_Doorbell where callback was paged but should not be because it can potentially acquire a spinlock.  Regression introduced in v1.1.114.
2. Correct definition names of macros that check for WDK versions.
3. Correct bug in DMF_UefiOperation where Methods did not receive DMFMODULE parameter (benign bug).
4. Add DMF_Utility_SystemTimeCurrentGet()  which is Kernel/User-mode compatible call to get system time.
5. Update DMF_NotifyUserWithRequestMultiple to support caching all buffers in queue, not just a single  (last) buffer.