### PR TITLE
Merge20220512

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.118
+// DMF Release: v1.1.119
 //
 
-#define DMF_VERSION 0x01010076
+#define DMF_VERSION 0x01010077
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfDefinitions.h
+++ b/Dmf/Framework/DmfDefinitions.h
@@ -1545,7 +1545,6 @@ DMF_Utility_IsEqualGUID(
     _In_ GUID* Guid2
     );
 
-_Must_inspect_result_
 _IRQL_requires_same_
 VOID
 DMF_Utility_SystemTimeCurrentGet(

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler_Public.h
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler_Public.h
@@ -38,5 +38,31 @@ typedef struct
 } Tests_IoctlHandler_Sleep;
 #pragma pack(pop)
 
+#if defined(DMF_KERNEL_MODE)
+
+// {6775E8C4-78EE-4269-8FF9-19DC127772F0}
+//
+DEFINE_GUID(GUID_Tests_IoctlHandler_INTERFACE_STANDARD, 
+    0x6775e8c4, 0x78ee, 0x4269, 0x8f, 0xf9, 0x19, 0xdc, 0x12, 0x77, 0x72, 0xf0);
+
+typedef
+BOOLEAN
+(*TestsIoctlHandler_ValueGet)(_In_ VOID* DmfModuleVoid,
+                              _Out_ UCHAR* Value);
+
+typedef
+BOOLEAN
+(*TestsIoctlHandler_ValueSet)(_In_ VOID* DmfModuleVoid,
+                              _In_ UCHAR Value);
+
+typedef struct _Tests_IoctlHandler_INTERFACE_STANDARD
+{
+    INTERFACE InterfaceHeader;
+    TestsIoctlHandler_ValueGet InterfaceValueGet;
+    TestsIoctlHandler_ValueSet InterfaceValueSet;
+} Tests_IoctlHandler_INTERFACE_STANDARD;
+
+#endif
+
 // eof: Dmf_Tests_IoctlHandler_Public.h
 //

--- a/Dmf/Modules.Library/DMF_UefiOperation.c
+++ b/Dmf/Modules.Library/DMF_UefiOperation.c
@@ -504,7 +504,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(
-    _In_ DMFMODULE DmfModule,
+    _In_opt_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,

--- a/Dmf/Modules.Library/DMF_UefiOperation.h
+++ b/Dmf/Modules.Library/DMF_UefiOperation.h
@@ -18,6 +18,19 @@ Environment:
 
 --*/
 
+// Uefi variable attribute bits.
+// See https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exsetfirmwareenvironmentvariable
+//
+//
+#define EFI_VARIABLE_NON_VOLATILE                           0x00000001
+#define EFI_VARIABLE_BOOTSERVICE_ACCESS                     0x00000002
+#define EFI_VARIABLE_RUNTIME_ACCESS                         0x00000004
+#define EFI_VARIABLE_HARDWARE_ERROR_RECORD                  0x00000008
+#define EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS             0x00000010
+#define EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS  0x00000020
+#define EFI_VARIABLE_APPEND_WRITE                           0x00000040
+#define EFI_VARIABLE_ENHANCED_AUTHENTICATED_ACCESS          0x00000080
+
 // This macro declares the following functions:
 // DMF_UefiOperation_ATTRIBUTES_INIT()
 // DMF_UefiOperation_Create()
@@ -36,7 +49,7 @@ DMF_UefiOperation_FirmwareEnvironmentVariableAllocateGet(
     _In_ LPGUID Guid,
     _Out_ VOID** VariableBuffer,
     _Inout_ ULONG* VariableBufferSize,
-    _Inout_ WDFMEMORY* VariableBufferHandle,
+    _Out_ WDFMEMORY* VariableBufferHandle,
     _Out_opt_ ULONG* Attributes
     );
 
@@ -59,7 +72,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
 DMF_UefiOperation_FirmwareEnvironmentVariableGetEx(
-    _In_ DMFMODULE DmfModule,
+    _In_opt_ DMFMODULE DmfModule,
     _In_ UNICODE_STRING* Name,
     _In_ LPGUID Guid,
     _Out_writes_bytes_opt_(*VariableBufferSize) VOID* VariableBuffer,

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.h
@@ -31,8 +31,14 @@ typedef enum
     DeviceInterfaceMultipleTarget_StateType_Invalid,
     DeviceInterfaceMultipleTarget_StateType_Open,
     DeviceInterfaceMultipleTarget_StateType_QueryRemove,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
     DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled,
+    DeviceInterfaceMultipleTarget_StateType_RemoveCancel = DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
     DeviceInterfaceMultipleTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceMultipleTarget_StateType_RemoveComplete = DeviceInterfaceMultipleTarget_StateType_QueryRemoveComplete,
     DeviceInterfaceMultipleTarget_StateType_Close,
     DeviceInterfaceMultipleTarget_StateType_Maximum
 } DeviceInterfaceMultipleTarget_StateType;
@@ -48,7 +54,7 @@ typedef enum
     // Module is opened in D0Entry and closed in D0Exit.
     //
     DeviceInterfaceMultipleTarget_PnpRegisterWhen_D0Entry,
-    // Module is opened in when module is created.
+    // Module is opened in when Module is created.
     //
     DeviceInterfaceMultipleTarget_PnpRegisterWhen_Create
 } DeviceInterfaceMultipleTarget_PnpRegisterWhen_Type;
