### PR TITLE
Merge20230705

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.134
+// DMF Release: v1.1.135
 //
 
-#define DMF_VERSION 0x01010086
+#define DMF_VERSION 0x01010087
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
+++ b/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
@@ -210,5 +210,13 @@ Environment:
 //
 #define DmfBreak    DbgBreakPoint
 
+// There are many spin locks created which causes the number of WDF handles to be high.
+// In order to reduce the number of handles, for internal locks DMF can use the native OS
+// locks instead.
+//
+// NOTE: In Kernel-mode, minimize use of WDF handles.
+//
+#define DMF_ALWAYS_USE_WDF_HANDLES_DISABLE
+
 // eof: DmfIncludes_KERNEL_MODE.h
 //

--- a/Dmf/Framework/DmfIncludes_USER_MODE.h
+++ b/Dmf/Framework/DmfIncludes_USER_MODE.h
@@ -194,5 +194,13 @@ Environment:
 //
 #define DmfBreak    DebugBreak
 
+// There are many spin locks created which causes the number of WDF handles to be high.
+// In order to reduce the number of handles, for internal locks DMF can use the native OS
+// locks instead.
+// 
+// NOTE: In User-mode, do not minimize use of WDF handles.
+//
+#define DMF_ALWAYS_USE_WDF_HANDLES
+
 // eof: DmfIncludes_USER_MODE.h
 //

--- a/Dmf/Framework/DmfInternal.c
+++ b/Dmf/Framework/DmfInternal.c
@@ -1630,12 +1630,15 @@ Return Value:
 
     dmfObject = DMF_ModuleToObject(DmfModule);
 
-    WdfSpinLockAcquire(dmfObject->ReferenceCountLock);
+    GENERIC_SPINLOCK_CONTEXT lockContext;
+    DMF_GenericSpinLockAcquire(&dmfObject->ReferenceCountLock,
+                               &lockContext);
 
     moduleClosed = dmfObject->ModuleClosed;
     dmfObject->ModuleClosed = TRUE;
 
-    WdfSpinLockRelease(dmfObject->ReferenceCountLock);
+    DMF_GenericSpinLockRelease(&dmfObject->ReferenceCountLock,
+                               lockContext);
 
     return moduleClosed;
 }

--- a/Dmf/Framework/DmfLiveKernelDump.c
+++ b/Dmf/Framework/DmfLiveKernelDump.c
@@ -80,10 +80,6 @@ Return Value:
 --*/
 {
     DMFMODULE dmfModule;
-    VOID* dmfConfig;
-    VOID* clientModuleInstanceName;
-    size_t dmfConfigSize;
-    size_t clientModuleInstanceNameSize;
     DMF_OBJECT* childDmfObject;
     CHILD_OBJECT_INTERATION_CONTEXT childObjectIterationContext;
 
@@ -112,25 +108,16 @@ Return Value:
                                             DmfObject,
                                             sizeof(DMF_OBJECT));
 
-    if (DmfObject->ModuleConfigMemory != NULL)
+    if (DmfObject->ModuleConfig != NULL)
     {
-        dmfConfig = WdfMemoryGetBuffer(DmfObject->ModuleConfigMemory,
-                                       &dmfConfigSize);
-
         DMF_MODULE_LIVEKERNELDUMP_POINTER_STORE(dmfModule,
-                                                dmfConfig,
-                                                dmfConfigSize);
+                                                DmfObject->ModuleConfig,
+                                                DmfObject->ModuleConfigSize);
     }
 
-    if (DmfObject->ClientModuleInstanceNameMemory != NULL)
-    {
-        clientModuleInstanceName = WdfMemoryGetBuffer(DmfObject->ClientModuleInstanceNameMemory,
-                                                      &clientModuleInstanceNameSize);
-
-        DMF_MODULE_LIVEKERNELDUMP_POINTER_STORE(dmfModule,
-                                                clientModuleInstanceName,
-                                                clientModuleInstanceNameSize);
-    }
+    DMF_MODULE_LIVEKERNELDUMP_POINTER_STORE(dmfModule,
+                                            DmfObject->ClientModuleInstanceName,
+                                            DmfObject->ClientModuleInstanceNameSizeBytes);
 
     // Call the Module specific Initialize function where the Module can store 
     // private structures to the ring buffer.

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_SelfTarget.c
@@ -270,7 +270,13 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
                                    timeoutMs,
                                    Tests_SelfTarget_SendCompletion,
                                    moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Completion routine will not happen. Return buffer now or a leak happens.
+        //
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           sleepIoctlBuffer);
+    }
 
 #if !defined(TEST_SIMPLE)
     ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
@@ -294,7 +300,13 @@ Tests_SelfTarget_ThreadAction_Asynchronous(
                                    timeoutMs,
                                    Tests_SelfTarget_SendCompletion,
                                    moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Completion routine will not happen. Return buffer now or a leak happens.
+        //
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           sleepIoctlBuffer);
+    }
 #endif
 }
 #pragma code_seg()
@@ -343,7 +355,13 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Completion routine will not happen. Return buffer now or a leak happens.
+        //
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           sleepIoctlBuffer);
+    }
     ntStatus = DMF_AlertableSleep_Sleep(moduleContext->DmfModuleAlertableSleep[ThreadIndex],
                                         0,
                                         timeToSleepMilliseconds / 2);
@@ -376,7 +394,13 @@ Tests_SelfTarget_ThreadAction_AsynchronousCancel(
                                    ASYNCHRONOUS_REQUEST_TIMEOUT_MS,
                                    Tests_SelfTarget_SendCompletion,
                                    moduleContext);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    if (!NT_SUCCESS(ntStatus))
+    {
+        // Completion routine will not happen. Return buffer now or a leak happens.
+        //
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           sleepIoctlBuffer);
+    }
     DMF_AlertableSleep_ResetForReuse(moduleContext->DmfModuleAlertableSleep[ThreadIndex],
                                      0);
     ntStatus = DMF_AlertableSleep_Sleep(moduleContext->DmfModuleAlertableSleep[ThreadIndex],

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
@@ -518,6 +518,15 @@ Return Value:
         Target->DmfModuleRundown = NULL;
     }
 
+    // Delete the associated DmfModuleRequestTarget.
+    //
+    if (Target->DmfModuleRequestTarget != NULL)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "WdfObjectDelete(Target->DmfModuleRequestTarget=0x%p) Target=0x%p Target->IoTarget=0x%p", Target->DmfModuleRequestTarget, Target, Target->IoTarget);
+        WdfObjectDelete(Target->DmfModuleRequestTarget);
+        Target->DmfModuleRequestTarget = NULL;
+    }
+
     // In case WDFIOTARGET not previously deleted, delete it now.
     //
     if (IoTarget != NULL)


### PR DESCRIPTION
Merge20230705
1. Fix memory leak in DMF_DeviceInterfaceMultipleTarget.
2. Reduce the number of WDF handles DMF Core uses to a) reduce memory usage b) reduce chance of warning about many WDF objects possibly indicating a memory leak. (Kernel-mode only).
3. Fix an error in DMF_SelfTarget unit test.