### PR TITLE
Restores compatibility with Windows 10 versions below 1803

### DIFF
--- a/Dmf/Modules.Library/Dmf_CrashDump.c
+++ b/Dmf/Modules.Library/Dmf_CrashDump.c
@@ -1915,9 +1915,8 @@ Return Value:
         goto Exit;
     }
     
-    t_KeInitializeTriageDumpDataArray fpInitializeTriage = (t_KeInitializeTriageDumpDataArray)MmGetSystemRoutineAddress(
-        (PUNICODE_STRING)&routineName
-    );
+    t_KeInitializeTriageDumpDataArray fpInitializeTriage = 
+        (t_KeInitializeTriageDumpDataArray)MmGetSystemRoutineAddress((PUNICODE_STRING)&routineName);
 
     if (fpInitializeTriage == NULL)
     {
@@ -4111,9 +4110,8 @@ Return Value:
     {
         DECLARE_CONST_UNICODE_STRING(routineName, L"KeAddTriageDumpDataBlock");
 
-        t_KeAddTriageDumpDataBlock fpDumpDataBlock = (t_KeAddTriageDumpDataBlock)MmGetSystemRoutineAddress(
-            (PUNICODE_STRING)&routineName
-        );
+        t_KeAddTriageDumpDataBlock fpDumpDataBlock = 
+            (t_KeAddTriageDumpDataBlock)MmGetSystemRoutineAddress((PUNICODE_STRING)&routineName);
 
         if (fpDumpDataBlock == NULL)
         {


### PR DESCRIPTION
This change converts hard-linking against `KeInitializeTriageDumpDataArray` and `KeAddTriageDumpDataBlock` (APIs only available since Windows 10 version 1803) into dynamically resolving them at runtime and soft-failing, if not found.

This restores full DMF compatibility again all the way down to Windows 10 version 1507.