### PR TITLE
Merge20221118

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.130
+// DMF Release: v1.1.131
 //
 
-#define DMF_VERSION 0x01010082
+#define DMF_VERSION 0x01010083
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library/Dmf_BufferPool.c
+++ b/Dmf/Modules.Library/Dmf_BufferPool.c
@@ -102,6 +102,11 @@ typedef ULONG BufferPool_SentinelType;
 #define BufferPool_SentinelData     0x33334444
 #define BufferPool_SentinelSize     sizeof(BufferPool_SentinelType)
 
+// Enforce the client buffer, which comes after this structure, to be 4-byte aligned, which
+// is a requirement on ARM systems. Without this forced alignment, in certain situations, Windows on
+// ARM will crash due to a misalignment fault when executing specific load instructions.
+//
+#pragma pack(push, 4)
 typedef struct
 {
     // Stores the location of this buffer in the list.
@@ -152,6 +157,7 @@ typedef struct
     BufferPool_SentinelType* SentinelContext;
     ULONG Signature;
 } BUFFERPOOL_ENTRY;
+#pragma pack(pop)
 
 // Function that inserts a buffer in the BufferList.
 //

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -1514,6 +1514,11 @@ Return Value:
 
 Exit:
 
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DeviceInterfaceTarget_SymbolicLinkNameClear(dmfModule);
+    }
+
     return ntStatus;
 }
 #pragma code_seg()
@@ -1736,8 +1741,7 @@ Return Value:
                                                                            deviceInterfaceChangeNotification->SymbolicLinkName);
             if (! NT_SUCCESS(ntStatus))
             {
-                // TODO: Display SymbolicLinkName.
-                //
+                DeviceInterfaceTarget_SymbolicLinkNameClear(dmfModule);
                 TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DeviceInterfaceTarget_DeviceCreateNewIoTargetByName() fails: ntStatus=%!STATUS!", ntStatus);
                 goto Exit;
             }
@@ -1755,6 +1759,7 @@ Return Value:
             ntStatus = DMF_ModuleOpen(dmfModule);
             if (! NT_SUCCESS(ntStatus))
             {
+                DeviceInterfaceTarget_SymbolicLinkNameClear(dmfModule);
                 TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleOpen() fails: ntStatus=%!STATUS!", ntStatus);
                 goto Exit;
             }


### PR DESCRIPTION
Merge20221118

1. Fix issue in DMF_BufferPool to enforce that ClientBuffer is 4-byte aligned. Some NT APIs on ARM require 4-byte alignment. When Client buffer is not 4-byte aligned it is possible that elements may not be aligned when they are at the start of buffer.
2. Clear symbolic link on other failure paths in DMF_DeviceInterfaceTarget.