### PR TITLE
Merge20221110

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.128
+// DMF Release: v1.1.129
 //
 
-#define DMF_VERSION 0x01010080
+#define DMF_VERSION 0x01010081
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library/Dmf_CrashDump.c
+++ b/Dmf/Modules.Library/Dmf_CrashDump.c
@@ -3166,7 +3166,9 @@ DMF_CrashDump_FileClose(
                                          FileObject);
     }
 
-    return TRUE;
+    // Allow Client driver and other Modules to process this callback.
+    //
+    return FALSE;
 }
 #pragma code_seg()
 

--- a/Dmf/Modules.Library/Dmf_SerialTarget.h
+++ b/Dmf/Modules.Library/Dmf_SerialTarget.h
@@ -85,6 +85,33 @@ BOOLEAN
 EVT_DMF_SerialTarget_CustomConfiguration(_In_ DMFMODULE DmfModule,
                                          _Out_ SerialTarget_Configuration* ConfigurationParameters);
 
+// Client Driver callback function for QueryRemove.
+//
+typedef
+_Function_class_(EVT_DMF_SerialTarget_QueryRemove)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+NTSTATUS
+EVT_DMF_SerialTarget_QueryRemove(_In_ DMFMODULE DmfModule);
+
+// Client Driver callback function for RemoveCanceled.
+//
+typedef
+_Function_class_(EVT_DMF_SerialTarget_RemoveCanceled)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_SerialTarget_RemoveCanceled(_In_ DMFMODULE DmfModule);
+
+// Client Driver callback function for RemoveComplete.
+//
+typedef
+_Function_class_(EVT_DMF_SerialTarget_RemoveComplete)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_SerialTarget_RemoveComplete(_In_ DMFMODULE DmfModule);
+
 // Client uses this structure to configure the Module specific parameters.
 //
 typedef struct
@@ -104,6 +131,15 @@ typedef struct
     // Child Request Stream Module.
     //
     DMF_CONFIG_ContinuousRequestTarget ContinuousRequestTargetModuleConfig;
+    // Client's QueryRemove callback.
+    //
+    EVT_DMF_SerialTarget_QueryRemove* EvtSerialTargetQueryRemove;
+    // Client's RemoveCancel callback.
+    //
+    EVT_DMF_SerialTarget_RemoveCanceled* EvtSerialTargetRemoveCanceled;
+    // Client's RemoveComplete callback.
+    //
+    EVT_DMF_SerialTarget_RemoveComplete* EvtSerialTargetRemoveComplete;
 } DMF_CONFIG_SerialTarget;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_SerialTarget.md
+++ b/Dmf/Modules.Library/Dmf_SerialTarget.md
@@ -26,9 +26,21 @@ typedef struct
   // Share Access.
   //
   ULONG ShareAccess;
+  // Module's Open option.
+  //
+  SerialTarget_OpenOption ModuleOpenOption;
   // Child Request Stream Module.
   //
   DMF_CONFIG_ContinuousRequestTarget ContinuousRequestTargetModuleConfig;
+  // Client's QueryRemove callback.
+  //
+  EVT_DMF_SerialTarget_QueryRemove* EvtSerialTargetQueryRemove;
+  // Client's RemoveCancel callback.
+  //
+  EVT_DMF_SerialTarget_RemoveCanceled* EvtSerialTargetRemoveCanceled;
+  // Client's RemoveComplete callback.
+  //
+  EVT_DMF_SerialTarget_RemoveComplete* EvtSerialTargetRemoveComplete;
 } DMF_CONFIG_SerialTarget;
 ````
 Member | Description
@@ -36,7 +48,11 @@ Member | Description
 EvtSerialTargetCustomConfiguration | Callback that allows the Client to perform specialized configuration of the serial device.
 OpenMode | See WDK documentation.
 ShareAccess | See WDK documentation.
+ModuleOpenOption |  Indicates when the Module should be opened.
 ContinuousRequestTargetModuleConfig | Allows the Client to configure the underlying Child DMF_ContinuousRequestTarget Module to send and receive data from the Serial device.
+EvtSerialTargetQueryRemove | Callback that allows the Client to perform action before the Module closes the IoTarget.
+EvtSerialTargetRemoveCanceled | Callback that allows the Client to perform action after the Module opens the IoTarget.
+EvtSerialTargetRemoveComplete | Callback that allows the Client to perform action on RemoveComplete.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -117,6 +133,81 @@ Parameter | Description
 ----|----
 DmfModule | An open DMF_SerialTarget Module handle.
 ConfigurationParameters | The Serial configuration parameters specified by the Client on return.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### EVT_DMF_SerialTarget_QueryRemove
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+NTSTATUS
+EVT_DMF_SerialTarget_QueryRemove(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+The Client uses this callback to take any action necessary before the Module closes the IoTarget.
+
+##### Returns
+
+NTSTATUS
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_SerialTarget Module handle.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### EVT_DMF_SerialTarget_RemoveCanceled
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_SerialTarget_RemoveCanceled(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+The Client uses this callback to take any action necessary after the Module opens the IoTarget.
+
+##### Returns
+
+VOID
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_SerialTarget Module handle.
+
+##### Remarks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### EVT_DMF_SerialTarget_RemoveComplete
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_SerialTarget_RemoveComplete(
+    _In_ DMFMODULE DmfModule
+    );
+````
+
+The Client uses this callback to take any action when target device has been removed.
+
+##### Returns
+
+VOID
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_SerialTarget Module handle.
 
 ##### Remarks
 

--- a/DmfSamples/NonPnp1/exe/install.c
+++ b/DmfSamples/NonPnp1/exe/install.c
@@ -510,7 +510,7 @@ SetupDriverName(
     //
     if (FAILED(StringCbPrintf(DriverLocation,
                               BufferLength,
-                              "%s%s.sys",
+                              "%s\\%s.sys",
                               DriverLocation,
                               DriverName)))
     {


### PR DESCRIPTION
Merge20221110

1. Correct issue where Client driver File Close callback was not called.
2. Correct assert reporting error when setting up WDFFILEOBJECT callbacks in Client driver.
3. Update Non-Pnp sample to show how to set up WDFILEOBJECT callbacks.
4. Update DMF_SerialTarget to support underlying target removal.
5. Fix directory issue in NonPnp1Exe sample.