### PR TITLE
Merge20220812

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.124
+// DMF Release: v1.1.125
 //
 
-#define DMF_VERSION 0x0101007C
+#define DMF_VERSION 0x0101007D
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfGeneric.c
+++ b/Dmf/Framework/DmfGeneric.c
@@ -821,6 +821,9 @@ Return Value:
         // This Module's Notification Registration is automatically closed in D0Exit.
         //
         DMF_Internal_NotificationUnregister(DmfModule);
+        // This is needed for cases where Module Opens, Close and Opens again.
+        //
+        dmfObject->ModuleNotificationRegisteredDuring = ModuleOpenedDuringType_Invalid;
     }
     else if (dmfObject->ModuleDescriptor.OpenOption < DMF_MODULE_OPEN_OPTION_LAST)
     {
@@ -1404,10 +1407,9 @@ Return Value:
 
     ntStatus = STATUS_SUCCESS;
 
-    // It is possible for a Module to be created but not open if the Module uses a
-    // notification to open but the notification has not happened yet.
+    // Module can be in any valid state.
     //
-    DMF_HandleValidate_IsCreatedOrOpened(dmfObject);
+    DMF_HandleValidate_IsAvailable(dmfObject);
 
     FuncExit(DMF_TRACE, "dmfObject=0x%p [%s] returnValue=0", dmfObject, dmfObject->ClientModuleInstanceName);
 

--- a/Dmf/Modules.Library/DmfModules.Library.h
+++ b/Dmf/Modules.Library/DmfModules.Library.h
@@ -80,6 +80,7 @@ extern "C"
 #include "Dmf_UdeClient.h"
 #include "DMF_UefiLogs.h"
 #include "Dmf_UefiOperation.h"
+#include "Dmf_Time.h"
 
 // Buffers
 //

--- a/Dmf/Modules.Library/Dmf_Time.c
+++ b/Dmf/Modules.Library/Dmf_Time.c
@@ -123,6 +123,8 @@ Return Value:
         ntStatus = STATUS_INTEGER_OVERFLOW;
         goto Exit;
     }
+
+    ntStatus = STATUS_SUCCESS;
 #endif
 
     *ElapsedTimeInNanoseconds = (result / PerformanceFrequency);

