### PR TITLE
Merge202040409

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.143
+// DMF Release: v1.1.144
 //
 
-#define DMF_VERSION 0x0101008F
+#define DMF_VERSION 0x01010090
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
@@ -48,6 +48,13 @@ Environment:
 #define TIMEOUT_SLOW_MS             5000
 #define TIMEOUT_TRAFFIC_DELAY_MS    1000
 
+#define USE_STREAMING
+#if defined(USE_STREAMING)
+    #define NUMBER_OF_CONTINUOUS_REQUESTS   1
+#else
+    #define NUMBER_OF_CONTINUOUS_REQUESTS   0
+#endif
+
 // This is returned from User-mode stack sometimes.
 // TODO: Investigate root cause.
 //
@@ -1188,6 +1195,7 @@ Return Value:
         WdfIoTargetStart(moduleContext->IoTargetPassiveOutputZeroSize);
     }
 
+#if defined(USE_STREAMING)
     ntStatus = DMF_DefaultTarget_StreamStart(moduleContext->DmfModuleDefaultTargetPassiveInput);
     DmfAssert(NT_SUCCESS(ntStatus));
 
@@ -1196,6 +1204,7 @@ Return Value:
 
     ntStatus = DMF_DefaultTarget_StreamStart(moduleContext->DmfModuleDefaultTargetPassiveOutputZeroSize);
     DmfAssert(NT_SUCCESS(ntStatus));
+#endif
 
     ntStatus = Tests_DefaultTarget_NonContinousStartAuto(DmfModule);
     DmfAssert(NT_SUCCESS(ntStatus));
@@ -1256,9 +1265,11 @@ Return Value:
     Tests_DefaultTarget_NonContinousStopAuto(DmfModule);
     Tests_DefaultTarget_NonContinousStopManual(DmfModule);
 
+#if defined(USE_STREAMING)
     DMF_DefaultTarget_StreamStop(moduleContext->DmfModuleDefaultTargetPassiveInput);
     DMF_DefaultTarget_StreamStop(moduleContext->DmfModuleDefaultTargetPassiveOutput);
     DMF_DefaultTarget_StreamStop(moduleContext->DmfModuleDefaultTargetPassiveOutputZeroSize);
+#endif
 
     ntStatus = STATUS_SUCCESS;
 
@@ -1333,9 +1344,9 @@ Return Value:
     //
     DMF_CONFIG_DefaultTarget_AND_ATTRIBUTES_INIT(&moduleConfigDefaultTarget,
                                                  &moduleAttributes);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferInputSize = sizeof(Tests_IoctlHandler_Sleep);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PoolTypeInput = NonPagedPoolNx;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_SLEEP;
@@ -1353,9 +1364,9 @@ Return Value:
     //
     DMF_CONFIG_DefaultTarget_AND_ATTRIBUTES_INIT(&moduleConfigDefaultTarget,
                                                  &moduleAttributes);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountInput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferInputSize = sizeof(Tests_IoctlHandler_Sleep);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PoolTypeInput = NonPagedPoolNx;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_SLEEP;
@@ -1374,9 +1385,9 @@ Return Value:
     //
     DMF_CONFIG_DefaultTarget_AND_ATTRIBUTES_INIT(&moduleConfigDefaultTarget,
                                                  &moduleAttributes);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = sizeof(DWORD);
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PoolTypeOutput = NonPagedPoolNx;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.PurgeAndStartTargetInD0Callbacks = FALSE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROBUFFER;
@@ -1444,7 +1455,7 @@ Return Value:
                                                  &moduleAttributes);
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferCountOutput = 0;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.BufferOutputSize = 0;
-    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = 1;
+    moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestCount = NUMBER_OF_CONTINUOUS_REQUESTS;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.ContinuousRequestTargetIoctl = IOCTL_Tests_IoctlHandler_ZEROSIZE;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.EvtContinuousRequestTargetBufferOutput = Tests_DefaultTarget_BufferOutputZeroSize;
     moduleConfigDefaultTarget.ContinuousRequestTargetModuleConfig.RequestType = ContinuousRequestTarget_RequestType_Ioctl;

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
@@ -323,7 +323,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DefaultTarget_SendCompletion(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDefaultTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -332,19 +332,23 @@ Tests_DefaultTarget_SendCompletion(
     _In_ NTSTATUS CompletionStatus
     )
 {
+    DMFMODULE dmfModule;
     DMF_CONTEXT_Tests_DefaultTarget* moduleContext;
     Tests_IoctlHandler_Sleep* sleepIoctlBuffer;
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBuffer);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DefaultTarget*)ClientRequestContext;
+    dmfModule = DMF_ParentModuleGet(DmfModuleDefaultTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DefaultTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
     DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
                        (VOID*)sleepIoctlBuffer);
