### PR TITLE
Merge20230714

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.135
+// DMF Release: v1.1.136
 //
 
-#define DMF_VERSION 0x01010087
+#define DMF_VERSION 0x01010088
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfCall.c
+++ b/Dmf/Framework/DmfCall.c
@@ -584,13 +584,21 @@ Return Value:
                                          DMF_ModuleTreeDestroy,
                                          &DmfChildObjectIterateBackward);
 
-    // Dispatch callback to the given Parent DMF Module next.
-    //
-    DmfAssert(dmfObject->ModuleDescriptor.CallbacksDmf->ModuleInstanceDestroy != NULL);
-    // 'The current function is permitted to run at an IRQ level above the maximum permitted'
-    //
-    #pragma warning(suppress:28118)
-    (dmfObject->ModuleDescriptor.CallbacksDmf->ModuleInstanceDestroy)(dmfModule);
+    if (dmfObject->ModuleDescriptor.CallbacksDmf != NULL)
+    {
+        // Dispatch callback to the given Parent DMF Module next.
+        //
+        DmfAssert(dmfObject->ModuleDescriptor.CallbacksDmf->ModuleInstanceDestroy != NULL);
+        // 'The current function is permitted to run at an IRQ level above the maximum permitted'
+        //
+        #pragma warning(suppress:28118)
+        (dmfObject->ModuleDescriptor.CallbacksDmf->ModuleInstanceDestroy)(dmfModule);
+    }
+    else 
+    {
+        // NOTE: In cases of low memory or fault injection, CallbacksDmf can be NULL.
+        //
+    }
 
     // The Module Callback always does this. Do it for the Module.
     // NOTE: Don't delete the memory because it will be deleted by WDF.
@@ -612,8 +620,16 @@ Return Value:
     // Child is deleted so that Child can access Parent Module's
     // WDFOBJECT context while running down.
     //