--- a/Dmf/Modules.Library/Dmf_Time.c
+++ b/Dmf/Modules.Library/Dmf_Time.c
@@ -1,0 +1,426 @@
+/*++
+
+   Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT license.
+
+Module Name:
+
+    Dmf_Time.c
+
+Abstract:
+
+    Implements a Time data structure.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+// DMF and this Module's Library specific definitions.
+//
+#include "DmfModule.h"
+#include "DmfModules.Library.h"
+#include "DmfModules.Library.Trace.h"
+
+#if defined(DMF_INCLUDE_TMH)
+#include "Dmf_Time.tmh"
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Enumerations and Structures
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Context
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+typedef struct _DMF_CONTEXT_Time
+{
+    // Get Performance Frequency during module Open. This value will not change. 
+    //
+    LARGE_INTEGER PerformanceFrequency;
+} DMF_CONTEXT_Time;
+
+// This macro declares the following function:
+// DMF_CONTEXT_GET()
+//
+DMF_MODULE_DECLARE_CONTEXT(Time)
+
+// This macro declares the following function:
+// DMF_CONFIG_GET()
+//
+DMF_MODULE_DECLARE_NO_CONFIG(Time)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Support Code
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#define NANOSECONDS_TO_MILLISECONDS         (1000000U)
+#define SECONDS_TO_NANOSECONDS              (1000000000U)
+
+__forceinline
+NTSTATUS
+ElapsedTimeInNanosecondsGet(
+    _In_ LONGLONG CurrentTick,
+    _In_ LONGLONG LastQueryTick,
+    _In_ LONGLONG PerformanceFrequency,
+    _Out_ LONGLONG* ElapsedTimeInNanoseconds
+    )
+/*++
+
+Routine Description:
+
+    Calculate elapsed time in nanoseconds given the current and last tick count.
+
+Arguments:
+
+    CurrentTick - Current tick count.
+    LastQueryTick - Last tick count.
+    PerformanceFrequency - performance-counter frequency.
+    ElapsedTimeInNanoseconds - Return the elapsed time in nanoseconds.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    LONGLONG elaspedTicks;
+    LONGLONG result;
+
+    DmfAssert(PerformanceFrequency);
+
+    ntStatus = STATUS_UNSUCCESSFUL;
+
+    elaspedTicks = CurrentTick - LastQueryTick;
+
+#ifdef DMF_KERNEL_MODE
+    ntStatus = RtlLong64Mult(elaspedTicks,
+                             SECONDS_TO_NANOSECONDS, 
+                             &result);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DmfAssert(false);
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Integer overflow when performing multiplication of %lld and %lld", elaspedTicks, SECONDS_TO_NANOSECONDS);
+        goto Exit;
+    }
+#else
+    HRESULT hResult;
+
+    hResult = Long64Mult(elaspedTicks,
+                         SECONDS_TO_NANOSECONDS,
+                         &result);
+    if (hResult != S_OK)
+    {
+        DmfAssert(false);
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "Integer overflow when performing multiplication of %lld and %lld", elaspedTicks, SECONDS_TO_NANOSECONDS);
+        ntStatus = STATUS_INTEGER_OVERFLOW;
+        goto Exit;
+    }
+#endif
+
+    *ElapsedTimeInNanoseconds = (result / PerformanceFrequency);
+
+Exit:
+
+    return ntStatus;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// WDF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_Function_class_(DMF_Open)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+static
+NTSTATUS
+DMF_Time_Open(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+   Initialize an instance of a DMF Module of type Time.
+
+Arguments:
+
+   DmfModule - This Module's handle.
+
+Return Value:
+
+   NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_Time* moduleContext;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    ntStatus = STATUS_SUCCESS;
+
+    // moduleContext->PerformanceFrequency saves the performance counter frequency in ticks per second.
+    //
+#if defined(DMF_KERNEL_MODE)
+    KeQueryPerformanceCounter(&moduleContext->PerformanceFrequency);
+#else
+    QueryPerformanceFrequency(&moduleContext->PerformanceFrequency);
+#endif
+
+    DmfAssert(moduleContext->PerformanceFrequency.QuadPart != 0);
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Calls by Client
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_Create(
+    _In_ WDFDEVICE Device,
+    _In_ DMF_MODULE_ATTRIBUTES* DmfModuleAttributes,
+    _In_ WDF_OBJECT_ATTRIBUTES* ObjectAttributes,
+    _Out_ DMFMODULE* DmfModule
+    )
+/*++
+
+Routine Description:
+
+   Create an instance of a DMF Module of type Time.
+
+Arguments:
+
+    Device - Client driver's WDFDEVICE object.
+    DmfModuleAttributes - Opaque structure that contains parameters DMF needs to initialize the Module.
+    ObjectAttributes - WDF object attributes for DMFMODULE.
+    DmfModule - Address of the location where the created DMFMODULE handle is returned.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_MODULE_DESCRIPTOR dmfModuleDescriptor_Time;
+    DMF_CALLBACKS_DMF dmfCallbacksDmf_Time;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    DMF_CALLBACKS_DMF_INIT(&dmfCallbacksDmf_Time);
+    dmfCallbacksDmf_Time.DeviceOpen = DMF_Time_Open;
+    DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_Time,
+                                            Time,
+                                            DMF_CONTEXT_Time,
+                                            DMF_MODULE_OPTIONS_DISPATCH_MAXIMUM,
+                                            DMF_MODULE_OPEN_OPTION_OPEN_Create);
+
+    dmfModuleDescriptor_Time.CallbacksDmf = &dmfCallbacksDmf_Time;
+
+    ntStatus = DMF_ModuleCreate(Device,
+                                DmfModuleAttributes,
+                                ObjectAttributes,
+                                &dmfModuleDescriptor_Time,
+                                DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleCreate fails: ntStatus=%!STATUS!", ntStatus);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return(ntStatus);
+}
+#pragma code_seg()
+
+// Module Methods
+//
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeMillisecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTime,
+    _Out_ LONGLONG* ElapsedTimeInMilliSeconds
+    )
+/*++
+
+Routine Description:
+
+    Calculate the elasped time in milliseconds.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    StartTick - Tick start count.
+    ElapsedTimeInMilliSeconds - Return the elapsed time in milliseconds.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_Time* moduleContext;
+    LARGE_INTEGER elapsedTimeInNanoseconds;
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Time);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    // Calculate the elapsed time.
+    //
+    ntStatus = DMF_Time_ElapsedTimeNanosecondsGet(DmfModule,
+                                                  StartTime,
+                                                  &elapsedTimeInNanoseconds.QuadPart);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    *ElapsedTimeInMilliSeconds = (elapsedTimeInNanoseconds.QuadPart / NANOSECONDS_TO_MILLISECONDS);
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeNanosecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTick,
+    _Out_ LONGLONG* ElapsedTimeInNanoSeconds
+    )
+/*++
+
+Routine Description:
+
+    Calculate the elasped time in nanoseconds.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    StartTick - Tick start count.
+    ElapsedTimeInNanoSeconds - Return the elapsed time in nanoseconds.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_Time* moduleContext;
+    LARGE_INTEGER endTick;
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Time);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    // Get current tick count.
+    //
+#if defined(DMF_KERNEL_MODE)
+    endTick = KeQueryPerformanceCounter(NULL);
+#else
+    QueryPerformanceCounter(&endTick);
+#endif
+
+    DmfAssert(StartTick < endTick.QuadPart);
+
+    // Calculate the elapsed time.
+    //
+    ntStatus = ElapsedTimeInNanosecondsGet(endTick.QuadPart,
+                                           StartTick,
+                                           moduleContext->PerformanceFrequency.QuadPart,
+                                           ElapsedTimeInNanoSeconds);
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+LONGLONG
+DMF_Time_TickCountGet(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Return the current tick count.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    Current tick count.
+
+--*/
+{
+    LARGE_INTEGER timeTick;
+
+    UNREFERENCED_PARAMETER(DmfModule);
+
+    FuncEntry(DMF_TRACE);
+
+    DMFMODULE_VALIDATE_IN_METHOD(DmfModule,
+                                 Time);
+
+#if defined(DMF_KERNEL_MODE)
+    timeTick = KeQueryPerformanceCounter(NULL);
+#else
+    QueryPerformanceCounter(&timeTick);
+#endif
+
+    FuncExitVoid(DMF_TRACE);
+
+    return timeTick.QuadPart;
+}
+
+// eof: Dmf_Time.c
+//