@@ -355,7 +359,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DefaultTarget_SendCompletionMustBeCancelled(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDefaultTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -364,18 +368,22 @@ Tests_DefaultTarget_SendCompletionMustBeCancelled(
     _In_ NTSTATUS CompletionStatus
     )
 {
+    DMFMODULE dmfModule;
     DMF_CONTEXT_Tests_DefaultTarget* moduleContext;
     Tests_IoctlHandler_Sleep* sleepIoctlBuffer;
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DefaultTarget*)ClientRequestContext;
+    dmfModule = DMF_ParentModuleGet(DmfModuleDefaultTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DefaultTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
     DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
                        (VOID*)sleepIoctlBuffer);

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
@@ -592,7 +592,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DeviceInterfaceMultipleTarget_SendCompletion(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDeviceInterfaceMultipleTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -627,14 +627,17 @@ Return Value:
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBuffer);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget*)ClientRequestContext;
+    DMFMODULE dmfModule = DMF_ParentModuleGet(DmfModuleDeviceInterfaceMultipleTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "MDI: RECEIVE sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p", 
@@ -650,7 +653,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DeviceInterfaceMultipleTarget_SendCompletionMustBeCancelled(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDeviceInterfaceMultipleTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -685,13 +688,16 @@ Return Value:
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget*)ClientRequestContext;
+    DMFMODULE dmfModule = DMF_ParentModuleGet(DmfModuleDeviceInterfaceMultipleTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DeviceInterfaceMultipleTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "MDI: CANCELED sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p", 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -528,7 +528,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DeviceInterfaceTarget_SendCompletion(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDeviceInterfaceTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -542,14 +542,17 @@ Tests_DeviceInterfaceTarget_SendCompletion(
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBuffer);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceTarget*)ClientRequestContext;
+    DMFMODULE dmfModule = DMF_ParentModuleGet(DmfModuleDeviceInterfaceTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DeviceInterfaceTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DI: RECEIVE sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p CompletionStatus=%!STATUS!", 
@@ -566,7 +569,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 _IRQL_requires_same_
 VOID
 Tests_DeviceInterfaceTarget_SendCompletionMustBeCancelled(
-    _In_ DMFMODULE DmfModule,
+    _In_ DMFMODULE DmfModuleDeviceInterfaceTarget,
     _In_ VOID* ClientRequestContext,
     _In_reads_(InputBufferBytesWritten) VOID* InputBuffer,
     _In_ size_t InputBufferBytesWritten,
@@ -580,13 +583,16 @@ Tests_DeviceInterfaceTarget_SendCompletionMustBeCancelled(
 
     // TODO: Get time and compare with send time.
     //
-    UNREFERENCED_PARAMETER(DmfModule);
+    UNREFERENCED_PARAMETER(ClientRequestContext);
     UNREFERENCED_PARAMETER(InputBufferBytesWritten);
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputBufferBytesRead);
     UNREFERENCED_PARAMETER(CompletionStatus);
 
-    moduleContext = (DMF_CONTEXT_Tests_DeviceInterfaceTarget*)ClientRequestContext;
+    DMFMODULE dmfModule = DMF_ParentModuleGet(DmfModuleDeviceInterfaceTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+    DmfAssert(moduleContext == (DMF_CONTEXT_Tests_DeviceInterfaceTarget*)ClientRequestContext);
+
     sleepIoctlBuffer = (Tests_IoctlHandler_Sleep*)InputBuffer;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DI: CANCELED sleepIoctlBuffer->TimeToSleepMilliseconds=%d InputBuffer=0x%p", 

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
@@ -72,7 +72,12 @@ DEFINE_GUID(GUID_NO_DEVICE, 0x5f4f3758, 0xd11e, 0x4684, 0xb5, 0xad, 0xfe, 0x6d, 
 #define TIMEOUT_CANCEL_MS           15
 #define TIMEOUT_CANCEL_LONG_MS      250
 
-#define NUMBER_OF_CONTINUOUS_REQUESTS   32
+#define USE_STREAMING
+#if defined(USE_STREAMING)
+    #define NUMBER_OF_CONTINUOUS_REQUESTS   32
+#else
+    #define NUMBER_OF_CONTINUOUS_REQUESTS   0
+#endif
 
 typedef enum _TEST_ACTION
 {
@@ -1878,9 +1883,13 @@ Return Value:
                                          0);
     }
 
+#if defined(USE_STREAMING)
     // Start streaming.
     //
     ntStatus = DMF_DeviceInterfaceTarget_StreamStart(DmfModule);
+#else
+    ntStatus = STATUS_SUCCESS;
+#endif
     if (NT_SUCCESS(ntStatus))
     {
         // Start threads.
@@ -1949,9 +1958,13 @@ Return Value:
                                          0);
     }
 
+#if defined(USE_STREAMING)
     // Start streaming.
     //
     ntStatus = DMF_DeviceInterfaceTarget_StreamStart(DmfModule);
+#else
+    ntStatus = STATUS_SUCCESS;
+#endif
     if (NT_SUCCESS(ntStatus))
     {
         // Start threads.
@@ -2010,9 +2023,11 @@ Return Value:
                          WdfIoTargetPurgeIoAndWait);
     }
 
+#if defined(USE_STREAMING)
     // Stop streaming.
     //
     DMF_DeviceInterfaceTarget_StreamStop(DmfModule);
+#endif
     // Stop threads.
     //
     Tests_DeviceInterfaceTarget_StopPassiveInput(dmfModuleParent);
@@ -2065,9 +2080,11 @@ Return Value:
                          WdfIoTargetPurgeIoAndWait);
     }
 
+#if defined(USE_STREAMING)
     // Stop streaming.
     //
     DMF_DeviceInterfaceTarget_StreamStop(DmfModule);
+#endif
     // Stop threads.
     //
     Tests_DeviceInterfaceTarget_StopPassiveOutput(dmfModuleParent);

--- a/Dmf/Modules.Library/DmfModules.Library.h
+++ b/Dmf/Modules.Library/DmfModules.Library.h
@@ -116,6 +116,7 @@ extern "C"
 //
 #include "Dmf_EyeGazeIoctl.h"
 #include "Dmf_HidPortableDeviceButtons.h"
+#include "Dmf_HidDeviceListener.h"
 #include "Dmf_VirtualEyeGaze.h"
 #include "Dmf_VirtualHidAmbientColorSensor.h"
 #include "Dmf_VirtualHidAmbientLightSensor.h"

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.c
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.c
@@ -572,7 +572,7 @@ DefaultTarget_Target_SendEx(
     completionCallbackContext->SendCompletionCallback = EvtRequestSinkSingleAsynchronousRequest;
     completionCallbackContext->SendCompletionCallbackContext = SingleAsynchronousRequestClientContext;
 
-    ntStatus = DMF_RequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
+    ntStatus = DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
                                         RequestBuffer,
                                         RequestLength,
                                         ResponseBuffer,

--- a/Dmf/Modules.Library/Dmf_DefaultTarget.c
+++ b/Dmf/Modules.Library/Dmf_DefaultTarget.c
@@ -142,6 +142,9 @@ typedef struct _DMF_CONTEXT_DefaultTarget
     //
     DMFMODULE DmfModuleContinuousRequestTarget;
     DMFMODULE DmfModuleRequestTarget;
+    // Stores callback/callback context for asynchronous sends.
+    //
+    DMFMODULE DmfModuleBufferPool;
     RequestSink_SendSynchronously_Type* RequestSink_SendSynchronously;
     RequestSink_Send_Type* RequestSink_Send;
     RequestSink_SendEx_Type* RequestSink_SendEx;
@@ -166,6 +169,77 @@ DMF_MODULE_DECLARE_CONFIG(DefaultTarget)
 // DMF Module Support Code
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+
+// Context that stores client's callback information so that proper callback chaining happens.
+//
+typedef struct
+{
+    // Client's callbck.
+    //
+    EVT_DMF_RequestTarget_SendCompletion* SendCompletionCallback;
+    // Client's callback context.
+    //
+    VOID* SendCompletionCallbackContext;
+} DefaultTarget_SingleAsynchronousRequestContext;
+
+_Function_class_(EVT_DMF_RequestTarget_SendCompletion)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+DefaultTarget_SendCompletion(
+    _In_ DMFMODULE DmfModuleContinuousRequestTarget,
+    _In_ VOID* ClientRequestContext,
+    _In_reads_(InputBufferBytesRead) VOID* InputBuffer,
+    _In_ size_t InputBufferBytesRead,
+    _In_reads_(OutputBufferBytesWritten) VOID* OutputBuffer,
+    _In_ size_t OutputBufferBytesWritten,
+    _In_ NTSTATUS CompletionStatus
+    )
+/*++
+
+Routine Description:
+
+    Completion routine for _Send() and _SendEx().
+
+Arguments:
+
+    DmfModuleContinuousRequestTarget - Child Module that calls this callback.
+    ClientRequestContext - Context passed by caller of _Send() or _SendEx().
+    InputBuffer - Input buffer  passed by caller of _Send() or _SendEx().
+    InputBufferBytesRead - Bytes read by WDFIOTARGET.
+    OutputBuffer - Output buffer  passed by caller of _Send() or _SendEx().
+    OutputBufferBytesRead - Bytes written by WDFIOTARGET.
+    CompletionStatus - Completion status returned by WDFIOTARGET.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMFMODULE dmfModule;
+    DMF_CONTEXT_DefaultTarget* moduleContext;
+    DefaultTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+
+    dmfModule = DMF_ParentModuleGet(DmfModuleContinuousRequestTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+
+    completionCallbackContext = (DefaultTarget_SingleAsynchronousRequestContext*)ClientRequestContext;
+
+    if (completionCallbackContext->SendCompletionCallback != NULL)
+    {
+        completionCallbackContext->SendCompletionCallback(dmfModule,
+                                                          completionCallbackContext->SendCompletionCallbackContext,
+                                                          InputBuffer,
+                                                          InputBufferBytesRead,
+                                                          OutputBuffer,
+                                                          OutputBufferBytesWritten,
+                                                          CompletionStatus);
+    }
+
+    DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                       completionCallbackContext);
+}
 
 // ContinuousRequestTarget Methods
 // -------------------------------
@@ -223,6 +297,22 @@ DefaultTarget_Stream_SendSynchronously(
 
 _Must_inspect_result_
 NTSTATUS
+DefaultTarget_Stream_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_opt_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
+    );
+
+_Must_inspect_result_
+NTSTATUS
 DefaultTarget_Stream_Send(
     _In_ DMFMODULE DmfModule,
     _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
@@ -241,16 +331,17 @@ DefaultTarget_Stream_Send(
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(moduleContext->OpenedInStreamMode);
-    return DMF_ContinuousRequestTarget_Send(moduleContext->DmfModuleContinuousRequestTarget,
-                                            RequestBuffer,
-                                            RequestLength,
-                                            ResponseBuffer,
-                                            ResponseLength,
-                                            RequestType,
-                                            RequestIoctl,
-                                            RequestTimeoutMilliseconds,
-                                            EvtRequestSinkSingleAsynchronousRequest,
-                                            SingleAsynchronousRequestClientContext);
+    return DefaultTarget_Stream_SendEx(DmfModule,
+                                       RequestBuffer,
+                                       RequestLength,
+                                       ResponseBuffer,
+                                       ResponseLength,
+                                       RequestType,
+                                       RequestIoctl,
+                                       RequestTimeoutMilliseconds,
+                                       EvtRequestSinkSingleAsynchronousRequest,
+                                       SingleAsynchronousRequestClientContext,
+                                       NULL);
 }
 
 _Must_inspect_result_
@@ -270,22 +361,44 @@ DefaultTarget_Stream_SendEx(
     )
 {
     DMF_CONTEXT_DefaultTarget* moduleContext;
+    DefaultTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+    NTSTATUS ntStatus;
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(moduleContext->OpenedInStreamMode);
 
-    return DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
-                                              RequestBuffer,
-                                              RequestLength,
-                                              ResponseBuffer,
-                                              ResponseLength,
-                                              RequestType,
-                                              RequestIoctl,
-                                              RequestTimeoutMilliseconds,
-                                              EvtRequestSinkSingleAsynchronousRequest,
-                                              SingleAsynchronousRequestClientContext,
-                                              DmfRequestId);
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&completionCallbackContext,
+                                  NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    completionCallbackContext->SendCompletionCallback = EvtRequestSinkSingleAsynchronousRequest;
+    completionCallbackContext->SendCompletionCallbackContext = SingleAsynchronousRequestClientContext;
+
+    ntStatus = DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
+                                                  RequestBuffer,
+                                                  RequestLength,
+                                                  ResponseBuffer,
+                                                  ResponseLength,
+                                                  RequestType,
+                                                  RequestIoctl,
+                                                  RequestTimeoutMilliseconds,
+                                                  DefaultTarget_SendCompletion,
+                                                  completionCallbackContext,
+                                                  DmfRequestId);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           completionCallbackContext);
+    }
+
+Exit:
+
+    return ntStatus;
 }
 
 VOID
@@ -374,6 +487,22 @@ DefaultTarget_Target_SendSynchronously(
 
 _Must_inspect_result_
 NTSTATUS
+DefaultTarget_Target_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_opt_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
+    );
+
+_Must_inspect_result_
+NTSTATUS
 DefaultTarget_Target_Send(
     _In_ DMFMODULE DmfModule,
     _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
@@ -393,16 +522,17 @@ DefaultTarget_Target_Send(
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(! moduleContext->OpenedInStreamMode);
-    ntStatus = DMF_RequestTarget_Send(moduleContext->DmfModuleRequestTarget,
-                                      RequestBuffer,
-                                      RequestLength,
-                                      ResponseBuffer,
-                                      ResponseLength,
-                                      RequestType,
-                                      RequestIoctl,
-                                      RequestTimeoutMilliseconds,
-                                      EvtRequestSinkSingleAsynchronousRequest,
-                                      SingleAsynchronousRequestClientContext);
+    ntStatus = DefaultTarget_Target_SendEx(DmfModule,
+                                           RequestBuffer,
+                                           RequestLength,
+                                           ResponseBuffer,
+                                           ResponseLength,
+                                           RequestType,
+                                           RequestIoctl,
+                                           RequestTimeoutMilliseconds,
+                                           EvtRequestSinkSingleAsynchronousRequest,
+                                           SingleAsynchronousRequestClientContext,
+                                           NULL);
 
     return ntStatus;
 }
@@ -424,22 +554,44 @@ DefaultTarget_Target_SendEx(
     )
 {
     DMF_CONTEXT_DefaultTarget* moduleContext;
+    DefaultTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+    NTSTATUS ntStatus;
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(! moduleContext->OpenedInStreamMode);
 
-    return DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
-                                    RequestBuffer,
-                                    RequestLength,
-                                    ResponseBuffer,
-                                    ResponseLength,
-                                    RequestType,
-                                    RequestIoctl,
-                                    RequestTimeoutMilliseconds,
-                                    EvtRequestSinkSingleAsynchronousRequest,
-                                    SingleAsynchronousRequestClientContext,
-                                    DmfRequestId);
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&completionCallbackContext,
+                                  NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    completionCallbackContext->SendCompletionCallback = EvtRequestSinkSingleAsynchronousRequest;
+    completionCallbackContext->SendCompletionCallbackContext = SingleAsynchronousRequestClientContext;
+
+    ntStatus = DMF_RequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
+                                        RequestBuffer,
+                                        RequestLength,
+                                        ResponseBuffer,
+                                        ResponseLength,
+                                        RequestType,
+                                        RequestIoctl,
+                                        RequestTimeoutMilliseconds,
+                                        DefaultTarget_SendCompletion,
+                                        completionCallbackContext,
+                                        DmfRequestId);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           completionCallbackContext);
+    }
+
+Exit:
+
+    return ntStatus;
 }
 
 VOID
@@ -857,6 +1009,27 @@ Return Value:
 
     moduleConfig = DMF_CONFIG_GET(DmfModule);
     moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    // BufferPoolContext
+    // -----------------
+    //
+    DMF_CONFIG_BufferPool moduleConfigBufferPool;
+    DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+                                              &moduleAttributes);
+    moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
+    moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = TRUE;
+    moduleConfigBufferPool.Mode.SourceSettings.BufferCount = 1;
+    // NOTE: BufferPool context must always be NonPagedPool because it is accessed in the
+    //       completion routine running at DISPATCH_LEVEL.
+    //
+    moduleConfigBufferPool.Mode.SourceSettings.PoolType = NonPagedPoolNx;
+    moduleConfigBufferPool.Mode.SourceSettings.BufferSize = sizeof(DefaultTarget_SingleAsynchronousRequestContext);
+    moduleAttributes.ClientModuleInstanceName = "BufferPoolContext";
+    moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleBufferPool);
 
     // If Client has set ContinousRequestCount > 0, then it means streaming is capable.
     // Otherwise, streaming is not capable.

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -191,6 +191,9 @@ typedef struct _DMF_CONTEXT_DeviceInterfaceTarget
     //
     DMFMODULE DmfModuleContinuousRequestTarget;
     DMFMODULE DmfModuleRequestTarget;
+    // Stores callback/callback context for asynchronous sends.
+    //
+    DMFMODULE DmfModuleBufferPool;
     RequestSink_SendSynchronously_Type* RequestSink_SendSynchronously;
     RequestSink_Send_Type* RequestSink_Send;
     RequestSink_SendEx_Type* RequestSink_SendEx;
@@ -223,6 +226,77 @@ DMF_MODULE_DECLARE_CONFIG(DeviceInterfaceTarget)
 // DMF Module Support Code
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+
+// Context that stores client's callback information so that proper callback chaining happens.
+//
+typedef struct
+{
+    // Client's callbck.
+    //
+    EVT_DMF_RequestTarget_SendCompletion* SendCompletionCallback;
+    // Client's callback context.
+    //
+    VOID* SendCompletionCallbackContext;
+} DeviceInterfaceTarget_SingleAsynchronousRequestContext;
+
+_Function_class_(EVT_DMF_RequestTarget_SendCompletion)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_IRQL_requires_same_
+VOID
+DeviceInterfaceTarget_SendCompletion(
+    _In_ DMFMODULE DmfModuleContinuousRequestTarget,
+    _In_ VOID* ClientRequestContext,
+    _In_reads_(InputBufferBytesRead) VOID* InputBuffer,
+    _In_ size_t InputBufferBytesRead,
+    _In_reads_(OutputBufferBytesWritten) VOID* OutputBuffer,
+    _In_ size_t OutputBufferBytesWritten,
+    _In_ NTSTATUS CompletionStatus
+    )
+/*++
+
+Routine Description:
+
+    Completion routine for _Send() and _SendEx().
+
+Arguments:
+
+    DmfModuleContinuousRequestTarget - Child Module that calls this callback.
+    ClientRequestContext - Context passed by caller of _Send() or _SendEx().
+    InputBuffer - Input buffer  passed by caller of _Send() or _SendEx().
+    InputBufferBytesRead - Bytes read by WDFIOTARGET.
+    OutputBuffer - Output buffer  passed by caller of _Send() or _SendEx().
+    OutputBufferBytesRead - Bytes written by WDFIOTARGET.
+    CompletionStatus - Completion status returned by WDFIOTARGET.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMFMODULE dmfModule;
+    DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
+    DeviceInterfaceTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+
+    dmfModule = DMF_ParentModuleGet(DmfModuleContinuousRequestTarget);
+    moduleContext = DMF_CONTEXT_GET(dmfModule);
+
+    completionCallbackContext = (DeviceInterfaceTarget_SingleAsynchronousRequestContext*)ClientRequestContext;
+
+    if (completionCallbackContext->SendCompletionCallback != NULL)
+    {
+        completionCallbackContext->SendCompletionCallback(dmfModule,
+                                                          completionCallbackContext->SendCompletionCallbackContext,
+                                                          InputBuffer,
+                                                          InputBufferBytesRead,
+                                                          OutputBuffer,
+                                                          OutputBufferBytesWritten,
+                                                          CompletionStatus);
+    }
+
+    DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                       completionCallbackContext);
+}
 
 ModuleCloseReason_Type
 DeviceInterfaceTarget_ModuleCloseReasonSet(
@@ -512,6 +586,25 @@ DeviceInterfaceTarget_Stream_SendSynchronously(
                                                          BytesWritten);
 }
 
+// TEMPORARY: This is here to make code review eaiser.
+//            Remove after code review and move this function under the next function.
+//
+_Must_inspect_result_
+NTSTATUS
+DeviceInterfaceTarget_Stream_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_opt_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
+    );
+
 _Must_inspect_result_
 NTSTATUS
 DeviceInterfaceTarget_Stream_Send(
@@ -527,22 +620,17 @@ DeviceInterfaceTarget_Stream_Send(
     _In_opt_ VOID* SingleAsynchronousRequestClientContext
     )
 {
-    DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
-
-    moduleContext = DMF_CONTEXT_GET(DmfModule);
-
-    DmfAssert(moduleContext->ContinuousReaderMode);
-    return DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
-                                              RequestBuffer,
-                                              RequestLength,
-                                              ResponseBuffer,
-                                              ResponseLength,
-                                              RequestType,
-                                              RequestIoctl,
-                                              RequestTimeoutMilliseconds,
-                                              EvtRequestSinkSingleAsynchronousRequest,
-                                              SingleAsynchronousRequestClientContext,
-                                              NULL);
+    return DeviceInterfaceTarget_Stream_SendEx(DmfModule,
+                                               RequestBuffer,
+                                               RequestLength,
+                                               ResponseBuffer,
+                                               ResponseLength,
+                                               RequestType,
+                                               RequestIoctl,
+                                               RequestTimeoutMilliseconds,
+                                               EvtRequestSinkSingleAsynchronousRequest,
+                                               SingleAsynchronousRequestClientContext,
+                                               NULL);
 }
 
 _Must_inspect_result_
@@ -562,22 +650,44 @@ DeviceInterfaceTarget_Stream_SendEx(
     )
 {
     DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
+    DeviceInterfaceTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+    NTSTATUS ntStatus;
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(moduleContext->ContinuousReaderMode);
 
-    return DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
-                                              RequestBuffer,
-                                              RequestLength,
-                                              ResponseBuffer,
-                                              ResponseLength,
-                                              RequestType,
-                                              RequestIoctl,
-                                              RequestTimeoutMilliseconds,
-                                              EvtRequestSinkSingleAsynchronousRequest,
-                                              SingleAsynchronousRequestClientContext,
-                                              DmfRequestId);
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&completionCallbackContext,
+                                  NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    completionCallbackContext->SendCompletionCallback = EvtRequestSinkSingleAsynchronousRequest;
+    completionCallbackContext->SendCompletionCallbackContext = SingleAsynchronousRequestClientContext;
+
+    ntStatus = DMF_ContinuousRequestTarget_SendEx(moduleContext->DmfModuleContinuousRequestTarget,
+                                                  RequestBuffer,
+                                                  RequestLength,
+                                                  ResponseBuffer,
+                                                  ResponseLength,
+                                                  RequestType,
+                                                  RequestIoctl,
+                                                  RequestTimeoutMilliseconds,
+                                                  DeviceInterfaceTarget_SendCompletion,
+                                                  completionCallbackContext,
+                                                  DmfRequestId);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           completionCallbackContext);
+    }
+
+Exit:
+
+    return ntStatus;
 }
 
 VOID
@@ -664,6 +774,25 @@ DeviceInterfaceTarget_Target_SendSynchronously(
     return ntStatus;
 }
 
+// TEMPORARY: This is here to make code review eaiser.
+//            Remove after code review and move this function under the next function.
+//
+_Must_inspect_result_
+NTSTATUS
+DeviceInterfaceTarget_Target_SendEx(
+    _In_ DMFMODULE DmfModule,
+    _In_reads_bytes_opt_(RequestLength) VOID* RequestBuffer,
+    _In_ size_t RequestLength,
+    _Out_writes_bytes_opt_(ResponseLength) VOID* ResponseBuffer,
+    _In_ size_t ResponseLength,
+    _In_ ContinuousRequestTarget_RequestType RequestType,
+    _In_ ULONG RequestIoctl,
+    _In_ ULONG RequestTimeoutMilliseconds,
+    _In_opt_ EVT_DMF_RequestTarget_SendCompletion* EvtRequestSinkSingleAsynchronousRequest,
+    _In_opt_ VOID* SingleAsynchronousRequestClientContext,
+    _Out_opt_ RequestTarget_DmfRequest* DmfRequestId
+    );
+
 _Must_inspect_result_
 NTSTATUS
 DeviceInterfaceTarget_Target_Send(
@@ -685,17 +814,17 @@ DeviceInterfaceTarget_Target_Send(
 
     DmfAssert(! moduleContext->ContinuousReaderMode);
 
-    return DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
-                                    RequestBuffer,
-                                    RequestLength,
-                                    ResponseBuffer,
-                                    ResponseLength,
-                                    RequestType,
-                                    RequestIoctl,
-                                    RequestTimeoutMilliseconds,
-                                    EvtRequestSinkSingleAsynchronousRequest,
-                                    SingleAsynchronousRequestClientContext,
-                                    NULL);
+    return DeviceInterfaceTarget_Target_SendEx(moduleContext->DmfModuleRequestTarget,
+                                               RequestBuffer,
+                                               RequestLength,
+                                               ResponseBuffer,
+                                               ResponseLength,
+                                               RequestType,
+                                               RequestIoctl,
+                                               RequestTimeoutMilliseconds,
+                                               EvtRequestSinkSingleAsynchronousRequest,
+                                               SingleAsynchronousRequestClientContext,
+                                               NULL);
 }
 
 _Must_inspect_result_
@@ -715,22 +844,44 @@ DeviceInterfaceTarget_Target_SendEx(
     )
 {
     DMF_CONTEXT_DeviceInterfaceTarget* moduleContext;
+    DeviceInterfaceTarget_SingleAsynchronousRequestContext* completionCallbackContext;
+    NTSTATUS ntStatus;
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
 
     DmfAssert(! moduleContext->ContinuousReaderMode);
 
-    return DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
-                                    RequestBuffer,
-                                    RequestLength,
-                                    ResponseBuffer,
-                                    ResponseLength,
-                                    RequestType,
-                                    RequestIoctl,
-                                    RequestTimeoutMilliseconds,
-                                    EvtRequestSinkSingleAsynchronousRequest,
-                                    SingleAsynchronousRequestClientContext,
-                                    DmfRequestId);
+    ntStatus = DMF_BufferPool_Get(moduleContext->DmfModuleBufferPool,
+                                  (VOID**)&completionCallbackContext,
+                                  NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        goto Exit;
+    }
+
+    completionCallbackContext->SendCompletionCallback = EvtRequestSinkSingleAsynchronousRequest;
+    completionCallbackContext->SendCompletionCallbackContext = SingleAsynchronousRequestClientContext;
+
+    ntStatus = DMF_RequestTarget_SendEx(moduleContext->DmfModuleRequestTarget,
+                                        RequestBuffer,
+                                        RequestLength,
+                                        ResponseBuffer,
+                                        ResponseLength,
+                                        RequestType,
+                                        RequestIoctl,
+                                        RequestTimeoutMilliseconds,
+                                        DeviceInterfaceTarget_SendCompletion,
+                                        completionCallbackContext,
+                                        DmfRequestId);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        DMF_BufferPool_Put(moduleContext->DmfModuleBufferPool,
+                           completionCallbackContext);
+    }
+
+Exit:
+
+    return ntStatus;
 }
 
 VOID
@@ -2376,6 +2527,27 @@ Return Value:
 
     moduleConfig = DMF_CONFIG_GET(DmfModule);
     moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    // BufferPoolContext
+    // -----------------
+    //
+    DMF_CONFIG_BufferPool moduleConfigBufferPool;
+    DMF_CONFIG_BufferPool_AND_ATTRIBUTES_INIT(&moduleConfigBufferPool,
+                                              &moduleAttributes);
+    moduleConfigBufferPool.BufferPoolMode = BufferPool_Mode_Source;
+    moduleConfigBufferPool.Mode.SourceSettings.EnableLookAside = TRUE;
+    moduleConfigBufferPool.Mode.SourceSettings.BufferCount = 1;
+    // NOTE: BufferPool context must always be NonPagedPool because it is accessed in the
+    //       completion routine running at DISPATCH_LEVEL.
+    //
+    moduleConfigBufferPool.Mode.SourceSettings.PoolType = NonPagedPoolNx;
+    moduleConfigBufferPool.Mode.SourceSettings.BufferSize = sizeof(DeviceInterfaceTarget_SingleAsynchronousRequestContext);
+    moduleAttributes.ClientModuleInstanceName = "BufferPoolContext";
+    moduleAttributes.PassiveLevel = DmfParentModuleAttributes->PassiveLevel;
+    DMF_DmfModuleAdd(DmfModuleInit,
+                     &moduleAttributes,
+                     WDF_NO_OBJECT_ATTRIBUTES,
+                     &moduleContext->DmfModuleBufferPool);
 
     // If Client has set ContinousRequestCount > 0, then it means streaming is capable.
     // Otherwise, streaming is not capable.

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -814,7 +814,7 @@ DeviceInterfaceTarget_Target_Send(
 
     DmfAssert(! moduleContext->ContinuousReaderMode);
 
-    return DeviceInterfaceTarget_Target_SendEx(moduleContext->DmfModuleRequestTarget,
+    return DeviceInterfaceTarget_Target_SendEx(DmfModule,
                                                RequestBuffer,
                                                RequestLength,
                                                ResponseBuffer,

--- a/Dmf/Modules.Library/Dmf_HidDeviceListener.c
+++ b/Dmf/Modules.Library/Dmf_HidDeviceListener.c
@@ -1,0 +1,1349 @@
+/*++
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+Module Name:
+
+    Dmf_HidDeviceListener.c
+
+Abstract:
+
+    HidDeviceListener notifies client of arrival and removal of HID devices specified in the Module's configuration.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+// DMF and this Module's Library specific definitions.
+//
+#include "DmfModule.h"
+#include "DmfModules.Library.h"
+#include "DmfModules.Library.Trace.h"
+
+#if defined(DMF_INCLUDE_TMH)
+#include "Dmf_HidDeviceListener.tmh"
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Enumerations and Structures
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Module Private Context
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+typedef struct _DMF_CONTEXT_HidDeviceListener
+{
+    // HID Interface arrival/removal notification handle.
+    //
+#if defined(DMF_USER_MODE)
+    HCMNOTIFICATION HidInterfaceNotification;
+#else
+    VOID* HidInterfaceNotification;
+#endif // defined(DMF_USER_MODE)
+
+    // Collection of symbolic link names of matched devices.
+    // 
+    // This collection is used when a HID device is removed. It removed device's name is checked against the collection
+    // to identify if it was one of the devices that matches the configurations.This is used for remote targets since there
+    // can be multiple devices matching the specified configuration.
+    //
+    WDFCOLLECTION MatchedDevicesSymbolicLinkNames;
+} DMF_CONTEXT_HidDeviceListener;
+
+// This macro declares the following function:
+// DMF_CONTEXT_GET()
+//
+DMF_MODULE_DECLARE_CONTEXT(HidDeviceListener)
+
+// This macro declares the following function:
+// DMF_CONFIG_GET()
+//
+DMF_MODULE_DECLARE_CONFIG(HidDeviceListener)
+
+// Memory Pool Tag.
+//
+#define MemoryTag 'LedH'
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Support Code
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_MatchedDevicesAdd(
+    _In_ DMFMODULE DmfModule,
+    _In_ PUNICODE_STRING SymbolicLinkName,
+    _Out_ BOOLEAN* Added
+    )
+/*++
+
+Routine Description:
+
+    Add new symbolic link name to the collection of matched symbolic link names.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    SymbolicLinkName - The symbolic link name that of a matched hid device.
+    Added - Boolean indicating if the symbolic link name was added to the collection.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    WDF_OBJECT_ATTRIBUTES attributes;
+    WDFSTRING symbolicLinkNameString;
+    WDFSTRING existingSymbolicLinkNameString;
+    UNICODE_STRING existingSymbolicLinkName;
+    LONG unicodeCompareResult;
+    ULONG collectionCount;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+    ntStatus = STATUS_SUCCESS;
+    *Added = FALSE;
+
+    DMF_ModuleLock(DmfModule);
+
+    // Check if the symbolic link name is already exists in collection.
+    // 
+    // This can happen in the usermode case where one needs to both regiser for device arrival as well as scan
+    // for existing device. If a new device is added after the registration but before the scan existing device completes,
+    // both paths will detect the new device and attempt to add it to the collection.
+    //
+    collectionCount = WdfCollectionGetCount(moduleContext->MatchedDevicesSymbolicLinkNames);
+    for (ULONG collectionIndex = 0; collectionIndex < collectionCount; collectionIndex++)
+    {
+        existingSymbolicLinkNameString = (WDFSTRING)WdfCollectionGetItem(moduleContext->MatchedDevicesSymbolicLinkNames,
+                                                                         collectionIndex);
+
+        WdfStringGetUnicodeString(existingSymbolicLinkNameString,
+                                  &existingSymbolicLinkName);
+
+        unicodeCompareResult = RtlCompareUnicodeString(SymbolicLinkName,
+                                                       &existingSymbolicLinkName,
+                                                       TRUE);
+        if (unicodeCompareResult == 0)
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "%S already added", SymbolicLinkName->Buffer);
+            goto Exit;
+        }
+    }
+
+    // Add SymbolicLinkName to list of matching devices.
+    //
+    WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+    attributes.ParentObject = moduleContext->MatchedDevicesSymbolicLinkNames;
+    ntStatus = WdfStringCreate(SymbolicLinkName,
+                               &attributes,
+                               &symbolicLinkNameString);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfStringCreate fails: %!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    ntStatus = WdfCollectionAdd(moduleContext->MatchedDevicesSymbolicLinkNames,
+                                symbolicLinkNameString);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        WdfObjectDelete(symbolicLinkNameString);
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionAdd fails: %!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    *Added = TRUE;
+
+Exit:
+
+    DMF_ModuleUnlock(DmfModule);
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_HandleHidDeviceArrival(
+    _In_ DMFMODULE DmfModule,
+    _In_ PUNICODE_STRING SymbolicLinkName
+    )
+/*++
+
+Routine Description:
+
+    Handles arrival of new hid device. Check to see if the device matches the specification in the Module's config.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    SymbolicLinkName - The symbolic link name that of the hid device that arrived.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    WDFIOTARGET ioTarget;
+    WDFDEVICE device;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+    HID_COLLECTION_INFORMATION hidCollectionInformation;
+    PHIDP_PREPARSED_DATA preparsedHidData;
+    WDFMEMORY preparsedHidDataMemory;
+    HIDP_CAPS hidCaps;
+    WDF_IO_TARGET_OPEN_PARAMS openParams;
+    WDF_MEMORY_DESCRIPTOR outputDescriptor;
+    WDF_OBJECT_ATTRIBUTES attributes;
+    BOOLEAN pidFound;
+    BOOLEAN symbolicLinkNameAdded;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    device = DMF_ParentDeviceGet(DmfModule);
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+
+    symbolicLinkNameAdded = FALSE;
+    ioTarget = NULL;
+    preparsedHidData = NULL;
+    preparsedHidDataMemory = NULL;
+
+    RtlZeroMemory(&hidCollectionInformation,
+                  sizeof(hidCollectionInformation));
+
+    // Open the device to be queried.
+    // NOTE: When opening HID device for enumeration purposes (to see if
+    // it is the required device, the Open Mode should be zero and share should be Read/Write.
+    //
+    WDF_IO_TARGET_OPEN_PARAMS_INIT_OPEN_BY_NAME(&openParams,
+                                                SymbolicLinkName,
+                                                0);
+
+    openParams.ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
+
+    // Create an I/O target object.
+    //
+    ntStatus = WdfIoTargetCreate(device,
+                                 WDF_NO_OBJECT_ATTRIBUTES,
+                                 &ioTarget);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfIoTargetCreate fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    // Try to open the target.
+    //
+    ntStatus = WdfIoTargetOpen(ioTarget,
+                               &openParams);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfIoTargetOpen fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    // Get the collection information.
+    //
+    WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&outputDescriptor,
+                                      (VOID*)&hidCollectionInformation,
+                                      sizeof(HID_COLLECTION_INFORMATION));
+    ntStatus = WdfIoTargetSendIoctlSynchronously(ioTarget,
+                                                 NULL,
+                                                 IOCTL_HID_GET_COLLECTION_INFORMATION,
+                                                 NULL,
+                                                 &outputDescriptor,
+                                                 NULL,
+                                                 NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "IOCTL_HID_GET_COLLECTION_INFORMATION fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    if (0 == hidCollectionInformation.DescriptorSize)
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "hidCollectionInformation.DescriptorSize==0, ntStatus=%!STATUS!", ntStatus);
+        ntStatus = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "VID = 0x%x", hidCollectionInformation.VendorID);
+
+    // Check VID/PID
+    //
+    if (hidCollectionInformation.VendorID != moduleConfig->VendorId)
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Unsupported VID");
+        goto Exit;
+    }
+
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "PID = 0x%x",  hidCollectionInformation.ProductID);
+
+    // See if it is one of the PIDs that the Client wants.
+    //
+    if (moduleConfig->ProductIdsCount > 0)
+    {
+        pidFound = FALSE;
+
+        for (ULONG pidIndex = 0; pidIndex < moduleConfig->ProductIdsCount; pidIndex++)
+        {
+            if (hidCollectionInformation.ProductID == moduleConfig->ProductIds[pidIndex])
+            {
+                pidFound = TRUE;
+                TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "found supported PID: 0x%x", moduleConfig->ProductIds[pidIndex]);
+                break;
+            }
+        }
+
+        if (pidFound != TRUE)
+        {
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Unsupported PID");
+            goto Exit;
+        }
+
+    }
+
+    // Get Hid Descriptor.
+    //
+    WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+    attributes.ParentObject = device;
+    ntStatus = WdfMemoryCreate(&attributes,
+                               NonPagedPoolNx,
+                               MemoryTag,
+                               hidCollectionInformation.DescriptorSize,
+                               &preparsedHidDataMemory,
+                               (VOID**)&preparsedHidData);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        ntStatus = STATUS_INSUFFICIENT_RESOURCES;
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfMemoryCreate fails: ntStatus=%!STATUS!", ntStatus);
+        preparsedHidDataMemory = NULL;
+        goto Exit;
+    }
+
+    WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&outputDescriptor,
+                                      (VOID*)preparsedHidData,
+                                      hidCollectionInformation.DescriptorSize);
+
+    ntStatus = WdfIoTargetSendIoctlSynchronously(ioTarget,
+                                                 NULL,
+                                                 IOCTL_HID_GET_COLLECTION_DESCRIPTOR,
+                                                 NULL,
+                                                 &outputDescriptor,
+                                                 NULL,
+                                                 NULL);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "IOCTL_HID_GET_COLLECTION_DESCRIPTOR fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    // Get Hid Capabilities.
+    //
+    ntStatus = HidP_GetCaps(preparsedHidData,
+                            &hidCaps);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HidP_GetCaps() fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    // Check the usage and usage page.
+    //
+    if ((hidCaps.Usage != moduleConfig->Usage) ||
+        (hidCaps.UsagePage != moduleConfig->UsagePage))
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "incorrect usage or usage page failed");
+        ntStatus = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Found matching device %S", SymbolicLinkName->Buffer);
+
+    // Add symbolic link name to collection of matched devices.
+    //
+    ntStatus = HidDeviceListener_MatchedDevicesAdd(DmfModule,
+                                                   SymbolicLinkName,
+                                                   &symbolicLinkNameAdded);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HidDeviceListener_MatchedDevicesAdd() fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    if (symbolicLinkNameAdded == TRUE
+        && moduleConfig->EvtHidTargetDeviceArrivalCallback != NULL)
+    {
+        // Notify user of matching device arrival.
+        //
+        moduleConfig->EvtHidTargetDeviceArrivalCallback(DmfModule,
+                                                        SymbolicLinkName,
+                                                        ioTarget,
+                                                        preparsedHidData,
+                                                        &hidCollectionInformation);
+    }
+  
+Exit:
+
+    if (ioTarget != NULL)
+    {
+        WdfIoTargetClose(ioTarget);
+        WdfObjectDelete(ioTarget);
+    }
+
+    if (preparsedHidDataMemory != NULL)
+    {
+        WdfObjectDelete(preparsedHidDataMemory);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+HidDeviceListener_HandleHidDeviceRemoval(
+    _In_ DMFMODULE DmfModule,
+    _In_ PUNICODE_STRING SymbolicLinkName
+    )
+/*++
+
+Routine Description:
+
+    Handles removal of new hid device. Check to see if the device matches the specification in the Module's config.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    SymbolicLinkName - The symbolic link name of the hid device that is being removed.
+
+Return Value:
+
+    VOID
+
+--*/
+{
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+    ULONG collectionCount;
+    WDFSTRING symbolicLinkNameString;
+    UNICODE_STRING symbolicLinkName;
+    LONG unicodeCompareResult;
+    BOOLEAN symbolicNameFound;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+    symbolicLinkNameString = NULL;
+    symbolicNameFound = FALSE;
+
+    DMF_ModuleLock(DmfModule);
+
+    // Check if device being removed is in the matched device collection; this would mean that it is a matched device.
+    //
+    collectionCount = WdfCollectionGetCount(moduleContext->MatchedDevicesSymbolicLinkNames);
+    for (ULONG collectionIndex = 0; collectionIndex < collectionCount; collectionIndex++)
+    {
+        symbolicLinkNameString = (WDFSTRING)WdfCollectionGetItem(moduleContext->MatchedDevicesSymbolicLinkNames,
+                                                                 collectionIndex);
+
+        WdfStringGetUnicodeString(symbolicLinkNameString,
+                                  &symbolicLinkName);
+
+        unicodeCompareResult = RtlCompareUnicodeString(SymbolicLinkName,
+                                                       &symbolicLinkName,
+                                                       TRUE);
+        if (unicodeCompareResult == 0)
+        {
+            symbolicNameFound = TRUE;
+            break;
+        }
+    }
+
+    if (symbolicNameFound == TRUE)
+    {
+        WdfCollectionRemove(moduleContext->MatchedDevicesSymbolicLinkNames,
+                            symbolicLinkNameString);
+        WdfObjectDelete(symbolicLinkNameString);
+
+        // Notify client of matching device removal.
+        //
+        if (moduleConfig->EvtHidTargetDeviceRemovalCallback != NULL)
+        {
+            moduleConfig->EvtHidTargetDeviceRemovalCallback(DmfModule,
+                                                            SymbolicLinkName);
+        }
+    }
+
+    DMF_ModuleUnlock(DmfModule);
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+#if !defined(DMF_USER_MODE)
+#pragma code_seg("PAGE")
+_Function_class_(DRIVER_NOTIFICATION_CALLBACK_ROUTINE)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_InterfaceArrivalRemovalCallbackKernel(
+    _In_ VOID* NotificationStructure,
+    _Inout_opt_ VOID* Context
+    )
+/*++
+
+Routine Description:
+
+    PnP notification function that is called when a HID device arrives or removes.
+
+Arguments:
+
+    NotificationStructure - Gives information about the enumerated device.
+    Context - This Module's handle.
+
+Return Value:
+
+    STATUS_SUCCESS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    PDEVICE_INTERFACE_CHANGE_NOTIFICATION info;
+    DMFMODULE dmfModule;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    // warning C6387: 'Context' could be '0'.
+    //
+    #pragma warning(suppress:6387)
+    dmfModule = DMFMODULEVOID_TO_MODULE(Context);
+    DmfAssert(dmfModule != NULL);
+    moduleConfig = DMF_CONFIG_GET(dmfModule);
+
+    info = (PDEVICE_INTERFACE_CHANGE_NOTIFICATION)NotificationStructure;
+    ntStatus = STATUS_SUCCESS;
+
+    if (DMF_Utility_IsEqualGUID((LPGUID)&(info->Event),
+                                (LPGUID)&GUID_DEVICE_INTERFACE_ARRIVAL))
+    {
+        DmfAssert(info->SymbolicLinkName);
+
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "GUID_DEVICE_INTERFACE_ARRIVAL Found HID Device %S", info->SymbolicLinkName->Buffer);
+
+        ntStatus = HidDeviceListener_HandleHidDeviceArrival(dmfModule,
+                                                            info->SymbolicLinkName);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HidDeviceListener_HandleHidDeviceArrival fails: ntStatus=%!STATUS!", ntStatus);
+            goto Exit;
+        }
+    }
+    else if (DMF_Utility_IsEqualGUID((LPGUID)&(info->Event),
+                                     (LPGUID)&GUID_DEVICE_INTERFACE_REMOVAL))
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "GUID_DEVICE_INTERFACE_REMOVAL %S", info->SymbolicLinkName->Buffer);
+
+        HidDeviceListener_HandleHidDeviceRemoval(dmfModule,
+                                                 info->SymbolicLinkName);
+    }
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return STATUS_SUCCESS;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_NotificationRegisterKernel(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Register for notification for all hid devices arrival/removal.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+
+    WDFDEVICE parentDevice;
+    PDEVICE_OBJECT deviceObject;
+    PDRIVER_OBJECT driverObject;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    parentDevice = DMF_ParentDeviceGet(DmfModule);
+    DmfAssert(parentDevice != NULL);
+
+    deviceObject = WdfDeviceWdmGetDeviceObject(parentDevice);
+    DmfAssert(deviceObject != NULL);
+    driverObject = deviceObject->DriverObject;
+
+    DmfAssert(NULL == moduleContext->HidInterfaceNotification);
+    ntStatus = IoRegisterPlugPlayNotification(EventCategoryDeviceInterfaceChange,
+                                              PNPNOTIFY_DEVICE_INTERFACE_INCLUDE_EXISTING_INTERFACES,
+                                              (void*)&GUID_DEVINTERFACE_HID,
+                                              driverObject,
+                                              (PDRIVER_NOTIFICATION_CALLBACK_ROUTINE)HidDeviceListener_InterfaceArrivalRemovalCallbackKernel,
+                                              (VOID*)DmfModule,
+                                              &(moduleContext->HidInterfaceNotification));
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "IoRegisterPlugPlayNotification: Notification Entry 0x%p ntStatus=%!STATUS!", moduleContext->HidInterfaceNotification, ntStatus);
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+HidDeviceListener_NotificationUnregisterKernel(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Unregister a notification for hid device arriave/removal.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+
+    PAGED_CODE();
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    if (moduleContext->HidInterfaceNotification != NULL)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Destroy Notification Entry 0x%p", moduleContext->HidInterfaceNotification);
+
+        ntStatus = IoUnregisterPlugPlayNotificationEx(moduleContext->HidInterfaceNotification);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "IoUnregisterPlugPlayNotificationEx() fails: ntStatus=%!STATUS!", ntStatus);
+            DmfAssert(FALSE);
+            goto Exit;
+        }
+
+        moduleContext->HidInterfaceNotification = NULL;
+    }
+    else
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "IoUnregisterPlugPlayNotificationEx() skipped.");
+        DmfAssert(FALSE);
+    }
+
+Exit:
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+#else
+
+#pragma code_seg("PAGE")
+DWORD
+HidDeviceListener_InterfaceArrivalCallbackUser(
+    _In_ HCMNOTIFICATION Notify,
+    _In_opt_ VOID* Context,
+    _In_ CM_NOTIFY_ACTION Action,
+    _In_reads_bytes_(EventDataSize) PCM_NOTIFY_EVENT_DATA EventData,
+    _In_ DWORD EventDataSize
+    )
+/*++
+
+Routine Description:
+
+    Callback called when the notification that is registered detects an arrival or
+    removal of a device interface of any Hid device.
+
+Arguments:
+
+    Notify- Handle to this notification.
+    Context - This Module's handle.
+    Action - One of the action in CM_NOTIFY_ACTION.
+    EventData - Event Data associated with the notification callback.
+    EventDataSize - Size of Event Data.
+
+Return Value:
+
+    DWORD returns ERROR_SUCCESS always.
+
+--*/
+{
+    DMFMODULE dmfModule;
+    NTSTATUS ntStatus;
+
+    UNREFERENCED_PARAMETER(Notify);
+    UNREFERENCED_PARAMETER(EventDataSize);
+
+    dmfModule = DMFMODULEVOID_TO_MODULE(Context);
+
+    ntStatus = STATUS_SUCCESS;
+
+    if (Action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL)
+    {
+        DmfAssert(EventData->u.DeviceInterface.SymbolicLink);
+        UNICODE_STRING symbolicLinkName;
+
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Processing interface arrival %ws", EventData->u.DeviceInterface.SymbolicLink);
+        RtlInitUnicodeString(&symbolicLinkName,
+                             EventData->u.DeviceInterface.SymbolicLink);
+
+        ntStatus = HidDeviceListener_HandleHidDeviceArrival(dmfModule,
+                                                            &symbolicLinkName);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "HidDeviceListener_HandleHidDeviceArrival fails: ntStatus=%!STATUS!", ntStatus);
+        }
+    }
+    else if (Action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL)
+    {
+        DmfAssert(EventData->u.DeviceInterface.SymbolicLink);
+        UNICODE_STRING symbolicLinkName;
+
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Processing interface removal %ws", EventData->u.DeviceInterface.SymbolicLink);
+        RtlInitUnicodeString(&symbolicLinkName,
+                             EventData->u.DeviceInterface.SymbolicLink);
+
+        HidDeviceListener_HandleHidDeviceRemoval(dmfModule,
+                                                 &symbolicLinkName);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    // Return SUCCESS here always.
+    //
+    return ERROR_SUCCESS;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_MatchedTargetForExistingInterfacesGet(
+    _In_ DMFMODULE DmfModule,
+    _In_ const GUID* InterfaceGuid
+    )
+/*++
+
+Routine Description:
+
+    This helper function searches all existing interfaces for the given InterfaceGuid,
+    for a matching device and creates an IoTarget to it.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    InterfaceGuid - Guid to search for.
+
+Return Value:
+
+    NTSTATUS - STATUS_SUCCESS if the device is matched, and IoTarget is opened to it, otherwise error status.
+
+--*/
+{
+    NTSTATUS ntStatus;
+    CONFIGRET cr;
+    DWORD lastError;
+    PWSTR deviceInterfaceList;
+    ULONG deviceInterfaceListLength;
+    PWSTR currentInterface;
+    DWORD index;
+
+    PAGED_CODE();
+
+    deviceInterfaceList = NULL;
+    deviceInterfaceListLength = 0;
+
+    // Get the existing Device Interfaces for the given Guid.
+    // It is recommended to do this in a loop, as the
+    // size can change between the call to CM_Get_Device_Interface_List_Size and
+    // CM_Get_Device_Interface_List.
+    //
+    do
+    {
+        cr = CM_Get_Device_Interface_List_Size(&deviceInterfaceListLength,
+                                               (LPGUID)InterfaceGuid,
+                                               NULL,
+                                               CM_GET_DEVICE_INTERFACE_LIST_ALL_DEVICES);
+        if (cr != CR_SUCCESS)
+        {
+            lastError = GetLastError();
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "CM_Get_Device_Interface_List_Size failed with Result %d and lastError %!WINERROR!", cr, lastError);
+            ntStatus = NTSTATUS_FROM_WIN32(lastError);
+            goto Exit;
+        }
+
+        if (deviceInterfaceList != NULL)
+        {
+            if (! HeapFree(GetProcessHeap(),
+                           0,
+                           deviceInterfaceList))
+            {
+                lastError = GetLastError();
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HeapFree failed with lastError %!WINERROR!", lastError);
+                ntStatus = NTSTATUS_FROM_WIN32(lastError);
+                deviceInterfaceList = NULL;
+                goto Exit;
+            }
+        }
+
+        deviceInterfaceList = (PWSTR)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, deviceInterfaceListLength * sizeof(WCHAR));
+        if (deviceInterfaceList == NULL)
+        {
+            lastError = GetLastError();
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HeapAlloc failed with lastError %!WINERROR!", lastError);
+            ntStatus = NTSTATUS_FROM_WIN32(lastError);
+            goto Exit;
+        }
+
+        cr = CM_Get_Device_Interface_List((LPGUID)InterfaceGuid,
+                                          NULL,
+                                          deviceInterfaceList,
+                                          deviceInterfaceListLength,
+                                          CM_GET_DEVICE_INTERFACE_LIST_ALL_DEVICES);
+
+    } while (cr == CR_BUFFER_SMALL);
+
+    if (cr != CR_SUCCESS)
+    {
+        lastError = GetLastError();
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "CM_Get_Device_Interface_List failed with Result %d and lastError %!WINERROR!", cr, lastError);
+        ntStatus = NTSTATUS_FROM_WIN32(lastError);
+        goto Exit;
+    }
+
+    // Loop through the interfaces for a matching target and open it.
+    // Ensure to return STATUS_SUCCESS only on a matched target get.
+    //
+    ntStatus = STATUS_NOT_FOUND;
+    index = 0;
+    UNICODE_STRING symbolicLinkName;
+    for (currentInterface = deviceInterfaceList;
+         *currentInterface;
+         currentInterface += wcslen(currentInterface) + 1)
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "[index %d] Processing interface %ws", index, currentInterface);
+
+        RtlInitUnicodeString(&symbolicLinkName,
+                             currentInterface);
+
+        ntStatus = HidDeviceListener_HandleHidDeviceArrival(DmfModule,
+                                                            &symbolicLinkName);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HidDeviceListener_HandleHidDeviceArrival fails: ntStatus=%!STATUS! symbolicLinkName=%S", ntStatus, symbolicLinkName.Buffer);
+            goto Exit;
+        }
+
+        index++;
+    }
+
+Exit:
+
+    if (deviceInterfaceList != NULL)
+    {
+        if (!HeapFree(GetProcessHeap(),
+                      0,
+                      deviceInterfaceList))
+        {
+            // Not a critical error.
+            //
+            lastError = GetLastError();
+            TraceEvents(TRACE_LEVEL_WARNING, DMF_TRACE, "HeapFree failed with lastError %!WINERROR!", lastError);
+        }
+
+        deviceInterfaceList = NULL;
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+HidDeviceListener_NotificationRegisterUser(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Register for a notification for all Hid device interfaces.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+    CM_NOTIFY_FILTER cmNotifyFilter = { 0 };
+    CONFIGRET configRet;
+    const GUID* interfaceGuid;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+    interfaceGuid = &GUID_DEVINTERFACE_HID;
+    cmNotifyFilter.cbSize = sizeof(CM_NOTIFY_FILTER);
+    cmNotifyFilter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+    cmNotifyFilter.u.DeviceInterface.ClassGuid = *interfaceGuid;
+
+    configRet = CM_Register_Notification(&cmNotifyFilter,
+                                         (VOID*)DmfModule,
+                                         (PCM_NOTIFY_CALLBACK)HidDeviceListener_InterfaceArrivalCallbackUser,
+                                         &(moduleContext->HidInterfaceNotification));
+    // Target device might already be there. So try now.
+    //
+    if (configRet == CR_SUCCESS)
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Processing existing interfaces- START");
+
+        ntStatus = HidDeviceListener_MatchedTargetForExistingInterfacesGet(DmfModule,
+                                                                           interfaceGuid);
+        if (!NT_SUCCESS(ntStatus))
+        {
+            TraceEvents(TRACE_LEVEL_WARNING, DMF_TRACE, "HidDeviceListener_MatchedTargetForExistingInterfacesGet fails: ntStatus=%!STATUS!", ntStatus);
+            // Should always return success here, since notification might be called back later for the desired device.
+            //
+            ntStatus = STATUS_SUCCESS;
+        }
+
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Processing existing interfaces- END");
+    }
+    else
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "CM_Register_Notification fails: configRet=0x%x", configRet);
+
+        ntStatus = NTSTATUS_FROM_WIN32(GetLastError());
+        goto Exit;
+    }
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+HidDeviceListener_NotificationUnregisterUser(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Unregister for a notification for all Hid device interfaces.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    if (moduleContext->HidInterfaceNotification != NULL)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE,  "Destroy Notification Entry 0x%p", moduleContext->HidInterfaceNotification);
+
+        CONFIGRET cr;
+        cr = CM_Unregister_Notification(moduleContext->HidInterfaceNotification);
+        if (cr != CR_SUCCESS)
+        {
+            NTSTATUS ntStatus;
+            ntStatus = NTSTATUS_FROM_WIN32(GetLastError());
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "CM_Unregister_Notification fails: ntStatus=%!STATUS!", ntStatus);
+            goto Exit;
+        }
+
+        moduleContext->HidInterfaceNotification = NULL;
+    }
+    else
+    {
+        // Allow caller to unregister notification even if it has not been registered.
+        //
+        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "CM_Unregister_Notification skipped.");
+    }
+
+Exit:
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+#endif // !defined(DMF_USER_MODE)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// WDF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+_Function_class_(DMF_ModuleSelfManagedIoCleanup)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+DMF_HidDeviceListener_SelfManagedIoCleanup(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+   HidDeviceListener callback for ModuleSelfManagedIoCleanup.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    UNREFERENCED_PARAMETER(DmfModule);
+
+    FuncEntry(DMF_TRACE);
+
+#if defined DMF_USER_MODE
+    HidDeviceListener_NotificationUnregisterUser(DmfModule);
+#else
+    HidDeviceListener_NotificationUnregisterKernel(DmfModule);
+#endif
+
+    FuncExitVoid(DMF_TRACE);
+}
+
+_Function_class_(DMF_ModuleSelfManagedIoInit)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_HidDeviceListener_SelfManagedIoInit(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+   HidDeviceListener callback for ModuleSelfManagedIoInit.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+
+    PAGED_CODE();
+
+    UNREFERENCED_PARAMETER(DmfModule);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    // This function should not be not called twice.
+    //
+    DmfAssert(NULL == moduleContext->HidInterfaceNotification);
+
+    moduleConfig = DMF_CONFIG_GET(DmfModule);
+
+#if defined DMF_USER_MODE
+    ntStatus = HidDeviceListener_NotificationRegisterUser(DmfModule);
+#else
+    ntStatus = HidDeviceListener_NotificationRegisterKernel(DmfModule);
+#endif
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "HidDeviceListener_NotificationRegister fails: ntStatus=%!STATUS!", ntStatus);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// DMF Module Callbacks
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_Function_class_(DMF_Open)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+static
+NTSTATUS
+DMF_HidDeviceListener_Open(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Initialize an instance of a DMF Module of type HidDeviceListener.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    STATUS_SUCCESS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_CONTEXT_HidDeviceListener* moduleContext;
+    WDF_OBJECT_ATTRIBUTES objectAttributes;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+    moduleContext->MatchedDevicesSymbolicLinkNames = NULL;
+    moduleContext->HidInterfaceNotification = NULL;
+
+    // Create collection used to track the symbolic link names of all the devices that match the HID device described
+    // in the Module's config when they arrive. This is used to check if a HID device being removed is one of the
+    // matched devices that arrived earlier.
+    //
+    // Note: Collection does not need to be deleted in ModuleClose. This Module will be closed when it is being destroyed.
+    //       Therefore, the Collection will also be cleaned up since it is parented to the Module.
+    //
+    WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+    objectAttributes.ParentObject = DmfModule;
+
+    ntStatus = WdfCollectionCreate(&objectAttributes,
+                                   &moduleContext->MatchedDevicesSymbolicLinkNames);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionCreate fails: ntStatus=%!STATUS!", ntStatus);
+    }
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return ntStatus;
+}
+#pragma code_seg()
+
+#pragma code_seg("PAGE")
+_Function_class_(DMF_Close)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+static
+VOID
+DMF_HidDeviceListener_Close(
+    _In_ DMFMODULE DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Uninitialize an instance of a DMF Module of type HidDeviceListener.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+
+Return Value:
+
+    None
+
+--*/
+{
+    PAGED_CODE();
+
+    UNREFERENCED_PARAMETER(DmfModule);
+
+    FuncEntry(DMF_TRACE);
+
+    FuncExitVoid(DMF_TRACE);
+}
+#pragma code_seg()
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Calls by Client
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+#pragma code_seg("PAGE")
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_Must_inspect_result_
+NTSTATUS
+DMF_HidDeviceListener_Create(
+    _In_ WDFDEVICE Device,
+    _In_ DMF_MODULE_ATTRIBUTES* DmfModuleAttributes,
+    _In_ WDF_OBJECT_ATTRIBUTES* ObjectAttributes,
+    _Out_ DMFMODULE* DmfModule
+    )
+/*++
+
+Routine Description:
+
+    Create an instance of a DMF Module of type HidDeviceListener.
+
+Arguments:
+
+    Device - Client driver's WDFDEVICE object.
+    DmfModuleAttributes - Opaque structure that contains parameters DMF needs to initialize the Module.
+    ObjectAttributes - WDF object attributes for DMFMODULE.
+    DmfModule - Address of the location where the created DMFMODULE handle is returned.
+
+Return Value:
+
+    NTSTATUS
+
+--*/
+{
+    NTSTATUS ntStatus;
+    DMF_MODULE_DESCRIPTOR dmfModuleDescriptor_HidDeviceListener;
+    DMF_CALLBACKS_DMF dmfCallbacksDmf_HidDeviceListener;
+    DMF_CALLBACKS_WDF dmfCallbacksWdf_HidDeviceListener;
+    DMF_CONFIG_HidDeviceListener* moduleConfig;
+
+    PAGED_CODE();
+
+    FuncEntry(DMF_TRACE);
+
+    DMF_CALLBACKS_DMF_INIT(&dmfCallbacksDmf_HidDeviceListener);
+    dmfCallbacksDmf_HidDeviceListener.DeviceOpen = DMF_HidDeviceListener_Open;
+    dmfCallbacksDmf_HidDeviceListener.DeviceClose = DMF_HidDeviceListener_Close;
+
+    
+    DMF_CALLBACKS_WDF_INIT(&dmfCallbacksWdf_HidDeviceListener);
+    dmfCallbacksWdf_HidDeviceListener.ModuleSelfManagedIoInit = DMF_HidDeviceListener_SelfManagedIoInit;
+    dmfCallbacksWdf_HidDeviceListener.ModuleSelfManagedIoCleanup = DMF_HidDeviceListener_SelfManagedIoCleanup;
+
+    DMF_MODULE_DESCRIPTOR_INIT_CONTEXT_TYPE(dmfModuleDescriptor_HidDeviceListener,
+                                            HidDeviceListener,
+                                            DMF_CONTEXT_HidDeviceListener,
+                                            DMF_MODULE_OPTIONS_PASSIVE,
+                                            DMF_MODULE_OPEN_OPTION_OPEN_Create);
+
+    dmfModuleDescriptor_HidDeviceListener.CallbacksDmf = &dmfCallbacksDmf_HidDeviceListener;
+    dmfModuleDescriptor_HidDeviceListener.CallbacksWdf = &dmfCallbacksWdf_HidDeviceListener;
+
+    ntStatus = DMF_ModuleCreate(Device,
+                                DmfModuleAttributes,
+                                ObjectAttributes,
+                                &dmfModuleDescriptor_HidDeviceListener,
+                                DmfModule);
+    if (!NT_SUCCESS(ntStatus))
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_ModuleCreate fails: ntStatus=%!STATUS!", ntStatus);
+        goto Exit;
+    }
+
+    moduleConfig = DMF_CONFIG_GET(*DmfModule);
+
+Exit:
+
+    FuncExit(DMF_TRACE, "ntStatus=%!STATUS!", ntStatus);
+
+    return(ntStatus);
+}
+#pragma code_seg()
+
+// eof: Dmf_HidDeviceListener.c
+//