@@ -226,6 +232,21 @@ DMF_DeviceInterfaceMultipleTarget_StreamStart(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DMF_DeviceInterfaceMultipleTarget_StreamStop(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_DeviceInterfaceMultipleTarget_TargetDereference(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_DeviceInterfaceMultipleTarget_TargetReference(
     _In_ DMFMODULE DmfModule,
     _In_ DeviceInterfaceMultipleTarget_Target Target
     );

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.md
@@ -68,13 +68,19 @@ Enum to specify IO Target State.
 ````
 typedef enum
 {
-  DeviceInterfaceMultipleTarget_StateType_Invalid,
-  DeviceInterfaceMultipleTarget_StateType_Open,
-  DeviceInterfaceMultipleTarget_StateType_QueryRemove,
-  DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled,
-  DeviceInterfaceMultipleTarget_StateType_QueryRemoveComplete,
-  DeviceInterfaceMultipleTarget_StateType_Close,
-  DeviceInterfaceMultipleTarget_StateType_Maximum
+    DeviceInterfaceMultipleTarget_StateType_Invalid,
+    DeviceInterfaceMultipleTarget_StateType_Open,
+    DeviceInterfaceMultipleTarget_StateType_QueryRemove,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
+    DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled,
+    DeviceInterfaceMultipleTarget_StateType_RemoveCancel = DeviceInterfaceMultipleTarget_StateType_QueryRemoveCancelled,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
+    DeviceInterfaceMultipleTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceMultipleTarget_StateType_RemoveComplete = DeviceInterfaceMultipleTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceMultipleTarget_StateType_Close,
+    DeviceInterfaceMultipleTarget_StateType_Maximum
 } DeviceInterfaceMultipleTarget_StateType;
 ````
 
@@ -90,7 +96,7 @@ typedef enum
     // Module is opened in D0Entry and closed in D0Exit.
     //
     DeviceInterfaceMultipleTarget_PnpRegisterWhen_D0Entry,
-    // Module is opened in when module is created.
+    // Module is opened in when Module is created.
     //
     DeviceInterfaceMultipleTarget_PnpRegisterWhen_Create
 } DeviceInterfaceMultipleTarget_PnpRegisterWhen_Type;
@@ -514,6 +520,67 @@ DmfModule | An open DMF_DeviceInterfaceMultipleTarget Module handle.
 Target | The given DMFIOTARGET handle.
 
 ##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_DeviceInterfaceMultipleTarget_TargetDereference
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+VOID
+DMF_DeviceInterfaceMultipleTarget_TargetDereference(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    );
+````
+
+Releases a reference to the WDFIOTARGET associated with the given Target.
+
+##### Returns
+
+None.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DeviceInterfaceMultipleTarget Module handle.
+Target | The given DMFIOTARGET handle.
+
+##### Remarks
+
+* Use this Method instead of DMF_ModuleDereference() because there more than one WDFIOTARGET may be open.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_DeviceInterfaceMultipleTarget_TargetReference
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_DeviceInterfaceMultipleTarget_TargetReference(
+    _In_ DMFMODULE DmfModule,
+    _In_ DeviceInterfaceMultipleTarget_Target Target
+    );
+````
+
+Acquires a reference to the WDFIOTARGET associated with the given Target.
+
+##### Returns
+
+STATUS_SUCCESS indicates that the given Target is valid and will remain available until
+`DMF_DeviceInterfaceMultipleTarget_TargetDereference` is called.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DeviceInterfaceMultipleTarget Module handle.
+Target | The given DMFIOTARGET handle.
+
+##### Remarks
+
+* Use this Method instead of DMF_ModuleReference() because there more than one WDFIOTARGET may be open.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -27,8 +27,14 @@ typedef enum
     DeviceInterfaceTarget_StateType_Invalid,
     DeviceInterfaceTarget_StateType_Open,
     DeviceInterfaceTarget_StateType_QueryRemove,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
     DeviceInterfaceTarget_StateType_QueryRemoveCancelled,
+    DeviceInterfaceTarget_StateType_RemoveCancel = DeviceInterfaceTarget_StateType_QueryRemoveCancelled,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
     DeviceInterfaceTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceTarget_StateType_RemoveComplete = DeviceInterfaceTarget_StateType_QueryRemoveComplete,
     DeviceInterfaceTarget_StateType_Close,
     DeviceInterfaceTarget_StateType_Maximum
 } DeviceInterfaceTarget_StateType;

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -62,13 +62,19 @@ Enum to specify IO Target State.
 ````
 typedef enum
 {
-  DeviceInterfaceTarget_StateType_Invalid,
-  DeviceInterfaceTarget_StateType_Open,
-  DeviceInterfaceTarget_StateType_QueryRemove,
-  DeviceInterfaceTarget_StateType_QueryRemoveCancelled,
-  DeviceInterfaceTarget_StateType_QueryRemoveComplete,
-  DeviceInterfaceTarget_StateType_Close,
-  DeviceInterfaceTarget_StateType_Maximum
+    DeviceInterfaceTarget_StateType_Invalid,
+    DeviceInterfaceTarget_StateType_Open,
+    DeviceInterfaceTarget_StateType_QueryRemove,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
+    DeviceInterfaceTarget_StateType_QueryRemoveCancelled,
+    DeviceInterfaceTarget_StateType_RemoveCancel = DeviceInterfaceTarget_StateType_QueryRemoveCancelled,
+    // NOTE: This name is not correct. The correct name is on next line, but old name is kept for backward compatibility.
+    //
+    DeviceInterfaceTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceTarget_StateType_RemoveComplete = DeviceInterfaceTarget_StateType_QueryRemoveComplete,
+    DeviceInterfaceTarget_StateType_Close,
+    DeviceInterfaceTarget_StateType_Maximum
 } DeviceInterfaceTarget_StateType;
 ````
 

--- a/Dmf/Modules.Library/Dmf_File.h
+++ b/Dmf/Modules.Library/Dmf_File.h
@@ -32,6 +32,19 @@ DECLARE_DMF_MODULE_NO_CONFIG(File)
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
+DMF_File_BufferDecompress(
+    _In_ DMFMODULE DmfModule,
+    _In_ USHORT CompressionFormat,
+    _Out_writes_bytes_(UncompressedBufferSize) UCHAR* UncompressedBuffer,
+    _In_ ULONG UncompressedBufferSize,
+    _In_reads_bytes_(CompressedBufferSize) UCHAR* CompressedBuffer,
+    _In_ ULONG CompressedBufferSize,
+    _Out_ ULONG* FinalUncompressedSize
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
 DMF_File_DriverFileRead(
     _In_ DMFMODULE DmfModule,
     _In_ WCHAR* FileName, 

--- a/Dmf/Modules.Library/Dmf_File.md
+++ b/Dmf/Modules.Library/Dmf_File.md
@@ -39,6 +39,44 @@ Support for working with files in drivers.
 #### Module Methods
 
 -----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_File_BufferDecompress
+
+````
+_Must_inspect_result_
+NTSTATUS
+DMF_File_BufferDecompress(
+    _In_ DMFMODULE DmfModule,
+    _In_ USHORT CompressionFormat,
+    _Inout_ UCHAR* UncompressedBuffer,
+    _Inout_ ULONG UncompressedBufferSize,
+    _In_ UCHAR* CompressedBuffer,
+    _In_ ULONG CompressedBufferSize,
+    _Inout_ ULONG* FinalUncompressedSize
+    );
+````
+
+    Decompresses the input buffer and writes the uncompressed buffer back.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | This Module's handle.
+CompressionFormat | CompressionFormat.
+UncompressedBuffer | Uncompressed output buffer handle of buffer holding data to write.
+UncompressedBufferSize |  Uncompressed output buffer size
+CompressedBuffer | Compressed input buffer handle
+CompressedBufferSize | Compressed input buffer size
+FinalUncompressedSize | Final uncompressed size of the buffer
+
+##### Remarks
+
+*
+
+-----------------------------------------------------------------------------------------------------------------------------------
 
 ##### DMF_File_DriverFileRead
 
@@ -172,8 +210,6 @@ FileContentMemory | Buffer handle of buffer holding data to write.
 ##### Remarks
 
 *
-
------------------------------------------------------------------------------------------------------------------------------------
 
 #### Module Children
 

--- a/Dmf/Modules.Library/Dmf_NotifyUserWithRequestMultiple.c
+++ b/Dmf/Modules.Library/Dmf_NotifyUserWithRequestMultiple.c
@@ -511,6 +511,9 @@ Return Value:
 
     // Process data to service first request from Client.
     //
+    // 'Dereferencing NULL pointer. 'fileObjectContext''
+    //
+    #pragma warning(suppress:28182)
     DMF_NotifyUserWithRequest_DataProcess(fileObjectContext->DmfModuleNotifyUserWithRequest,
                                           moduleConfig->CompletionCallback,
                                           bufferQueueContext->DataBuffer,

--- a/Dmf/Modules.Library/Dmf_Rundown.h
+++ b/Dmf/Modules.Library/Dmf_Rundown.h
@@ -21,8 +21,8 @@ Environment:
 #pragma once
 
 // This macro declares the following functions:
-// DMF_Registry_ATTRIBUTES_INIT()
-// DMF_Registry_Create()
+// DMF_Rundown_ATTRIBUTES_INIT()
+// DMF_Rundown_Create()
 //
 DECLARE_DMF_MODULE_NO_CONFIG(Rundown)
 

--- a/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.h
+++ b/Dmf/Modules.Library/Dmf_VirtualHidDeviceVhf.h
@@ -1138,17 +1138,11 @@ Environment:
 #define HID_LOGICAL_MAXIMUM_DWORD(val)          (HID_GLOBAL_LOGICAL_MAXIMUM | HID_SIZE_DWORD), (val & 0xFF), ((val >> 8) & 0xFF), ((val >> 16) & 0xFF), ((val >> 24) & 0xFF)
 
 #define HID_UNIT_EXPONENT_BYTE(val)             (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_BYTE), val
-#define HID_UNIT_EXPONENT_BYTE(val)             (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_BYTE), val
 #define HID_UNIT_EXPONENT_WORD(val)             (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_WORD), (val & 0xFF), ((val >> 8) & 0xFF)
-#define HID_UNIT_EXPONENT_WORD(val)             (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_WORD), (val & 0xFF), ((val >> 8) & 0xFF)
-#define HID_UNIT_EXPONENT_DWORD(val)            (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_DWORD), (val & 0xFF), ((val >> 8) & 0xFF), ((val >> 16) & 0xFF), ((val >> 24) & 0xFF)
 #define HID_UNIT_EXPONENT_DWORD(val)            (HID_GLOBAL_UNIT_EXPONENT | HID_SIZE_DWORD), (val & 0xFF), ((val >> 8) & 0xFF), ((val >> 16) & 0xFF), ((val >> 24) & 0xFF)
 
 #define HID_UNIT_BYTE(val)                      (HID_GLOBAL_UNIT | HID_SIZE_BYTE), val
-#define HID_UNIT_BYTE(val)                      (HID_GLOBAL_UNIT | HID_SIZE_BYTE), val
 #define HID_UNIT_WORD(val)                      (HID_GLOBAL_UNIT | HID_SIZE_WORD), (val & 0xFF), ((val >> 8) & 0xFF)
-#define HID_UNIT_WORD(val)                      (HID_GLOBAL_UNIT | HID_SIZE_WORD), (val & 0xFF), ((val >> 8) & 0xFF)
-#define HID_UNIT_DWORD(val)                     (HID_GLOBAL_UNIT | HID_SIZE_DWORD), (val & 0xFF), ((val >> 8) & 0xFF), ((val >> 16) & 0xFF), ((val >> 24) & 0xFF)
 #define HID_UNIT_DWORD(val)                     (HID_GLOBAL_UNIT | HID_SIZE_DWORD), (val & 0xFF), ((val >> 8) & 0xFF), ((val >> 16) & 0xFF), ((val >> 24) & 0xFF)
 
 // This Module is only supported in Kernel-mode because VHF only support Kernel-mode.

--- a/Dmf/Modules.Library/Dmf_VirtualHidKeyboard.c
+++ b/Dmf/Modules.Library/Dmf_VirtualHidKeyboard.c
@@ -9,6 +9,8 @@ Module Name:
 Abstract:
 
     Support for creating a virtual keyboard device that "types" keys into the host.
+    NOTE: See https://usb.org/sites/default/files/hut1_3_0.pdf (chapter 10) to find
+          keystroke map values.
 
 Environment:
 
@@ -350,6 +352,8 @@ Return Value:
                             inputReport.Input.KeyboardInput.Key);
                 isKeyDown = TRUE;
             }
+
+            inputReport.ReportId = REPORT_ID_KEYBOARD;
         }
         else if (UsagePage == HID_USAGE_PAGE_CONSUMER)
         {


### PR DESCRIPTION
Merge20220512

1. Correct issue with missing ReportId field in DMF_VirtualHidKeyboard.
2. Correct bug in DMF_DeviceInterfaceTarget and DMF_DeviceInterfaceMultipleTarget when Client vetoes QueryRemove.
3. Add example of how to use WdfIoTargetQueryInterface() when using DMF_DeviceInterfaceTarget and DMF_DeviceInterfaceMultipleTarget. (See the corresponding Test Modules.)
4. Update DMF unit tests to test more scenarios such as QueryInterface. Also correct some issues in unit tests.
5. Correct some SAL issues.
6. Remove some duplicate definitions.
7. Correct some comments.
8. Add DMF_File_BufferDecompress() Method.
9. Add DMF_DeviceInterfaceMultipleTarget_Reference() and DMF_DeviceInterfaceMultipleTarget_Deeference() to allow Client to reference individual WDFIOTARGET exposed by the Module.