--- a/Dmf/Modules.Library/Dmf_Time.h
+++ b/Dmf/Modules.Library/Dmf_Time.h
@@ -1,0 +1,58 @@
+/*++
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+
+Module Name:
+
+    Dmf_Time.h
+
+Abstract:
+
+    Companion file to Dmf_Time.c.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+#pragma once
+
+// This macro declares the following functions:
+// DMF_Time_ATTRIBUTES_INIT()
+// DMF_Time_Create()
+//
+DECLARE_DMF_MODULE_NO_CONFIG(Time)
+
+// Module Methods
+//
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeMillisecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTime,
+    _Out_ LONGLONG* ElapsedTimeInMilliSeconds
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeNanosecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTick,
+    _Out_ LONGLONG* ElapsedTimeInNanoSeconds
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+LONGLONG
+DMF_Time_TickCountGet(
+    _In_ DMFMODULE DmfModule
+    );
+
+// eof: Dmf_Time.h
+//

--- a/Dmf/Modules.Library/Dmf_Time.md
+++ b/Dmf/Modules.Library/Dmf_Time.md
@@ -1,4 +1,4 @@
-## DMF_Stack
+## DMF_Time
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -13,17 +13,7 @@ Implements a time keeper module which gets current cpu ticks and also calculates
 #### Module Configuration
 
 -----------------------------------------------------------------------------------------------------------------------------------
-##### DMF_CONFIG_Stack
-````
-typedef struct
-{
-    // Keeping empty for now. Might add something later.
-    //
-} DMF_CONFIG_Stack;
-````
-Member | Description
-----|----
-
+* None
 -----------------------------------------------------------------------------------------------------------------------------------
 
 #### Module Enumeration Types
@@ -71,7 +61,7 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
-DmfModule | An open DMF_Stack Module handle.
+DmfModule | An open DMF_Time Module handle.
 StartTime | StartTime in tick count from which the elapsed time has to be calculated.
 ElapsedTimeInMilliSeconds | Return the elapsed time in milliseconds.
 
@@ -103,7 +93,7 @@ NTSTATUS
 ##### Parameters
 Parameter | Description
 ----|----
-DmfModule | An open DMF_Stack Module handle.
+DmfModule | An open DMF_Time Module handle.
 StartTime | StartTime in tick count from which the elapsed time has to be calculated.
 ElapsedTimeInNanoSeconds | Return the elapsed time in nanoseconds.
 
@@ -133,7 +123,7 @@ Tick count.
 ##### Parameters
 Parameter | Description
 ----|----
-DmfModule | An open DMF_Stack Module handle.
+DmfModule | An open DMF_Time Module handle.
 
 ##### Remarks
 

--- a/Dmf/Modules.Library/Dmf_Time.md
+++ b/Dmf/Modules.Library/Dmf_Time.md
@@ -1,0 +1,182 @@
+## DMF_Stack
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Summary
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+Implements a time keeper module which gets current cpu ticks and also calculates the time elapsed in milliseconds and nanoseconds.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Configuration
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_CONFIG_Stack
+````
+typedef struct
+{
+    // Keeping empty for now. Might add something later.
+    //
+} DMF_CONFIG_Stack;
+````
+Member | Description
+----|----
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Enumeration Types
+
+-----------------------------------------------------------------------------------------------------------------------------------
+* None
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Structures
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Callbacks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Methods
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Time_ElapsedTimeMillisecondsGet
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeMillisecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTime,
+    _Out_ LONGLONG* ElapsedTimeInMilliSeconds
+    );
+````
+
+Calculate elapsed time in milliseconds.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Stack Module handle.
+StartTime | StartTime in tick count from which the elapsed time has to be calculated.
+ElapsedTimeInMilliSeconds | Return the elapsed time in milliseconds.
+
+##### Remarks
+
+*None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Time_ElapsedTimeNanosecondsGet
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_Time_ElapsedTimeNanosecondsGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ LONGLONG StartTick,
+    _Out_ LONGLONG* ElapsedTimeInNanoSeconds
+    );
+````
+
+Calculate elapsed time in nanoseconds.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Stack Module handle.
+StartTime | StartTime in tick count from which the elapsed time has to be calculated.
+ElapsedTimeInNanoSeconds | Return the elapsed time in nanoseconds.
+
+##### Remarks
+
+*None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_Time_TickCountGet
+
+````
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Must_inspect_result_
+LONGLONG
+DMF_Time_TickCountGet(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+Queries current tick count and returns it to the caller.
+
+##### Returns
+
+Tick count.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_Stack Module handle.
+
+##### Remarks
+
+*None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module IOCTLs
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Remarks
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Children
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Implementation Details
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Examples
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### To Do
+
+-----------------------------------------------------------------------------------------------------------------------------------
+#### Module Category
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+

--- a/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj
+++ b/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj
@@ -72,6 +72,7 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_ThermalCoolingInterface.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_Thread.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_NotifyUserWithRequest.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_Time.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_UdeClient.c" />
     <ClCompile Include="..\..\Modules.Library\DMF_UefiLogs.c" />
     <ClCompile Include="..\..\Modules.Library\DMF_UefiOperation.c" />
@@ -134,6 +135,7 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_ThermalCoolingInterface.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_Thread.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_NotifyUserWithRequest.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_Time.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_UdeClient.h" />
     <ClInclude Include="..\..\Modules.Library\DMF_UefiLogs.h" />
     <ClInclude Include="..\..\Modules.Library\DMF_UefiOperation.h" />
@@ -448,6 +450,7 @@
     <None Include="..\..\Modules.Library\Dmf_Rundown.md" />
     <None Include="..\..\Modules.Library\Dmf_SpbTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_Stack.md" />
+    <None Include="..\..\Modules.Library\Dmf_Time.md" />
     <None Include="..\..\Modules.Library\Dmf_UdeClient.md" />
     <None Include="..\..\Modules.Library\DMF_UefiLogs.md" />
     <None Include="..\..\Modules.Library\DMF_UefiOperation.md" />

--- a/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfKModules.Library/DmfKModules.Library.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClCompile Include="..\..\Modules.Library\DMF_UefiLogs.c">
       <Filter>Modules\Driver Patterns</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Modules.Library\Dmf_Time.c">
+      <Filter>Modules\Driver Patterns</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Modules.Library\Dmf_PingPongBuffer.h">
@@ -352,6 +355,9 @@
       <Filter>Headers\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Modules.Library\DMF_UefiLogs.h">
+      <Filter>Headers\Driver Patterns</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_Time.h">
       <Filter>Headers\Driver Patterns</Filter>
     </ClInclude>
   </ItemGroup>
@@ -604,6 +610,9 @@
       <Filter>Documentation\Interfaces</Filter>
     </None>
     <None Include="..\..\Modules.Library\DMF_UefiLogs.md">
+      <Filter>Documentation\Modules\Driver Patterns</Filter>
+    </None>
+    <None Include="..\..\Modules.Library\Dmf_Time.md">
       <Filter>Documentation\Modules\Driver Patterns</Filter>
     </None>
   </ItemGroup>

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj
@@ -202,7 +202,9 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_NotifyUserWithRequest.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_ThreadedBufferQueue.h" />
     <ClInclude Include="..\..\Modules.Library\DmfModules.Library.Trace.h" />
+    <ClInclude Include="..\..\Modules.Library\Dmf_Time.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_Transport_ComponentFirmwareUpdate.h" />
+    <ClInclude Include="..\..\Modules.Library\DMF_UefiLogs.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_VirtualHidMini.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_MobileBroadband.h" />
     <ClInclude Include="..\..\Modules.Library\Dmf_UefiOperation.h" />
@@ -248,6 +250,8 @@
     <ClCompile Include="..\..\Modules.Library\Dmf_Thread.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_NotifyUserWithRequest.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_ThreadedBufferQueue.c" />
+    <ClCompile Include="..\..\Modules.Library\Dmf_Time.c" />
+    <ClCompile Include="..\..\Modules.Library\DMF_UefiLogs.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_VirtualHidMini.c" />
     <ClCompile Include="..\..\Modules.Library\Dmf_MobileBroadband.cpp" />
     <ClCompile Include="..\..\Modules.Library\Dmf_UefiOperation.c" />
@@ -292,6 +296,8 @@
     <None Include="..\..\Modules.Library\Dmf_SymbolicLinkTarget.md" />
     <None Include="..\..\Modules.Library\Dmf_Thread.md" />
     <None Include="..\..\Modules.Library\Dmf_ThreadedBufferQueue.md" />
+    <None Include="..\..\Modules.Library\Dmf_Time.md" />
+    <None Include="..\..\Modules.Library\DMF_UefiLogs.md" />
     <None Include="..\..\Modules.Library\Dmf_VirtualHidMini.md" />
     <None Include="..\..\Modules.Library\Dmf_UefiOperation.md" />
   </ItemGroup>

--- a/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
+++ b/Dmf/Solution/DmfUModules.Library/DmfUModules.Library.vcxproj.filters
@@ -252,6 +252,12 @@
     <ClInclude Include="..\..\Modules.Library\Dmf_DeviceInterfaceMultipleTarget.h">
       <Filter>Headers\Modules\Targets</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\DMF_UefiLogs.h">
+      <Filter>Headers\Modules\Driver Patterns</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Modules.Library\Dmf_Time.h">
+      <Filter>Headers\Modules\Driver Patterns</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Modules.Library\Dmf_CmApi.c">


### PR DESCRIPTION
1. Work around issue where WDF sometimes calls QuerRemove callback twice.
2. Fix some asserts.
3. Add DMF_Time Module. More Methods to be added later.
4. During RemoveComplete close WDFIOTARGET before calling Client callback so view is the same as if QueryRemove had happened.