--- a/Dmf/Modules.Library/Dmf_HidDeviceListener.h
+++ b/Dmf/Modules.Library/Dmf_HidDeviceListener.h
@@ -1,0 +1,80 @@
+/*++
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+Module Name:
+
+    Dmf_HidDeviceListener.h
+
+Abstract:
+
+    Companion file to Dmf_HidDeviceListener.c.
+
+Environment:
+
+    Kernel-mode Driver Framework
+    User-mode Driver Framework
+
+--*/
+
+#pragma once
+
+// The maximum number of devices of supported device product Ids that are
+// searched in the Module Config.
+//
+#define DMF_HidDeviceListener_Maximum_Pid_Count 8
+
+// Client callback for matching HID device arrival.
+//
+typedef
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+EVT_DMF_HidDeviceListener_DeviceArrivalCallback(_In_ DMFMODULE DmfModule,
+                                                _In_ PUNICODE_STRING SymbolicLinkName,
+                                                _In_ WDFIOTARGET IoTarget,
+                                                _In_ PHIDP_PREPARSED_DATA PreparsedHidData,
+                                                _In_ HID_COLLECTION_INFORMATION* HidCollectionInformation);
+
+// Client callback for matching HID device removal.
+//
+typedef
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+EVT_DMF_HidDeviceListener_DeviceRemovalCallback(_In_ DMFMODULE DmfModule,
+                                                _In_ PUNICODE_STRING SymbolicLinkName);
+
+typedef struct
+{
+    // The Vendor Id of the HID device(s).
+    //
+    UINT16 VendorId;
+    // List of HID Product Ids.
+    //
+    UINT16 ProductIds[DMF_HidDeviceListener_Maximum_Pid_Count];
+    // Number of entries in the above array.
+    //
+    ULONG ProductIdsCount;
+    // Information needed to idenitify the right HID device(s).
+    //
+    UINT16 Usage;
+    UINT16 UsagePage;
+    // Client callback for matching HID device arrival.
+    //
+    EVT_DMF_HidDeviceListener_DeviceArrivalCallback* EvtHidTargetDeviceArrivalCallback;
+
+    // Client callback for matching HID device removal.
+    //
+    EVT_DMF_HidDeviceListener_DeviceRemovalCallback* EvtHidTargetDeviceRemovalCallback;
+} DMF_CONFIG_HidDeviceListener;
+
+// This macro declares the following functions:
+// DMF_HidDeviceListener_ATTRIBUTES_INIT()
+// DMF_CONFIG_HidDeviceListener_AND_ATTRIBUTES_INIT()
+// DMF_HidDeviceListener_Create()
+//
+DECLARE_DMF_MODULE(HidDeviceListener)
+
+// eof: Dmf_HidDeviceListener.h
+//