-    WdfObjectDereferenceWithTag(objectToDereference,
-                                DMF_TAG_DYNAMIC_MODULE_REFERENCE);
+    if (objectToDereference != NULL)
+    {
+        WdfObjectDereferenceWithTag(objectToDereference,
+                                    DMF_TAG_DYNAMIC_MODULE_REFERENCE);
+    }
+    else
+    {
+        // It can be NULL in case of fault-injection or low memory scenarios.
+        //
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Dmf/Framework/DmfIncludeInternal.h
+++ b/Dmf/Framework/DmfIncludeInternal.h
@@ -38,6 +38,9 @@ Environment:
 typedef enum
 {
     ModuleState_Invalid = 0,
+    // The Module is being created.
+    //
+    ModuleState_PreCreate,
     // The Module has been created but not opened.
     //
     ModuleState_Created,
@@ -307,6 +310,15 @@ struct _DMF_OBJECT_
 // Memory Allocation Tag for Dmf. ('DmfT')
 //
 #define DMF_TAG                            'TfmD'
+#define DMF_TAG0                           '0fmD'
+#define DMF_TAG1                           '1fmD'
+#define DMF_TAG2                           '2fmD'
+#define DMF_TAG3                           '3fmD'
+#define DMF_TAG4                           '4fmD'
+#define DMF_TAG5                           '5fmD'
+#define DMF_TAG6                           '6fmD'
+#define DMF_TAG7                           '7fmD'
+#define DMF_TAG8                           '8fmD'
 
 #define DMF_TAG_DYNAMIC_MODULE_REFERENCE    ((VOID*)0x7654)
 
@@ -595,7 +607,7 @@ DMF_ModuleLiveKernelDump_ModuleCollectionInitialize(
 
 VOID*
 DMF_GenericMemoryAllocate(
-    _In_ ULONG PoolFlags,
+    _In_ ULONG64 PoolFlags,
     _In_ size_t Size,
     _In_ ULONG Tag
     );

--- a/Dmf/Framework/DmfModuleCollection.c
+++ b/Dmf/Framework/DmfModuleCollection.c
@@ -2838,7 +2838,7 @@ Return Value:
                                                  ModuleAttributes->SizeOfModuleSpecificConfig;
     ntStatus = WdfMemoryCreate(&objectAttributes,
                                NonPagedPoolNx,
-                               DMF_TAG,
+                               DMF_TAG5,
                                totalSizeOfAttributesAndCallbacksAndConfig,
                                &memoryConfigAndAttributes,
                                &memoryConfigAndAttributesBuffer);
@@ -3412,7 +3412,7 @@ Return Value:
     }
     ntStatus = WdfMemoryCreate(&attributes,
                                NonPagedPoolNx,
-                               DMF_TAG,
+                               DMF_TAG6,
                                sizeof(DMF_MODULE_COLLECTION),
                                &moduleCollectionHandleMemory,
                                (VOID**)&moduleCollectionHandle);
@@ -3453,7 +3453,7 @@ Return Value:
         attributes.ParentObject = (DMFCOLLECTION)(moduleCollectionHandle->ModuleCollectionHandleMemory);
         ntStatus = WdfMemoryCreate(&attributes,
                                    NonPagedPoolNx,
-                                   DMF_TAG,
+                                   DMF_TAG8,
                                    sizeof(DMF_OBJECT*) * numberOfClientModulesToCreate,
                                    &moduleCollectionHandle->ClientDriverDmfModulesMemory,
                                    (VOID**)&moduleCollectionHandle->ClientDriverDmfModules);

--- a/Dmf/Framework/DmfUtility.c
+++ b/Dmf/Framework/DmfUtility.c
@@ -609,7 +609,7 @@ Return Value:
     WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
     ntStatus = WdfMemoryCreate(&attributes,
                                 NonPagedPoolNx,
-                                DMF_TAG,
+                                DMF_TAG7,
                                 outputString.MaximumLength,
                                 &writeBufferMemoryHandle,
                                 (PVOID*)&outputString.Buffer);

--- a/Dmf/Framework/DmfValidate.c
+++ b/Dmf/Framework/DmfValidate.c
@@ -191,8 +191,7 @@ Return Value:
     DmfAssert(DmfObject != NULL);
     DmfAssert(DMF_OBJECT_SIGNATURE == DmfObject->Signature);
     DmfAssert(((ModuleState_Opened == DmfObject->ModuleState) || (ModuleState_Created == DmfObject->ModuleState)) ||
-              ((DmfObject->DmfObjectParent != NULL) && (DmfObject->ModuleState == ModuleState_Closed))
-              );
+              ((DmfObject->DmfObjectParent != NULL) && (DmfObject->ModuleState == ModuleState_Closed)));
 }
 
 VOID
@@ -282,7 +281,8 @@ Return Value:
     DmfAssert(DmfObject != NULL);
     DmfAssert(DMF_OBJECT_SIGNATURE == DmfObject->Signature);
     DmfAssert((ModuleState_Closed == DmfObject->ModuleState) ||
-              (ModuleState_Created == DmfObject->ModuleState));
+              (ModuleState_Created == DmfObject->ModuleState) ||
+              (ModuleState_PreCreate == DmfObject->ModuleState));
 }
 
 VOID

--- a/Dmf/Modules.Library/Dmf_HidTarget.h
+++ b/Dmf/Modules.Library/Dmf_HidTarget.h
@@ -203,6 +203,14 @@ DMF_HidTarget_FeatureSetEx(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 _Must_inspect_result_
 NTSTATUS
+DMF_HidTarget_HidCollectionInformationGet(
+    _In_ DMFMODULE DmfModule,
+    _Out_ HID_COLLECTION_INFORMATION* CollectionInformation
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
 DMF_HidTarget_InputRead(
     _In_ DMFMODULE DmfModule
     );


### PR DESCRIPTION
Merge20230714

1. Fix regression in pre-1809 Windows due to ExAllocatePool2.
2. Track buffers actually used in BufferPool so that better initial preallocation choices can be made.
3. Fix BSOD when Modules are created and memory is not available. (Fault injection/low memory situations.) Also fix associated asserts that failed in this case.
4. Use more tags to make it easier to understand what memory is allocated. (No logical change to algorithm...just additional counters.)
5. Add DMF_HidTarget_HidCollectionInformationGet() to HidTarget Module.