--- a/Dmf/Modules.Library/Dmf_HidDeviceListener.md
+++ b/Dmf/Modules.Library/Dmf_HidDeviceListener.md
@@ -1,0 +1,160 @@
+## DMF_HidDeviceListener
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Summary
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+HidDeviceListener notifies client of arrival and removal of HID devices specified in the Module's configuration.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Configuration
+
+-----------------------------------------------------------------------------------------------------------------------------------
+##### DMF_CONFIG_HidDeviceListener
+````
+typedef struct
+{
+    // The Vendor Id of the HID device.
+    //
+    UINT16 VendorId;
+    // List of HID Product Ids.
+    //
+    UINT16 ProductIds[DMF_HidDeviceListener_Maximum_Pid_Count];
+    // Number of entries in the above array.
+    //
+    ULONG ProductIdsCount;
+    // Information needed to idenitify the right HID device.
+    //
+    UINT16 Usage;
+    UINT16 UsagePage;
+    // Client callback for matching HID device arrival.
+    //
+    EVT_DMF_HidDeviceListener_DeviceArrivalCallback* EvtHidTargetDeviceArrivalCallback;
+
+    // Client callback for matching HID device removal.
+    //
+    EVT_DMF_HidDeviceListener_DeviceRemovalCallback* EvtHidTargetDeviceRemovalCallback;
+} DMF_CONFIG_HidDeviceListener;
+````
+Member | Description
+----|----
+VendorId | The Vendor Id of the HID devices the Client wants to be notified about.
+ProductIds | List of HID Product Ids of the HID device the Client wants to be notified about.
+ProductIdsCount | The number of entries in ProductIds.
+Usage | The Usage of the HID device the client wants to be notified about.
+UsagePage | The Usage Page of the HID device the client wants to be notified about.
+EvtHidTargetDeviceArrivalCallback | Client callback for matching HID device arrival.
+EvtHidTargetDeviceRemovalCallback | Client callback for matching HID device removal.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Enumeration Types
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### Remarks
+
+This section lists all the Enumeration Types specific to this Module that are accessible to Clients.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Callbacks
+
+-----------------------------------------------------------------------------------------------------------------------------------
+````
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+EVT_DMF_HidDeviceListener_DeviceArrivalCallback(
+    _In_ DMFMODULE DmfModule,
+    _In_ PUNICODE_STRING SymbolicLinkName,
+    _In_ WDFIOTARGET IoTarget,
+    _In_ PHIDP_PREPARSED_DATA PreparsedHidData,
+    _In_ HID_COLLECTION_INFORMATION* HidCollectionInformation
+    );
+````
+
+Notifies the client of matching HID device arrival.
+
+##### Returns
+
+VOID
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_HidDeviceListener Module handle.
+SymbolicLinkName | The symbolic link name of the matching HID device that has arrived.
+IoTarget | A WDFIOTARGET for the arrived HID device.
+PreparsedHidData | Allows the Client to access the HID API to determine more HID specific information about the given WDFIOTARGET.
+HidCollectionInformation | Allows the Client to access the HID API to determine more HID specific information about the given WDFIOTARGET.
+-----------------------------------------------------------------------------------------------------------------------------------
+````
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+EVT_DMF_HidDeviceListener_DeviceRemovalCallback(
+    _In_ DMFMODULE DmfModule,
+    _In_ PUNICODE_STRING SymbolicLinkName);
+````
+
+Notifies the client of matching HID device removal.
+
+##### Returns
+
+VOID
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_HidDeviceListener Module handle.
+SymbolicLinkName | The symbolic link name of the matching HID device that has been removed.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Methods
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module IOCTLs
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Remarks
+
+* None
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Children
+
+* None.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Module Implementation Details
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+#### Examples
+
+* SurfaceHotPlug
+
+-----------------------------------------------------------------------------------------------------------------------------------
+#### Module Category
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+Hardware
+
+-----------------------------------------------------------------------------------------------------------------------------------
+

--- a/Dmf/Modules.Library/Dmf_HidTarget.c
+++ b/Dmf/Modules.Library/Dmf_HidTarget.c
@@ -1078,7 +1078,7 @@ Return Value:
                   sizeof(hidCollectionInformation));
 
     // Open the device to be queried.
-    // NOTE: Per OSG (Austin Hodges), when opening HID device for enumeration purposes (to see if
+    // NOTE: When opening HID device for enumeration purposes (to see if
     // it is the required device, the Open Mode should be zero and share should be Read/Write.
     //
     ntStatus = HidTarget_IoTargetCreateByName(device,

--- a/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.c
+++ b/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.c
@@ -164,7 +164,7 @@ Return Value:
 
     DmfAssert(transportData != NULL);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportBind");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportBind");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportBind(DmfInterface,
                                                                           ProtocolBindData, 
@@ -199,7 +199,7 @@ Return Value:
 
     DmfAssert(transportData != NULL);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "SystemManagementFramework_UnbindSystemManagementFramework_Unbind");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "SystemManagementFramework_UnbindSystemManagementFramework_Unbind");
 
     transportData->DMF_SystemManagementFramework_TransportUnbind(DmfInterface);
 
@@ -246,7 +246,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_ChannelsGet");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_ChannelsGet");
 
     ntStatus = transportData->DMF_SystemManagementFramework_ChannelsGet(DmfInterface,
                                                                         NumberOfSensorChannels,
@@ -289,7 +289,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportInitialize");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportInitialize");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportInitialize(DmfInterface,
                                                                                 Capabilities,
@@ -327,7 +327,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportUninitialize");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportUninitialize");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportUninitialize(DmfInterface);
 
@@ -369,7 +369,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportControlSet");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportControlSet");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportControlSet(DmfInterface,
                                                                                 ChannelIndex,
@@ -412,7 +412,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportDataGet");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportDataGet");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportDataGet(DmfInterface,
                                                                              ChannelIndex,
@@ -454,7 +454,7 @@ Return Value:
 
     transportData = (DMF_INTERFACE_TRANSPORT_SystemManagementFramework_DECLARATION_DATA*)DMF_InterfaceTransportDeclarationDataGet(DmfInterface);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DMF_SystemManagementFramework_TransportResetCauseGet");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DMF_SystemManagementFramework_TransportResetCauseGet");
 
     ntStatus = transportData->DMF_SystemManagementFramework_TransportResetCauseGet(DmfInterface,
                                                                                    Data,

--- a/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
+++ b/Dmf/Modules.Library/Dmf_Interface_SystemManagementFramework.h
@@ -166,7 +166,10 @@ typedef enum
     // Channel types are SMF_POWER_LIMIT_CONTROL_TYPE and SMF_TIME_LIMIT_CONTROL_OUTPUT_TYPE.
     //
     SmfSoCControlChannelSystemAverageInstanceId = 54,
+    SmfSoCControlChannelSystemCurrentAverageInstanceId = 60,
+    SmfSoCControlChannelSystemCurrentMaximumInstanceId = 61,
     SmfSoCControlChannelSystemAverageTimeInstanceId = 63,
+    SmfSoCControlChannelSystemCurrentAverageTimeInstanceId = 65,
     SmfSoCControlChannelSystemMaximumInstanceId = 55,
     SmfSoCControlChannelSystemPeakInstanceId = 59,
     // This sets the maximum SOC temperature. Time coefficient can be used for dynamic behavior calculations.

--- a/Dmf/Modules.Library/Dmf_IoctlHandler.c
+++ b/Dmf/Modules.Library/Dmf_IoctlHandler.c
@@ -51,6 +51,13 @@ typedef struct _DMF_CONTEXT_IoctlHandler
     // Set to TRUE when device interface is created successfully.
     //
     BOOLEAN IsDeviceInterfaceCreated;
+    // In cases when a reference string is set, this element tracks the WDFFILEOBJECT
+    // that opened the WDFIOTARGET associated with the specific instance of the Module.
+    // This is necessary so that multiple instances of the SAME Parent Module that use
+    // this Module as a Child Module can be instantiated. It enables the code to ensure
+    // that the IOCTL call's WDFREQUEST is routed to the specific instance.
+    //
+    WDFCOLLECTION AssociatedFileObjects;
 } DMF_CONTEXT_IoctlHandler;
 
 // This macro declares the following function:
@@ -199,6 +206,63 @@ Exit:
 }
 #pragma code_seg()
 
+BOOLEAN
+IoctlHandler_AssociatedFileObjectsLookUp(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFFILEOBJECT LookFor,
+    _In_ BOOLEAN DeleteIfFound
+    )
+/*++
+
+Routine Description:
+
+    Search the list of associated file objects for a given WDFFILEOBJECT.
+
+Arguments:
+
+    DmfModule - This Module's handle.
+    LookFor - The given WDFFILEOBJECT.
+    DeleteIfFound - If TRUE, the given WDFFILEOBJECT is removed from list.
+
+Return Value:
+
+    TRUE if found. FALSE if not found in list.
+
+--*/
+{
+    BOOLEAN returnValue;
+    ULONG numberOfItemsInCollection;
+    ULONG itemIndex;
+    DMF_CONTEXT_IoctlHandler* moduleContext;
+
+    moduleContext = DMF_CONTEXT_GET(DmfModule);
+
+    returnValue = FALSE;
+
+    DMF_ModuleLock(DmfModule);
+    
+    numberOfItemsInCollection = WdfCollectionGetCount(moduleContext->AssociatedFileObjects);
+    for (itemIndex = 0; itemIndex < numberOfItemsInCollection; itemIndex++)
+    {
+        WDFOBJECT currentObject = WdfCollectionGetItem(moduleContext->AssociatedFileObjects,
+                                                       itemIndex);
+        if (currentObject == LookFor)                                                       
+        {
+            returnValue = TRUE;
+            if (DeleteIfFound)
+            {
+                WdfCollectionRemoveItem(moduleContext->AssociatedFileObjects,
+                                        itemIndex);
+            }
+            break;
+        }
+    }
+
+    DMF_ModuleUnlock(DmfModule);
+
+    return returnValue;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // WDF Module Callbacks
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -294,25 +358,17 @@ Return Value:
     if (moduleContext->ReferenceStringUnicodePointer != NULL)
     {
         WDFFILEOBJECT fileObjectOfRequest = WdfRequestGetFileObject(Request);
-        UNICODE_STRING* fileName = WdfFileObjectGetFileName(fileObjectOfRequest);
-        if (fileName->Length > sizeof(L'\\'))
+        BOOLEAN found = IoctlHandler_AssociatedFileObjectsLookUp(DmfModule,
+                                                                 fileObjectOfRequest,
+                                                                 FALSE);
+        if (! found)                                                                 
         {
-            // Skip preceding '\'.
+            // This instance only accepts WDFREQUEST where WDFFILEOBJECT is 
+            // equal to AssociatedFileObject. Another instance of this Module should
+            // handle this request.
             //
-            WCHAR* stringFileObject = &fileName->Buffer[1];
-            size_t stringLengthFileObject = fileName->Length - sizeof(L'\\');
-            WCHAR* stringModule = moduleContext->ReferenceStringUnicode.Buffer;
-            size_t stringLengthModule = moduleContext->ReferenceStringUnicode.Length;
-            LONG comparisonLength = RtlCompareUnicodeStrings(stringFileObject,
-                                                             stringLengthFileObject,
-                                                             stringModule,
-                                                             stringLengthModule,
-                                                             FALSE);
-            if (comparisonLength != 0)
-            {
-                handled = FALSE;
-                goto Exit;
-            }
+            handled = FALSE;
+            goto Exit;
         }
     }
 
@@ -545,6 +601,72 @@ Return Value:
     moduleContext = DMF_CONTEXT_GET(DmfModule);
     moduleConfig = DMF_CONFIG_GET(DmfModule);
 
+    // If this Module instance has been created using a reference string, route the WDFREQUEST to 
+    // its corresponding instance based on reference string.
+    // This allows two instances of the same IoctlHandler Module to be instantiated in a single 
+    // WDFDEVICE.
+    //
+    if (moduleContext->ReferenceStringUnicodePointer != NULL)
+    {
+        WDFFILEOBJECT fileObjectOfRequest = WdfRequestGetFileObject(Request);
+        UNICODE_STRING* fileName = WdfFileObjectGetFileName(fileObjectOfRequest);
+        if (fileName->Length > sizeof(L'\\'))
+        {
+            // Skip preceding '\'.
+            //
+            WCHAR* stringFileObject = &fileName->Buffer[1];
+            size_t stringLengthFileObject = fileName->Length - sizeof(L'\\');
+            WCHAR* stringModule = moduleContext->ReferenceStringUnicode.Buffer;
+            size_t stringLengthModule = moduleContext->ReferenceStringUnicode.Length;
+            LONG comparisonLength = RtlCompareUnicodeStrings(stringFileObject,
+                                                             stringLengthFileObject,
+                                                             stringModule,
+                                                             stringLengthModule,
+                                                             FALSE);
+            if (comparisonLength == 0)
+            {
+                // It means this instance will only accept WDREQUEST where its WDFFILEOBJECT
+                // is equal to fileObjectRequest.
+                //
+                DMF_ModuleLock(DmfModule);
+                ntStatus = WdfCollectionAdd(moduleContext->AssociatedFileObjects,
+                                            fileObjectOfRequest);
+                DMF_ModuleUnlock(DmfModule);
+                if (!NT_SUCCESS(ntStatus))
+                {
+                    DmfAssert(!handled);
+                    TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionAdd fails ntStatus=%!STATUS!", ntStatus);
+                    goto RequestCompleteOnError;
+                }
+            }
+            else
+            {
+                // Another instance of this Module will handle this request because the file object's reference
+                // string does not match the reference string of this Module's instance.
+                //
+                DmfAssert(!handled);
+                goto Exit;
+            }
+        }
+        else 
+        {
+            // To maintain backward compatibility, if the incoming WDFFILEOBJECT has no
+            // filename, then this file object is processed by the first instance of the 
+            // Module.
+            //
+            DMF_ModuleLock(DmfModule);
+            ntStatus = WdfCollectionAdd(moduleContext->AssociatedFileObjects,
+                                        fileObjectOfRequest);
+            DMF_ModuleUnlock(DmfModule);
+            if (!NT_SUCCESS(ntStatus))
+            {
+                DmfAssert(!handled);
+                TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionAdd fails ntStatus=%!STATUS!", ntStatus);
+                goto RequestCompleteOnError;
+            }
+        }
+    }
+
     if (IoctlHandler_AccessModeDefault == moduleConfig->AccessModeFilter ||
         IoctlHandler_AccessModeFilterKernelModeOnly == moduleConfig->AccessModeFilter)
     {
@@ -582,7 +704,7 @@ Return Value:
         {
             DmfAssert(FALSE);
             DmfAssert(! NT_SUCCESS(ntStatus));
-            goto RequestComplete;
+            goto RequestCompleteOnError;
         }
 
         // This is empirically determined.
@@ -592,7 +714,7 @@ Return Value:
         {
             DmfAssert(FALSE);
             DmfAssert(! NT_SUCCESS(ntStatus));
-            goto RequestComplete;
+            goto RequestCompleteOnError;
         }
 
         // Check if an Administrator is creating the handle.
@@ -630,11 +752,12 @@ Return Value:
             }
         }
 
-RequestComplete:
-
 #endif // !defined(DMF_USER_MODE)
 
-        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "EVT_DMF_IoctlHandler_AccessModeFilterAdministrator* ntStatus=%!STATUS!", ntStatus);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "AccessModeFilterAdministrator ntStatus=%!STATUS!", ntStatus);
+
+RequestCompleteOnError:
+
         if (!NT_SUCCESS(ntStatus))
         {
             // This call completes the request correctly for both filter and non-filter drivers.
@@ -671,6 +794,8 @@ RequestComplete:
         // WARNING: Request is not completed. This code should not run.
         //
     }
+
+Exit:
 
     FuncExit(DMF_TRACE, "handled=%d", handled);
 
@@ -716,12 +841,28 @@ Return Value:
     PAGED_CODE();
 
     moduleContext = DMF_CONTEXT_GET(DmfModule);
-
     moduleConfig = DMF_CONFIG_GET(DmfModule);
 
     // Allow Client driver and other Modules to process this callback.
     //
     handled = FALSE;
+
+    if (moduleContext->ReferenceStringUnicodePointer != NULL)
+    {
+        // This file handle is being closed so it must be removed from the list
+        // of associated file objects. If it is not found, then another instance
+        // of this Module should handle it.
+        //
+        BOOLEAN found = IoctlHandler_AssociatedFileObjectsLookUp(DmfModule,
+                                                                 FileObject,
+                                                                 TRUE);
+        if (!found)                                                                 
+        {
+            // Another instances of this Module should handle this request.
+            //
+            goto Exit;
+        }
+    }
 
     // (Optimize to add to list only in mode where the list is used.)
     //
@@ -926,6 +1067,18 @@ Return Value:
             TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "WdfCollectionCreate fails: ntStatus=%!STATUS!", ntStatus);
             goto Exit;
         }
+    }
+
+    // Create the collection of WDFILEOBJECTS whose filename matches this instance in the 
+    // case where a ReferenceString is set.
+    //
+    if (moduleContext->ReferenceStringUnicodePointer != NULL)
+    {
+        WDF_OBJECT_ATTRIBUTES objectAttributes;
+        WDF_OBJECT_ATTRIBUTES_INIT(&objectAttributes);
+        objectAttributes.ParentObject = DmfModule;
+        ntStatus = WdfCollectionCreate(&objectAttributes,
+                                       &moduleContext->AssociatedFileObjects);
     }
 
 Exit:

--- a/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.c
+++ b/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.c
@@ -220,13 +220,13 @@ Return Value:
         DmfAssert(moduleContext->EventCountHeld > 0);
         InterlockedDecrement(&moduleContext->EventCountHeld);
         numberOfRequestsCompleted++;
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "DEQUEUE request=0x%p PendingEvents=%d", request, moduleContext->EventCountHeld);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "DEQUEUE request=0x%p PendingEvents=%d", request, moduleContext->EventCountHeld);
         if (NULL == EventCallbackFunction)
         {
             // Complete the request on behalf of Client Driver.
             // NOTE: NtStatus can be STATUS_CANCELLED or any other NTSTATUS.
             //
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Complete request=0x%p", request);
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Complete request=0x%p", request);
             WdfRequestComplete(request,
                                NtStatus);
         }
@@ -234,7 +234,7 @@ Return Value:
         {
             // Allow Client Driver to complete this request.
             //
-            TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Pass request=0x%p to Client Driver", request);
+            TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Pass request=0x%p to Client Driver", request);
             EventCallbackFunction(DmfModule,
                                   request,
                                   EventCallbackContext,
@@ -243,7 +243,7 @@ Return Value:
     }
     else
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "Cannot find request ntStatus:%!STATUS!", ntStatus);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "Cannot find request ntStatus:%!STATUS!", ntStatus);
     }
 
     FuncExit(DMF_TRACE, "numberOfRequestsCompleted=%d", numberOfRequestsCompleted);
@@ -988,7 +988,7 @@ Return Value:
         }
 
         requestContext->Timestamp = DMF_Time_TickCountGet(moduleContext->DmfModuleTime);
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "requestContext Timestamp=%lld", requestContext->Timestamp);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "requestContext Timestamp=%lld", requestContext->Timestamp);
     }
 
     // When a process comes or goes this request will be dequeued and completed.
@@ -997,7 +997,7 @@ Return Value:
                                           moduleContext->EventRequestQueue);
     if (NT_SUCCESS(ntStatus))
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "ENQUEUE Request=0x%p EventsHeld=%d", Request, moduleContext->EventCountHeld);
+        TraceEvents(TRACE_LEVEL_VERBOSE, DMF_TRACE, "ENQUEUE Request=0x%p EventsHeld=%d", Request, moduleContext->EventCountHeld);
     }
     else
     {

--- a/Dmf/Modules.Library/Dmf_ScheduledTask.c
+++ b/Dmf/Modules.Library/Dmf_ScheduledTask.c
@@ -489,6 +489,7 @@ Return:
         {
             // Let NumberOfPendingCalls decrement to zero.
             //
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_Rundown_Reference fails: ntStatus=%!STATUS!", ntStatus);
         }
         pendingCalls = InterlockedDecrement(&moduleContext->NumberOfPendingCalls);
     } while (pendingCalls > 0);
@@ -1301,7 +1302,7 @@ Return Value:
         }
         else
         {
-            ntStatus = STATUS_UNSUCCESSFUL;
+            TraceEvents(TRACE_LEVEL_ERROR, DMF_TRACE, "DMF_Rundown_Reference fails: ntStatus=%!STATUS!", ntStatus);
             InterlockedDecrement(&moduleContext->NumberOfPendingCalls);
         }
     }


### PR DESCRIPTION
Merge202040409
1. Correct regression in DMF_IoctlHandler when ReferenceString is used. BSOD caused by incorrect use of WdfFileObjectGetFileName().
2. Add DMF_HidDeviceListener. Lets client know when HID devices appear/disappear.
3. Correct DMF_DefaultTarget, DMF_DeviceInterfaceMultipleTarget and DMF_DeviceInterfaceTarget callback chaining. Chaining was not correct because it was not honoring rule that DMFMODULE passed to callback must be from immediate Child Module. Also, make corresponding changes to unit test code, DMF_Tests_DefaultTarget, DMF_Tests_DeviceInterfaceTarget and DMF_Tests_DeviceInterfaceMultipleTarget.
4. Make DMF_MobileBroadband more robust in cases of stress.
5. Clean up logging in DMF_NotifyUserWithRequest.
6. Fix issue in DMF_IoctlHandler when filtering WDFERQUESTS for Administrator mode when multiple instances of the Module are instantiated.
7. Correct issue with wrong handle used in DMF_DefaultTarget when streaming is not used.
8. Correct issue with wrong handle used in DMF_DeviceInterfaceTarget when streaming is not used.
9. Add tests for non-streaming mode for above two Modules.
10. Correct issues with DMF_QueuedWorkItem_Enqueue() and DMF_QueuedWorkItem_EnqueueAndWait(). These Methods were not properly detecting failures that can happen during stress testing.