### PR TITLE
Add cmake build system support for DMF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.18)
+
+# Query Windows SDK root directory.
+# CMake populates these with a bunch of unnecessary libraries, which requires
+# extra case-correcting symlinks and what not. Instead, let projects explicitly
+# control which libraries they require.
+file(
+    WRITE "${CMAKE_BINARY_DIR}/MakeRulesOverwrite.cmake"
+[=[
+    if (MSVC)
+        set(CMAKE_CXX_STANDARD_LIBRARIES_INIT " "  CACHE STRING "" FORCE)
+        set(CMAKE_C_STANDARD_LIBRARIES_INIT " "  CACHE STRING "" FORCE)
+    endif()
+]=]
+)
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_BINARY_DIR}/MakeRulesOverwrite.cmake")
+
+# Skip simpile Test program which may result in cmake failure
+SET(CMAKE_C_COMPILER_WORKS 1)
+SET(CMAKE_CXX_COMPILER_WORKS 1)
+set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 0)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+message(FATAL_ERROR "In-tree builds are not supported. Run CMake from a separate directory: cmake -B build")
+endif()
+
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+project(DMF)
+enable_language(CXX)
+enable_language(C)
+# enable_language(ASM_MARMASM)
+
+# Variables
+list(APPEND CMAKE_MODULE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+message("Detecting OS and Architecture")
+include(DetectOS)
+
+# validate supported OS
+if(HOST_OS_LINUX)
+    message(STATUS "OS: Linux")
+elseif(HOST_OS_WINDOWS)
+    message(STATUS "OS: Windows")
+else()
+    message(FATAL_ERROR "Unsupported OS")
+    return()
+endif()
+	
+# Validate supported architecture
+if(TARGET_ARCH_X64)
+	message(STATUS "Target Architecture: x64")
+elseif(TARGET_ARCH_X86)
+	message(STATUS "Target Architecture: x86")
+elseif(TARGET_ARCH_ARM64)
+	message(STATUS "Target Architecture: arm64")
+else()
+	message(FATAL_ERROR "Unsupported architecture")
+	return()
+endif()
+	
+if(HOST_OS_WINDOWS)
+    message("Locating Windows Driver Kit")
+    include(msvc-configurations)
+    include(FindWDK)
+elseif(HOST_OS_LINUX)
+    message("Locating Linux Kernel Module Builder")
+    include(LKM)
+endif()
+
+if(HOST_OS_WINDOWS) # msvc
+	if( CMAKE_CXX_FLAGS_DEBUG MATCHES "/RTC1" )
+	string( REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" )
+	endif()	
+
+	if( CMAKE_C_FLAGS_DEBUG MATCHES "/RTC1" )
+	string( REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}" )
+	endif()
+
+	if( CMAKE_CXX_FLAGS MATCHES "/EHsc" )
+	string( REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
+	endif()	
+
+	if( CMAKE_C_FLAGS MATCHES "/EHsc" )
+	string( REPLACE "/EHsc" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
+	endif()
+
+	if( CMAKE_CXX_FLAGS MATCHES "/GR" )
+	string( REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
+	endif()	
+
+	if( CMAKE_C_FLAGS MATCHES "/GR" )
+	string( REPLACE "/GR" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
+	endif()
+endif()
+
+set(DMF_LIB_FINAL_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/$<CONFIG>/${TARGET_PLATFORM}/)
+
+# DMF Lib list
+set(DMF_KLIBS DmfK DmfKFramework DmfKModules.Library DmfKModules.Library.Tests DmfKModules.Template)
+set(DMF_ULIBS DmfU DmfUFramework DmfUModules.Library )
+foreach(DMF_LIB IN LISTS DMF_KLIBS)
+	add_subdirectory(Dmf/Solution/${DMF_LIB})
+endforeach()
+foreach(DMF_LIB IN LISTS DMF_ULIBS)
+	add_subdirectory(Dmf/Solution/${DMF_LIB})
+endforeach()
+
+#DMF Samples Codes
+add_subdirectory(DmfSamples/InterfaceSample1)
+add_subdirectory(DmfSamples/InterfaceSample2)
+
+#Unit Test Code
+add_subdirectory(DmfTest/DmfKTest/sys)
+add_subdirectory(DmfTest/DmfUTest/sys)

--- a/Dmf/Solution/DmfK/CMakeLists.txt
+++ b/Dmf/Solution/DmfK/CMakeLists.txt
@@ -1,0 +1,56 @@
+# kernel mode lib generator script
+# set(DmfK_Srcs
+set(TargetName "DmfK")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfK.c
+)
+
+wdk_add_kmd_library(${TargetName} STATIC KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+		"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/lib/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/lib/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfKFramework/CMakeLists.txt
+++ b/Dmf/Solution/DmfKFramework/CMakeLists.txt
@@ -1,0 +1,71 @@
+# kernel mode lib generator script
+set(TargetName "DmfKFramework")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfBranchTrack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfCall.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfContainer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfCore.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfDeviceInit.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfFilter.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfGeneric.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfHelpers.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfInterfaceInternal.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfInternal.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfLiveKernelDump.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfModuleCollection.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfPortable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfUtility.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfValidate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/Dmf_BranchTrack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/Dmf_Bridge.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/Dmf_LiveKernelDump.c
+	)
+
+wdk_add_kmd_library(${TargetName} STATIC KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+	${WPP_PRPROC_FOLDER}
+	)
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} PRIVATE 
+${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfKModules.Library.Tests/CMakeLists.txt
+++ b/Dmf/Solution/DmfKModules.Library.Tests/CMakeLists.txt
@@ -1,0 +1,78 @@
+
+set(TargetName "DmfKModules.Library.Tests")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_AlertableSleep.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_BufferPool.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_HashTable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Pdo.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_PingPongBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Registry.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_RingBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_ScheduledTask.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Stack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_String.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/TestsUtility.c
+)
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+	# set(wpp_target ${TargetName})
+	set_source_files_properties(${${TargetName}_Srcs} PROPERTIES LANGUAGE CXX)
+endif()
+
+wdk_add_kmd_library(${TargetName} STATIC KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfKModules.Library/CMakeLists.txt
+++ b/Dmf/Solution/DmfKModules.Library/CMakeLists.txt
@@ -1,0 +1,124 @@
+
+set(TargetName "DmfKModules.Library")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_String.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_UefiLogs.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_UefiOperation.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AcpiNotification.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AcpiPepDevice.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AcpiPepDeviceFan.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AcpiTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ActivitySensor.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AlertableSleep.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_BufferPool.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_BufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ComponentFirmwareUpdateHidTransport.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ConnectedStandby.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ContinuousRequestTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_CrashDump.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DefaultTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DeviceInterfaceTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Doorbell.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_EyeGazeIoctl.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_File.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_GpioTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HashTable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HidPortableDeviceButtons.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HidTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HingeAngle.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_I2cTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_BusTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_ComponentFirmwareUpdate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_SystemManagementFramework.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_InterruptResource.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_IoctlHandler.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_MobileBroadband.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_NotifyUserWithEvent.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_NotifyUserWithRequest.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_NotifyUserWithRequestMultiple.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Pdo.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_PingPongBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_QueuedWorkItem.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Registry.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_RequestTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ResourceHub.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_RingBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Rundown.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ScheduledTask.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SelfTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SerialTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SimpleOrientation.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SmbiosWmi.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SpbTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SpiTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Stack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ThermalCoolingInterface.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Thread.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ThreadedBufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Time.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_UdeClient.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_VirtualEyeGaze.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_VirtualHidAmbientColorSensor.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_VirtualHidAmbientLightSensor.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_VirtualHidDeviceVhf.c
+	# ${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SymbolicLinkTarget.c
+	# ${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_CmApi.c
+	# ${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ComponentFirmwareUpdate.c
+	# ${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_CppContainer.cpp
+	)
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+	# set(wpp_target ${TargetName})
+	set_source_files_properties(${${TargetName}_Srcs} PROPERTIES LANGUAGE CXX)
+endif()
+
+wdk_add_kmd_library(${TargetName} STATIC KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+target_compile_options(${TargetName} PRIVATE /TP)
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfKModules.Template/CMakeLists.txt
+++ b/Dmf/Solution/DmfKModules.Template/CMakeLists.txt
@@ -1,0 +1,82 @@
+
+set(TargetName "DmfKModules.Template")
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterface.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterfaceLower.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterfaceUpper.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyTransportA.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyTransportB.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_NonPnp.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_OsrFx2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceProtocol1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Template.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_ToasterBus.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_VirtualHidMiniSample.c
+	)
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+	# set(wpp_target ${TargetName})
+	set_source_files_properties(${${TargetName}_Srcs} PROPERTIES LANGUAGE CXX)
+endif()
+
+wdk_add_kmd_library(${TargetName} STATIC KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfU/CMakeLists.txt
+++ b/Dmf/Solution/DmfU/CMakeLists.txt
@@ -1,0 +1,53 @@
+set(TargetName "DmfU")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfU.c
+	)
+
+wdk_add_umd_library(${TargetName} STATIC UMDF 2.23 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+	${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		umd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../
+	${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/lib/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/lib/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfUFramework/CMakeLists.txt
+++ b/Dmf/Solution/DmfUFramework/CMakeLists.txt
@@ -1,0 +1,68 @@
+set(TargetName "DmfUFramework")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfBranchTrack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfCall.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfContainer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfCore.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfDeviceInit.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfFilter.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfGeneric.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfHelpers.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfInterfaceInternal.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfInternal.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfModuleCollection.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfPortable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfUtility.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfValidate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/Dmf_BranchTrack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/Dmf_Bridge.c
+)
+wdk_add_umd_library(${TargetName} STATIC UMDF 2.23 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		umd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfUModules.Library.Tests/CMakeLists.txt
+++ b/Dmf/Solution/DmfUModules.Library.Tests/CMakeLists.txt
@@ -1,0 +1,69 @@
+set(TargetName "DmfUModules.Library.Tests")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_AlertableSleep.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_BufferPool.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_BufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DefaultTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_DeviceInterfaceTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_HashTable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Pdo.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_PingPongBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Registry.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_RingBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_ScheduledTask.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_SelfTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_Stack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/Dmf_Tests_String.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library.Tests/TestsUtility.c
+)
+wdk_add_umd_library(${TargetName} STATIC UMDF 2.23 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		umd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfUModules.Library/CMakeLists.txt
+++ b/Dmf/Solution/DmfUModules.Library/CMakeLists.txt
@@ -1,0 +1,99 @@
+
+set(TargetName "DmfUModules.Library")
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_String.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_UefiLogs.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/DMF_UefiOperation.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AcpiTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ActivitySensor.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_AlertableSleep.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_BufferPool.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_BufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ComponentFirmwareUpdateHidTransport.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ContinuousRequestTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DefaultTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DeviceInterfaceMultipleTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_DeviceInterfaceTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Doorbell.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_EyeGazeIoctl.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_File.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_GpioTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HashTable.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_HingeAngle.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_I2cTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_BusTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_ComponentFirmwareUpdate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Interface_SystemManagementFramework.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_InterruptResource.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_IoctlHandler.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_MobileBroadband.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_PingPongBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_QueuedWorkItem.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Registry.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_RequestTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_RingBuffer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Rundown.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ScheduledTask.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SimpleOrientation.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SmbiosWmi.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SpbTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SpiTarget.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Stack.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Thread.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ThreadedBufferQueue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_Time.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_CmApi.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_VirtualHidMini.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_ComponentFirmwareUpdate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Library/Dmf_SymbolicLinkTarget.c
+)
+
+wdk_add_umd_library(${TargetName} STATIC UMDF 2.23 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		umd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/Dmf/Solution/DmfUModules.Template/CMakeLists.txt
+++ b/Dmf/Solution/DmfUModules.Template/CMakeLists.txt
@@ -1,0 +1,74 @@
+set(TargetName "DmfUModules.Template")
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterface.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterfaceLower.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Interface_SampleInterfaceUpper.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyTransportA.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_LegacyTransportB.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_NonPnp.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_OsrFx2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceLowerTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceProtocol1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperProtocol.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperTransport1.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_SampleInterfaceUpperTransport2.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_Template.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_ToasterBus.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Modules.Template/Dmf_VirtualHidMiniSample.c
+)
+
+wdk_add_umd_library(${TargetName} STATIC UMDF 2.23 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;WIN32_LEAN_AND_MEAN=1>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_FLAGS
+	"/TP /std:c++17"
+)
+
+if(WPP_ENABLED EQUAL 1)
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} PRIVATE 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		umd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/DmfTrace.h)
+	endforeach()
+endif()
+
+target_include_directories(${TargetName} BEFORE PRIVATE 
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/Modules.Core/
+)
+
+add_custom_command(
+	TARGET ${TargetName} POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TargetName}.lib  ${DMF_LIB_FINAL_OUTPUT_PATH}/individual_libs/${TargetName}/${TargetName}.lib
+	VERBATIM
+)

--- a/DmfSamples/EyeGazeIoctl/CMakeLists.txt
+++ b/DmfSamples/EyeGazeIoctl/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+set(TargetName "EyeGazeIoctl")
+
+project(${TargetName})
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfInterface.c
+	)
+
+wdk_add_kmd_driver(${TargetName} KMDF 1.15 ${${TargetName}_Srcs})
+target_sources(${TargetName} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+target_link_libraries(${TargetName} ${DMF_KLIBS})
+target_link_libraries(${TargetName}
+	WDK::NTSTRSAFE
+	WDK::LKMDTEL
+	WDK::VHFKM
+	WDK::WERKERNELAPI
+)
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/trace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	)

--- a/DmfSamples/InterfaceSample1/CMakeLists.txt
+++ b/DmfSamples/InterfaceSample1/CMakeLists.txt
@@ -1,0 +1,56 @@
+
+set(TargetName "InterfaceSample1")
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfInterface.c
+	)
+
+wdk_add_kmd_driver(${TargetName} KMDF 1.15 ${${TargetName}_Srcs})
+target_sources(${TargetName} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+target_link_libraries(${TargetName} ${DMF_KLIBS})
+target_link_libraries(${TargetName}
+	WDK::NTSTRSAFE
+	WDK::LKMDTEL
+	WDK::VHFKM
+	WDK::WERKERNELAPI
+)
+
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/DmfTrace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	)

--- a/DmfSamples/InterfaceSample2/CMakeLists.txt
+++ b/DmfSamples/InterfaceSample2/CMakeLists.txt
@@ -1,0 +1,55 @@
+
+set(TargetName "InterfaceSample2")
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfInterface.c
+	)
+
+wdk_add_kmd_driver(${TargetName} KMDF 1.15 ${${TargetName}_Srcs})
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+target_link_libraries(${TargetName} ${DMF_KLIBS})
+target_link_libraries(${TargetName}
+	WDK::NTSTRSAFE
+	WDK::LKMDTEL
+	WDK::VHFKM
+	WDK::WERKERNELAPI
+)
+
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}/  ${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/DmfTrace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	)

--- a/DmfTest/DmfKTest/sys/CMakeLists.txt
+++ b/DmfTest/DmfKTest/sys/CMakeLists.txt
@@ -1,0 +1,73 @@
+
+set(TargetName "DmfKTest")
+
+project(${TargetName})
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfInterface.c
+	)
+
+# configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc ${CMAKE_CURRENT_BINARY_DIR}/${TargetName}.  @ONLY)
+wdk_add_kmd_driver(${TargetName} KMDF 1.15 ${${TargetName}_Srcs})
+
+target_sources(${TargetName} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc)
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY 
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+
+set_property(TARGET ${TargetName} APPEND PROPERTY CXX_COMPILE_FLAGS
+	"/std:c11"
+)
+
+target_link_libraries(${TargetName} ${DMF_KLIBS})
+
+target_link_libraries(${TargetName}
+	WDK::NTSTRSAFE
+	WDK::LKMDTEL
+	WDK::VHFKM
+	WDK::WERKERNELAPI
+)
+
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}  ${CMAKE_CURRENT_SOURCE_DIR}\\Trace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.smf/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	)

--- a/DmfTest/DmfUTest/sys/CMakeLists.txt
+++ b/DmfTest/DmfUTest/sys/CMakeLists.txt
@@ -1,0 +1,77 @@
+
+set(TargetName "DmfUTest")
+
+project(${TargetName})
+
+set(${TargetName}_Srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/DmfInterface.c
+	)
+
+# configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc ${CMAKE_CURRENT_BINARY_DIR}/${TargetName}.  @ONLY)
+wdk_add_usermode_driver(${TargetName}
+    UMDF 1.15
+    WINVER 0x0A00            # Windows 10
+    NTDDI_VERSION 0x0A000004 # Windows 10 1709
+    ${SOURCE_VIRTUAL_DISPLAY})
+
+target_sources(${TargetName} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${TargetName}.rc)
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Debug>:_WIN64;USE_ASSERT_BREAK;_UNICODE;UNICODE;DEBUG;DBG;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+set_property(TARGET ${TargetName} APPEND PROPERTY 
+	"$<$<CONFIG:Release>:_WIN64;NO_USE_ASSERT_BREAK;_UNICODE;UNICODE;>"
+)
+
+
+set_property(TARGET ${TargetName} APPEND PROPERTY CXX_COMPILE_FLAGS
+	"/std:c11"
+)
+
+target_link_libraries(${TargetName} ${DMF_ULIBS})
+
+# target_link_libraries(${TargetName}
+# 	WDK::NTSTRSAFE
+# 	WDK::LKMDTEL
+# 	WDK::VHFKM
+# 	WDK::WERKERNELAPI
+# )
+
+
+if(WPP_ENABLED EQUAL 1)
+
+	set(WPP_PRPROC_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/WppTmp)
+	file(MAKE_DIRECTORY ${WPP_PRPROC_FOLDER})
+	set_property(TARGET ${TargetName} APPEND PROPERTY COMPILE_DEFINITIONS
+	"ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME"
+	)
+	target_include_directories(${TargetName} BEFORE PUBLIC 
+		${WPP_PRPROC_FOLDER}
+	)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(wpp_target ${TargetName})
+	else()
+		add_custom_target(${TargetName}Null)
+		add_dependencies(${TargetName} ${TargetName}Null)
+		set(wpp_target ${TargetName}Null)
+	endif()
+	set(WPP_SOURCE_FILES ${${TargetName}_Srcs})
+	foreach(wpp_file IN LISTS WPP_SOURCE_FILES)
+		string(REPLACE "/" "\\" wpp_file_str  ${wpp_file})
+		kmd_wpp_preproc(${wpp_target}  ${wpp_file_str} ${WPP_PRPROC_FOLDER}  ${CMAKE_CURRENT_SOURCE_DIR}\\Trace.h)
+	endforeach()
+
+endif()
+
+target_include_directories(${TargetName} BEFORE PUBLIC 
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Framework/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library.Tests/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Template/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.Library/
+	${CMAKE_CURRENT_SOURCE_DIR}/../../Dmf/Modules.smf/
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ Detailed documentation about each Module is available on the wiki: https://githu
 #### Samples:
 [DmfSamples](https://github.com/Microsoft/DMF/tree/master/DmfSamples) has all the sample drivers that show in incremental steps how to use DMF in a driver. 
 
+#### Cmake Section
+##### For EWDK, Let's say ISO mounted as F: disk
+```
+#x64
+call "F:/LaunchBuildEnv.cmd" x86_AMD64 
+#arm64
+call "F:/LaunchBuildEnv.cmd" x86_arm64 
+cmake -B build_cmake  -DWPP_ENABLED=1   -G "Ninja Multi-Config"
+cmake --build build_cmake --config Debug
+```
+##### For EDK and SDK
+```
+#x64
+call "D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat"
+#arm64
+call "D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsx86_arm64.bat"  
+cmake -B build_cmake  -DWPP_ENABLED=1   -G "Ninja Multi-Config"
+cmake --build build_cmake --config Debug
+```
+
 #### Questions/Feedback
 Please send email to: dmf-feedback@microsoft.com
 

--- a/cmake/DetectOS.cmake
+++ b/cmake/DetectOS.cmake
@@ -1,0 +1,50 @@
+#
+# This script is used to detect the OS and architecture of the host system
+#
+
+# Detect host architecture
+if(CMAKE_C_PLATFORM_ID STREQUAL "Windows")
+    if(DEFINED ENV{PROCESSOR_ARCHITECTURE})
+        if("$ENV{PROCESSOR_ARCHITECTURE}" MATCHES "AMD64" ) 
+            set(HOST_ARCH  "x86")
+        else()
+            set(HOST_ARCH  "$ENV{PROCESSOR_ARCHITECTURE}")
+        endif()
+    else()
+    # If no PROCESSOR_ARCHITECTURE found, set to x86 defaultly
+        set(HOST_ARCH  "x86")
+    endif()
+    if(CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "x86")
+        set(TARGET_ARCH_X86 TRUE BOOL)
+        set(IS_CROSS_COMPILE FALSE BOOL)
+        set(TARGET_PLATFORM "x86")
+        elseif(CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "x64")
+        set(TARGET_ARCH_X64 TRUE BOOL)
+        set(TARGET_PLATFORM "x64")
+        set(IS_CROSS_COMPILE FALSE BOOL)
+        elseif(CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64")
+        set(TARGET_ARCH_ARM64 TRUE BOOL)
+        set(TARGET_PLATFORM "arm64")
+        set(IS_CROSS_COMPILE TRUE BOOL)
+    endif()
+elseif(CMAKE_C_PLATFORM_ID STREQUAL "Linux")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(TARGET_ARCH_X86 TRUE BOOL)
+        set(TARGET_PLATFORM "x86")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(TARGET_ARCH_X64 TRUE BOOL)
+        set(TARGET_PLATFORM "x64")
+    endif()
+endif()
+
+message(STATUS "CMAKE_C_COMPILER_ARCHITECTURE_ID: ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
+message(STATUS "HOST_ARCH: ${HOST_ARCH}")
+message(STATUS "TARGET_PLATFORM: ${TARGET_PLATFORM}")
+message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
+
+# Detect host operating system
+string(REGEX MATCH "Linux" HOST_OS_LINUX ${CMAKE_SYSTEM_NAME})
+
+if(WIN32)
+    set(HOST_OS_WINDOWS TRUE BOOL)
+endif()

--- a/cmake/FindWDK.cmake
+++ b/cmake/FindWDK.cmake
@@ -1,0 +1,521 @@
+# Redistribution and use is allowed under the OSI-approved 3-clause BSD license.
+# Copyright (c) 2018 Sergey Podobry (sergey.podobry at gmail.com). All rights reserved.
+
+#.rst:
+# FindWDK
+# ----------
+#
+# This module searches for the installed Windows Development Kit (WDK) and
+# exposes commands for creating kernel drivers and kernel libraries.
+#
+# Output variables:
+# - `WDK_FOUND` -- if false, do not try to use WDK
+# - `WDK_ROOT` -- where WDK is installed
+# - `WDK_VERSION` -- the version of the selected WDK
+# - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries
+#        (default value is `0x0601` and can be changed per target or globally)
+# - `WDK_NTDDI_VERSION` -- the NTDDI_VERSION used for kernel drivers and libraries,
+#                          if not set, the value will be automatically calculated by WINVER
+#        (default value is left blank and can be changed per target or globally)
+#
+# Example usage:
+#
+#   find_package(WDK REQUIRED)
+#
+#   wdk_add_kmd_library(KmdfCppLib STATIC KMDF 1.15
+#       KmdfCppLib.h
+#       KmdfCppLib.cpp
+#       )
+#   target_include_directories(KmdfCppLib INTERFACE .)
+#
+#   wdk_add_kmd_driver(KmdfCppDriver KMDF 1.15
+#       Main.cpp
+#       )
+#   target_link_libraries(KmdfCppDriver KmdfCppLib)
+#
+
+# Thanks to yousif for this trick with the registry!
+if(DEFINED ENV{WDKContentRoot})
+    file(GLOB WDK_NTDDK_FILES
+        "$ENV{WDKContentRoot}/Include/*/km/ntddk.h" # WDK 10
+        "$ENV{WDKContentRoot}/Include/km/ntddk.h" # WDK 8.0, 8.1
+    )
+else()
+    get_filename_component(WDK_ROOT
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]"
+        ABSOLUTE)
+    # Find all ntdkk.h files, then sort for the latest.
+    file(GLOB WDK_NTDDK_FILES ${WDK_ROOT}/Include/*/km/ntddk.h)
+endif()
+
+if(WDK_NTDDK_FILES)
+    if (NOT CMAKE_VERSION VERSION_LESS 3.18.0)
+        list(SORT WDK_NTDDK_FILES COMPARE NATURAL) # sort to use the latest available WDK
+    endif()
+    list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+
+if (NOT WDK_LATEST_NTDDK_FILE)
+    return()
+endif()
+
+get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+if (NOT WDK_ROOT MATCHES ".*/[0-9][0-9.]*$") # WDK 10 has a deeper nesting level
+    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY) # go up once more
+    set(WDK_LIB_VERSION "${WDK_VERSION}")
+    set(WDK_INC_VERSION "${WDK_VERSION}")
+else() # WDK 8.0, 8.1
+    set(WDK_INC_VERSION "")
+    foreach(VERSION winv6.3 win8 win7)
+        if (EXISTS "${WDK_ROOT}/Lib/${VERSION}/")
+            set(WDK_LIB_VERSION "${VERSION}")
+            break()
+        endif()
+    endforeach()
+    set(WDK_VERSION "${WDK_LIB_VERSION}")
+endif()
+
+message(STATUS "WDK_ROOT: ${WDK_ROOT}")
+message(STATUS "WDK_VERSION: ${WDK_VERSION}")
+
+# set(ENV{PATH} "${WDK_ROOT}/bin/${WDK_VERSION}/;$ENV{PATH}")
+# message(STATUS "PATH: $ENV{PATH}")
+message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+
+find_program(WDK_TRACE_WPP_TOOL tracewpp
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_TRACE_WPP_TOOL: ${WDK_TRACE_WPP_TOOL}")
+
+find_program(WDK_INF2CATTOOL inf2cat
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_INF2CATTOOL: ${WDK_INF2CATTOOL}")
+
+find_program(WDK_STAMPINF_TOOL stampinf
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_STAMPINF_TOOL: ${WDK_STAMPINF_TOOL}")
+
+find_program(WDK_SIGNTOOL signtool
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_SIGNTOOL: ${WDK_SIGNTOOL}")
+
+get_filename_component(PACKAGE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(WDK_PFX "${PACKAGE_DIR}/TestSigning.pfx" CACHE STRING "Private key used for signing the driver")
+if(NOT EXISTS "${WDK_PFX}")
+    message(FATAL_ERROR "PFX not found: ${WDK_PFX}")
+else()
+    message(STATUS "PFX: ${WDK_PFX}")
+endif()
+
+# Windows 10 1709 by default
+# https://learn.microsoft.com/ru-ru/cpp/porting/modifying-winver-and-win32-winnt
+# https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
+set(WDK_WINVER "0x0A00" CACHE STRING "Default WINVER for WDK targets")
+set(WDK_NTDDI_VERSION "0x0A000004" CACHE STRING "Specified NTDDI_VERSION for WDK targets if needed")
+
+set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
+file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+
+# location of warning.h
+set(WDK_WARNING_H_FILE "${WDK_ROOT}/Include/${WDK_VERSION}/shared/warning.h")
+set(WDK_COMPILE_FLAGS
+        "/Zi"
+        "/W4"
+        "/WX"
+        "/diagnostics:classic"
+        "/Oy-"
+        "/GF"
+        "/Gm-"
+        "/Zp8"
+        "/GS"
+        "/Gy"
+        "/analyze-" 
+        "/fp:precise"
+        "/Zc:wchar_t-"
+        "/Zc:forScope"
+        "/Zc:inline"
+        "/GR-"
+        "/wd4603"
+        "/wd4627"
+        "/wd4986"
+        "/wd4987"
+        "/wd4996"
+        "/wd4064"
+        "/wd4366"
+        "/wd4748"
+        "/wd4047"
+        "/wd4053"
+        "/Wv:18"
+        "/FC"
+        "/errorReport:prompt"
+        "-cbstring"
+        # "-d2epilogunwind"
+        "/d1nodatetime"
+        "/d1import_no_registry"
+        "/d2AllowCompatibleILVersions"
+        "/d2Zi+"
+        "/FI${WDK_WARNING_H_FILE}"
+    )
+list(APPEND WDK_COMPILE_FLAGS "$<$<CONFIG:Debug>:/Od>;$<$<CONFIG:Rlease>:/O2>")
+# message(STATUS "WDK_COMPILE_FLAGS: " ${WDK_COMPILE_FLAGS})
+
+set(WDK_COMPILE_DEFINITIONS "WINNT=1")
+set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
+set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I\"${WDK_ROOT}/Include/${WDK_INC_VERSION}/um\"")
+if(TARGET_ARCH_X86)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
+    set(WDK_PLATFORM "x86")
+    set(INF2CAT_OS_TYPE "10_X86")
+    set(STAMPINF_ARCH_TYPE "x86")
+elseif(TARGET_ARCH_X64)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
+    set(WDK_PLATFORM "X64")
+    set(INF2CAT_OS_TYPE "10_X64")
+    set(STAMPINF_ARCH_TYPE "AMD64")
+    elseif(TARGET_ARCH_ARM64)
+    set(WDK_PLATFORM "arm64")
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_ARM64_;ARM64")
+    set(OS_TYPE "server10_arm64")
+    set(INF2CAT_OS_TYPE "server10_arm64")
+    set(STAMPINF_ARCH_TYPE "ARM64")
+else()
+        message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+# EWDK Didn't Initilzie CMAKE_SIZEOF_VOID_P
+if(NOT DEFINED CMAKE_SIZEOF_VOID_P)
+    message(WARNING  "CMAKE_SIZEOF_VOID_P Not Defined, will be inferred by WDK_PLATFORM:${WDK_PLATFORM}")
+    if(WDK_PLATFORM MATCHES 64)
+        set(CMAKE_SIZEOF_VOID_P 8)
+        else()
+        set(CMAKE_SIZEOF_VOID_P 4)
+    endif()
+endif()
+
+string(CONCAT WDK_LINK_FLAGS
+    "/machine:${WDK_PLATFORM} "
+    "/MANIFEST:NO "
+    "/PROFILE "
+    "/WX "
+    "/Driver "
+    "/OPT:REF "
+    "/OPT:ICF "
+    "/INCREMENTAL:NO "
+    "/SUBSYSTEM:NATIVE,\"10.00\" "
+    "/MERGE:\"_TEXT=.text;_PAGE=PAGE\" "
+    "/NODEFAULTLIB "
+    "/SECTION:INIT,d "
+    "/IGNORE:4198,4010,4037,4039,4065,4070,4078,4087,4089,4221,4108,4088,4218,4218,4235,4257 "
+    "/osversion:\"10.0\" " 
+    "/version:\"10.0\" " 
+    "/pdbcompress "
+    "/debugtype:pdata "
+    "/nologo "
+)
+
+# Generate imported targets for WDK lib files
+file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_LIB_VERSION}/km/${WDK_PLATFORM}/*.lib")
+foreach(LIBRARY IN LISTS WDK_LIBRARIES)
+get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
+string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
+add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
+set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
+endforeach(LIBRARY)
+unset(WDK_LIBRARIES)
+set(CMAKE_CXX_STANDARD_LIBRARIES " ")
+set(CMAKE_C_STANDARD_LIBRARIES " ")
+
+function(wdk_add_kmd_driver _target)
+
+        cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})        
+        add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
+        set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
+
+        if(DEFINED WDK_KMDF)
+            string(REPLACE "." ";" WDK_KMDF_VER_LIST ${WDK_KMDF})
+            list(GET WDK_KMDF_VER_LIST 0 KMDF_VERSION_MAJOR)
+            list(GET WDK_KMDF_VER_LIST 1 KMDF_VERSION_MINOR)
+            list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MAJOR=${KMDF_VERSION_MAJOR}")
+            list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MINOR=${KMDF_VERSION_MINOR}")
+        endif()
+
+        list(APPEND WDK_COMPILE_FLAGS "/kernel")
+        # set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+
+        target_compile_options(${_target} PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+        $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+        $<$<COMPILE_LANGUAGE:ASM>:${ASM_FLAGS}>
+        )
+
+        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER};WINVER=${WDK_WINVER}"
+        )
+        # link parameter
+        set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+        set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/kernel ")
+
+        if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+        endif()
+        
+        target_include_directories(${_target} PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km/crt"
+        )
+        
+        target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWFASTFAILK WDK::WMILIB WDK::WPPRECORDER WDK::BUFFEROVERFLOWFASTFAILK) 
+        
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            target_link_libraries(${_target} WDK::MEMCMP)
+        endif()
+        
+        if(${WDK_PLATFORM} STREQUAL "arm64")
+            target_link_libraries(${_target} "${WDK_ROOT}/Lib/${WDK_INC_VERSION}/um/${WDK_PLATFORM}/arm64rt.lib")
+        endif()
+
+        if(DEFINED WDK_KMDF)
+            target_include_directories(${_target} PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+            target_link_libraries(${_target}
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
+            )
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
+            endif()
+        else()
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
+            endif()
+        endif()
+    
+    # copy inf
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_target}.inx ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${_target}.inf
+        VERBATIM
+    )
+    #timestamp inf stage
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${WDK_STAMPINF_TOOL}  -a ${STAMPINF_ARCH_TYPE} -v "*" -k "1.15"  -d "*" -x -f "${CMAKE_CURRENT_BINARY_DIR}\\$<CONFIG>\\${_target}.inf"
+        VERBATIM
+        )
+    # #inf2cat stage
+    # add_custom_command(
+    #     TARGET ${_target} POST_BUILD
+    #     COMMAND ${WDK_INF2CATTOOL}  /os:${INF2CAT_OS_TYPE} /driver:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+    #     VERBATIM
+    # )
+    # Code signing
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND "${WDK_SIGNTOOL}" sign /fd SHA256 /f "${WDK_PFX}" "$<TARGET_FILE:${_target}>"
+        VERBATIM
+    )
+endfunction()
+
+function(wdk_add_kmd_library _target)
+
+    cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+    message(STATUS "Target: " ${_target})
+    message(STATUS "WDK_KMDF: " ${WDK_KMDF})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    if(DEFINED WDK_KMDF)
+        string(REPLACE "." ";" WDK_KMDF_VER_LIST ${WDK_KMDF})
+        list(GET WDK_KMDF_VER_LIST 0 KMDF_VERSION_MAJOR)
+        list(GET WDK_KMDF_VER_LIST 1 KMDF_VERSION_MINOR)
+        list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MAJOR=${KMDF_VERSION_MAJOR}")
+        list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MINOR=${KMDF_VERSION_MINOR}")
+    endif()
+
+
+    list(APPEND WDK_COMPILE_FLAGS "/kernel")
+    # set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    target_compile_options(${_target} PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp ${ASM_FLAGS}>
+    )
+
+    set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS
+    "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER};WINVER=${WDK_WINVER}"
+    )
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km/crt"
+        )
+
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+    endif()
+endfunction()
+
+function(wdk_add_umd_library _target)
+
+    cmake_parse_arguments(WDK "" "UMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+    message(STATUS "Target: " ${_target})
+    message(STATUS "WDK_UMDF: " ${WDK_UMDF})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    if(DEFINED WDK_UMDF)
+        string(REPLACE "." ";" WDK_UMDF_VER_LIST ${WDK_UMDF})
+        list(GET WDK_UMDF_VER_LIST 0 UMDF_VERSION_MAJOR)
+        list(GET WDK_UMDF_VER_LIST 1 UMDF_VERSION_MINOR)
+    endif()
+
+    list(APPEND WDK_COMPILE_DEFINITIONS "UMDF_VERSION_MAJOR=${UMDF_VERSION_MAJOR}")
+    list(APPEND WDK_COMPILE_DEFINITIONS "UMDF_VERSION_MINOR=${UMDF_VERSION_MINOR}")
+
+    target_compile_options(${_target} PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:ASM>: ${ASM_FLAGS}>
+    )
+
+    set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS
+    "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER}"
+    )
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/winrt"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/ucrt"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um"
+        )
+
+    if(DEFINED WDK_UMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/umdf/${WDK_UMDF}")
+    endif()
+endfunction()
+
+function(wdk_add_usermode_driver _target)
+    cmake_parse_arguments(WDK "" "UMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+
+    message(STATUS "UMDF_VERSION_MAJOR: ${UMDF_VERSION_MAJOR}")
+    message(STATUS "WDK_UMDF: " ${WDK_UMDF})
+    message(STATUS "UMDF_VERSION_MAJOR : " ${UMDF_VERSION_MAJOR})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    set_target_properties(${_target} PROPERTIES SUFFIX ".dll")
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "/Gz")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};_WIN32_WINNT=${WDK_WINVER};NTDDI_VERSION=${WDK_NTDDI_VERSION}")
+    set_target_properties(${_target} PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
+
+    set(WDK_WDF_DIR "${WDK_WDF_ROOT}/wdf/umdf/${WDK_UMDF}")
+    set(WDK_WINRT_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/winrt")
+    set(WDK_UCRT_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/ucrt")
+    set(WDK_SHARED_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared")
+    set(WDK_UM_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um")
+    set(WDK_IDDCX_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um/iddcx/${IDDCX_VERSION_MAJOR}.${IDDCX_VERSION_MINOR}")
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_WDF_DIR}"
+        "${WDK_WINRT_DIR}"
+        "${WDK_UCRT_DIR}"
+        "${WDK_SHARED_DIR}"
+        "${WDK_UM_DIR}"
+        "${WDK_IDDCX_DIR}")
+
+    message(STATUS "WDK_WDF_DIR: ${WDK_WDF_DIR}")
+    message(STATUS "WDK_WINRT_DIR: ${WDK_WINRT_DIR}")
+    message(STATUS "WDK_UCRT_DIR: ${WDK_UCRT_DIR}")
+    message(STATUS "WDK_SHARED_DIR: ${WDK_SHARED_DIR}")
+    message(STATUS "WDK_UM_DIR: ${WDK_UM_DIR}")
+    message(STATUS "WDK_IDDCX_DIR: ${WDK_IDDCX_DIR}")
+
+    target_link_libraries(${_target} OneCoreUAP avrt)
+endfunction()
+
+function(kmd_wpp_preproc _target wpp_source_files source_dir scan_config_data)
+
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_TRACE_WPP_TOOL} -cfgdir:${WPP_CONFIGDIR} -odir:${source_dir} -scan:${scan_config_data} -km ${wpp_source_files}
+        VERBATIM
+    )
+
+endfunction()
+
+function(umd_wpp_preproc _target wpp_source_files source_dir scan_config_data)
+
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_TRACE_WPP_TOOL} -cfgdir:${WPP_CONFIGDIR} -odir:${source_dir} -scan:${scan_config_data} -dll ${wpp_source_files}
+        VERBATIM
+    )
+
+endfunction()
+
+function(wdk_etw_preproc _target etw_name source_dir)
+
+    # message("wpp_source_files "${wpp_source_files})    
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    # Code signing
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_ROOT}/bin/${WDK_INC_VERSION}/x64/mc.exe  -h ${source_dir} -km -r ${source_dir} -z ${etw_name} ${source_dir}/${etw_name}.xml
+        VERBATIM
+    )
+
+endfunction()

--- a/cmake/FindWDK.cmake.bak
+++ b/cmake/FindWDK.cmake.bak
@@ -1,0 +1,522 @@
+# Redistribution and use is allowed under the OSI-approved 3-clause BSD license.
+# Copyright (c) 2018 Sergey Podobry (sergey.podobry at gmail.com). All rights reserved.
+
+#.rst:
+# FindWDK
+# ----------
+#
+# This module searches for the installed Windows Development Kit (WDK) and
+# exposes commands for creating kernel drivers and kernel libraries.
+#
+# Output variables:
+# - `WDK_FOUND` -- if false, do not try to use WDK
+# - `WDK_ROOT` -- where WDK is installed
+# - `WDK_VERSION` -- the version of the selected WDK
+# - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries
+#        (default value is `0x0601` and can be changed per target or globally)
+# - `WDK_NTDDI_VERSION` -- the NTDDI_VERSION used for kernel drivers and libraries,
+#                          if not set, the value will be automatically calculated by WINVER
+#        (default value is left blank and can be changed per target or globally)
+#
+# Example usage:
+#
+#   find_package(WDK REQUIRED)
+#
+#   wdk_add_kmd_library(KmdfCppLib STATIC KMDF 1.15
+#       KmdfCppLib.h
+#       KmdfCppLib.cpp
+#       )
+#   target_include_directories(KmdfCppLib INTERFACE .)
+#
+#   wdk_add_kmd_driver(KmdfCppDriver KMDF 1.15
+#       Main.cpp
+#       )
+#   target_link_libraries(KmdfCppDriver KmdfCppLib)
+#
+
+# Thanks to yousif for this trick with the registry!
+if(DEFINED ENV{WDKContentRoot})
+    file(GLOB WDK_NTDDK_FILES
+        "$ENV{WDKContentRoot}/Include/*/km/ntddk.h" # WDK 10
+        "$ENV{WDKContentRoot}/Include/km/ntddk.h" # WDK 8.0, 8.1
+    )
+else()
+    get_filename_component(WDK_ROOT
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]"
+        ABSOLUTE)
+    # Find all ntdkk.h files, then sort for the latest.
+    file(GLOB WDK_NTDDK_FILES ${WDK_ROOT}/Include/*/km/ntddk.h)
+endif()
+
+if(WDK_NTDDK_FILES)
+    if (NOT CMAKE_VERSION VERSION_LESS 3.18.0)
+        list(SORT WDK_NTDDK_FILES COMPARE NATURAL) # sort to use the latest available WDK
+    endif()
+    list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+
+if (NOT WDK_LATEST_NTDDK_FILE)
+    return()
+endif()
+
+get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+if (NOT WDK_ROOT MATCHES ".*/[0-9][0-9.]*$") # WDK 10 has a deeper nesting level
+    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY) # go up once more
+    set(WDK_LIB_VERSION "${WDK_VERSION}")
+    set(WDK_INC_VERSION "${WDK_VERSION}")
+else() # WDK 8.0, 8.1
+    set(WDK_INC_VERSION "")
+    foreach(VERSION winv6.3 win8 win7)
+        if (EXISTS "${WDK_ROOT}/Lib/${VERSION}/")
+            set(WDK_LIB_VERSION "${VERSION}")
+            break()
+        endif()
+    endforeach()
+    set(WDK_VERSION "${WDK_LIB_VERSION}")
+endif()
+
+message(STATUS "WDK_ROOT: ${WDK_ROOT}")
+message(STATUS "WDK_VERSION: ${WDK_VERSION}")
+
+# set(ENV{PATH} "${WDK_ROOT}/bin/${WDK_VERSION}/;$ENV{PATH}")
+# message(STATUS "PATH: $ENV{PATH}")
+message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+
+find_program(WDK_TRACE_WPP_TOOL tracewpp
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_TRACE_WPP_TOOL: ${WDK_TRACE_WPP_TOOL}")
+
+find_program(WDK_INF2CATTOOL inf2cat
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_INF2CATTOOL: ${WDK_INF2CATTOOL}")
+
+find_program(WDK_STAMPINF_TOOL stampinf
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_STAMPINF_TOOL: ${WDK_STAMPINF_TOOL}")
+
+find_program(WDK_SIGNTOOL signtool
+    HINTS "${WDK_ROOT}/bin"
+    PATH_SUFFIXES
+        "${WDK_VERSION}/x64"
+        "${WDK_VERSION}/x86"
+        "x64"
+        "x86"
+    REQUIRED
+)
+message(STATUS "WDK_SIGNTOOL: ${WDK_SIGNTOOL}")
+
+get_filename_component(PACKAGE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(WDK_PFX "${PACKAGE_DIR}/TestSigning.pfx" CACHE STRING "Private key used for signing the driver")
+if(NOT EXISTS "${WDK_PFX}")
+    message(FATAL_ERROR "PFX not found: ${WDK_PFX}")
+else()
+    message(STATUS "PFX: ${WDK_PFX}")
+endif()
+
+# Windows 10 1709 by default
+# https://learn.microsoft.com/ru-ru/cpp/porting/modifying-winver-and-win32-winnt
+# https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
+set(WDK_WINVER "0x0A00" CACHE STRING "Default WINVER for WDK targets")
+set(WDK_NTDDI_VERSION "0x0A000004" CACHE STRING "Specified NTDDI_VERSION for WDK targets if needed")
+
+set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
+file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+
+# location of warning.h
+set(WDK_WARNING_H_FILE "${WDK_ROOT}/Include/${WDK_VERSION}/shared/warning.h")
+set(WDK_COMPILE_FLAGS
+        "/Zi"
+        "/W4"
+        "/WX"
+        "/diagnostics:classic"
+        "/Oy-"
+        "/GF"
+        "/Gm-"
+        "/Zp8"
+        "/GS"
+        "/Gy"
+        "/analyze-" 
+        "/fp:precise"
+        "/Zc:wchar_t-"
+        "/Zc:forScope"
+        "/Zc:inline"
+        "/GR-"
+        "/wd4603"
+        "/wd4627"
+        "/wd4986"
+        "/wd4987"
+        "/wd4996"
+        "/wd4064"
+        "/wd4366"
+        "/wd4748"
+        "/wd4047"
+        "/wd4053"
+        "/Wv:18"
+        "/FC"
+        "/errorReport:prompt"
+        "-cbstring"
+        # "-d2epilogunwind"
+        "/d1nodatetime"
+        "/d1import_no_registry"
+        "/d2AllowCompatibleILVersions"
+        "/d2Zi+"
+        "/FI${WDK_WARNING_H_FILE}"
+    )
+list(APPEND WDK_COMPILE_FLAGS "$<$<CONFIG:Debug>:/Od>;$<$<CONFIG:Rlease>:/O2>")
+# message(STATUS "WDK_COMPILE_FLAGS: " ${WDK_COMPILE_FLAGS})
+
+set(WDK_COMPILE_DEFINITIONS "WINNT=1")
+set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
+set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I\"${WDK_ROOT}/Include/${WDK_INC_VERSION}/um\"")
+if(TARGET_ARCH_X86)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
+    set(WDK_PLATFORM "x86")
+    set(INF2CAT_OS_TYPE "10_X86")
+    set(STAMPINF_ARCH_TYPE "x86")
+elseif(TARGET_ARCH_X64)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
+    set(WDK_PLATFORM "X64")
+    set(INF2CAT_OS_TYPE "10_X64")
+    set(STAMPINF_ARCH_TYPE "AMD64")
+    elseif(TARGET_ARCH_ARM64)
+    set(WDK_PLATFORM "arm64")
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_ARM64_;ARM64")
+    set(OS_TYPE "server10_arm64")
+    set(INF2CAT_OS_TYPE "server10_arm64")
+    set(STAMPINF_ARCH_TYPE "ARM64")
+else()
+        message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+# EWDK Didn't Initilzie CMAKE_SIZEOF_VOID_P
+if(NOT DEFINED CMAKE_SIZEOF_VOID_P)
+    message(WARNING  "CMAKE_SIZEOF_VOID_P Not Defined, will be inferred by WDK_PLATFORM:${WDK_PLATFORM}")
+    if(WDK_PLATFORM MATCHES 64)
+        set(CMAKE_SIZEOF_VOID_P 8)
+        else()
+        set(CMAKE_SIZEOF_VOID_P 4)
+    endif()
+endif()
+
+string(CONCAT WDK_LINK_FLAGS
+    "/machine:${WDK_PLATFORM} "
+    "/MANIFEST:NO "
+    "/PROFILE "
+    "/WX "
+    "/Driver "
+    "/OPT:REF "
+    "/OPT:ICF "
+    "/INCREMENTAL:NO "
+    "/SUBSYSTEM:NATIVE,\"10.00\" "
+    "/MERGE:\"_TEXT=.text;_PAGE=PAGE\" "
+    "/NODEFAULTLIB "
+    "/SECTION:INIT,d "
+    "/IGNORE:4198,4010,4037,4039,4065,4070,4078,4087,4089,4221,4108,4088,4218,4218,4235,4257 "
+    "/osversion:\"10.0\" " 
+    "/version:\"10.0\" " 
+    "/pdbcompress "
+    "/debugtype:pdata "
+    "/nologo "
+)
+
+# Generate imported targets for WDK lib files
+file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_LIB_VERSION}/km/${WDK_PLATFORM}/*.lib")
+foreach(LIBRARY IN LISTS WDK_LIBRARIES)
+get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
+string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
+add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
+set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
+endforeach(LIBRARY)
+unset(WDK_LIBRARIES)
+set(CMAKE_CXX_STANDARD_LIBRARIES " ")
+set(CMAKE_C_STANDARD_LIBRARIES " ")
+
+function(wdk_add_kmd_driver _target)
+
+        cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})        
+        add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
+        set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
+
+        if(DEFINED WDK_KMDF)
+            string(REPLACE "." ";" WDK_KMDF_VER_LIST ${WDK_KMDF})
+            list(GET WDK_KMDF_VER_LIST 0 KMDF_VERSION_MAJOR)
+            list(GET WDK_KMDF_VER_LIST 1 KMDF_VERSION_MINOR)
+            list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MAJOR=${KMDF_VERSION_MAJOR}")
+            list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MINOR=${KMDF_VERSION_MINOR}")
+        endif()
+
+        list(APPEND WDK_COMPILE_FLAGS "/kernel")
+        # set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+
+        target_compile_options(${_target} PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+        $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+        $<$<COMPILE_LANGUAGE:ASM>:${ASM_FLAGS}>
+        )
+
+        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER};WINVER=${WDK_WINVER}"
+        )
+        # link parameter
+        set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+        set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/kernel ")
+
+        if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+        endif()
+        
+        target_include_directories(${_target} PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km/crt"
+        )
+        
+        target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWFASTFAILK WDK::WMILIB WDK::WPPRECORDER WDK::BUFFEROVERFLOWFASTFAILK) 
+        
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            target_link_libraries(${_target} WDK::MEMCMP)
+        endif()
+        
+        if(${WDK_PLATFORM} STREQUAL "arm64")
+            target_link_libraries(${_target} "${WDK_ROOT}/Lib/${WDK_INC_VERSION}/um/${WDK_PLATFORM}/arm64rt.lib")
+        endif()
+
+        if(DEFINED WDK_KMDF)
+            target_include_directories(${_target} PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+            target_link_libraries(${_target}
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
+            )
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
+            endif()
+        else()
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
+            endif()
+        endif()
+    
+    # copy inf
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_target}.inx ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${_target}.inf
+        VERBATIM
+    )
+    #timestamp inf stage
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${WDK_STAMPINF_TOOL}  -a ${STAMPINF_ARCH_TYPE} -v "*" -k "1.15"  -d "*" -x -f "${CMAKE_CURRENT_BINARY_DIR}\\$<CONFIG>\\${_target}.inf"
+        VERBATIM
+        )
+    # #inf2cat stage
+    # add_custom_command(
+    #     TARGET ${_target} POST_BUILD
+    #     COMMAND ${WDK_INF2CATTOOL}  /os:${INF2CAT_OS_TYPE} /driver:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+    #     VERBATIM
+    # )
+    # Code signing
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND "${WDK_SIGNTOOL}" sign /fd SHA256 /f "${WDK_PFX}" "$<TARGET_FILE:${_target}>"
+        VERBATIM
+    )
+endfunction()
+
+function(wdk_add_kmd_library _target)
+
+    cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+    message(STATUS "Target: " ${_target})
+    message(STATUS "WDK_KMDF: " ${WDK_KMDF})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    if(DEFINED WDK_KMDF)
+        string(REPLACE "." ";" WDK_KMDF_VER_LIST ${WDK_KMDF})
+        list(GET WDK_KMDF_VER_LIST 0 KMDF_VERSION_MAJOR)
+        list(GET WDK_KMDF_VER_LIST 1 KMDF_VERSION_MINOR)
+        list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MAJOR=${KMDF_VERSION_MAJOR}")
+        list(APPEND WDK_COMPILE_DEFINITIONS "KMDF_VERSION_MINOR=${KMDF_VERSION_MINOR}")
+    endif()
+
+
+    list(APPEND WDK_COMPILE_FLAGS "/kernel")
+    # set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    target_compile_options(${_target} PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp ${ASM_FLAGS}>
+    )
+
+    set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS
+    "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER};WINVER=${WDK_WINVER}"
+    )
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/km/crt"
+        )
+
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+    endif()
+endfunction()
+
+function(wdk_add_umd_library _target)
+
+    cmake_parse_arguments(WDK "" "UMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+    message(STATUS "Target: " ${_target})
+    message(STATUS "WDK_UMDF: " ${WDK_UMDF})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    if(DEFINED WDK_UMDF)
+        string(REPLACE "." ";" WDK_UMDF_VER_LIST ${WDK_UMDF})
+        list(GET WDK_UMDF_VER_LIST 0 UMDF_VERSION_MAJOR)
+        list(GET WDK_UMDF_VER_LIST 1 UMDF_VERSION_MINOR)
+    endif()
+
+    list(APPEND WDK_COMPILE_DEFINITIONS "UMDF_VERSION_MAJOR=${UMDF_VERSION_MAJOR}")
+    list(APPEND WDK_COMPILE_DEFINITIONS "UMDF_VERSION_MINOR=${UMDF_VERSION_MINOR}")
+
+    target_compile_options(${_target} PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${C_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${CXX_DEFS} ${WDK_COMPILE_FLAGS}>
+    $<$<COMPILE_LANGUAGE:ASM>: ${ASM_FLAGS}>
+    )
+
+    set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS
+    "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER}"
+    )
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/winrt"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/ucrt"
+        "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um"
+        )
+
+    if(DEFINED WDK_UMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/umdf/${WDK_UMDF}")
+    endif()
+endfunction()
+
+function(wdk_add_usermode_driver _target)
+    cmake_parse_arguments(WDK "" "UMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
+
+    message(STATUS "UMDF_VERSION_MAJOR: ${UMDF_VERSION_MAJOR}")
+    message(STATUS "WDK_UMDF: " ${WDK_UMDF})
+    message(STATUS "UMDF_VERSION_MAJOR : " ${UMDF_VERSION_MAJOR})
+    message(STATUS "WDK_WINVER: " ${WDK_WINVER})
+    message(STATUS "WDK_NTDDI_VERSION: " ${WDK_NTDDI_VERSION})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    set_target_properties(${_target} PROPERTIES SUFFIX ".dll")
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "/Gz")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};_WIN32_WINNT=${WDK_WINVER};NTDDI_VERSION=${WDK_NTDDI_VERSION}")
+    set_target_properties(${_target} PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
+
+    set(WDK_WDF_DIR "${WDK_WDF_ROOT}/wdf/umdf/${WDK_UMDF}")
+    set(WDK_WINRT_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/winrt")
+    set(WDK_UCRT_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/ucrt")
+    set(WDK_SHARED_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/shared")
+    set(WDK_UM_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um")
+    set(WDK_IDDCX_DIR "${WDK_ROOT}/Include/${WDK_INC_VERSION}/um/iddcx/${IDDCX_VERSION_MAJOR}.${IDDCX_VERSION_MINOR}")
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_WDF_DIR}"
+        "${WDK_WINRT_DIR}"
+        "${WDK_UCRT_DIR}"
+        "${WDK_SHARED_DIR}"
+        "${WDK_UM_DIR}"
+        "${WDK_IDDCX_DIR}")
+
+    message(STATUS "WDK_WDF_DIR: ${WDK_WDF_DIR}")
+    message(STATUS "WDK_WINRT_DIR: ${WDK_WINRT_DIR}")
+    message(STATUS "WDK_UCRT_DIR: ${WDK_UCRT_DIR}")
+    message(STATUS "WDK_SHARED_DIR: ${WDK_SHARED_DIR}")
+    message(STATUS "WDK_UM_DIR: ${WDK_UM_DIR}")
+    message(STATUS "WDK_IDDCX_DIR: ${WDK_IDDCX_DIR}")
+
+    target_link_libraries(${_target} OneCoreUAP avrt)
+endfunction()
+
+function(kmd_wpp_preproc _target wpp_source_files source_dir scan_config_data)
+
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_TRACE_WPP_TOOL} -cfgdir:${WPP_CONFIGDIR} -odir:${source_dir} -scan:${scan_config_data} -km ${wpp_source_files}
+        VERBATIM
+    )
+
+endfunction()
+
+function(umd_wpp_preproc _target wpp_source_files source_dir scan_config_data)
+
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    # Code signing
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_TRACE_WPP_TOOL} -cfgdir:${WPP_CONFIGDIR} -odir:${source_dir} -scan:${scan_config_data} -dll ${wpp_source_files}
+        VERBATIM
+    )
+
+endfunction()
+
+function(wdk_etw_preproc _target etw_name source_dir)
+
+    # message("wpp_source_files "${wpp_source_files})    
+    set(WPP_CONFIGDIR ${WDK_ROOT}/bin/${WDK_INC_VERSION}/WppConfig/Rev1)
+    # Code signing
+    add_custom_command(
+        TARGET ${_target} PRE_BUILD
+        COMMAND ${WDK_ROOT}/bin/${WDK_INC_VERSION}/x64/mc.exe  -h ${source_dir} -km -r ${source_dir} -z ${etw_name} ${source_dir}/${etw_name}.xml
+        VERBATIM
+    )
+
+endfunction()

--- a/cmake/LKM.cmake
+++ b/cmake/LKM.cmake
@@ -1,0 +1,63 @@
+#
+# Linux Kernel Module Builder
+#
+
+# set the kernel build directory
+set(KERNEL_DIR "/lib/modules/${CMAKE_HOST_SYSTEM_VERSION}/build")
+
+message(STATUS "KERNEL_VERSION: ${CMAKE_HOST_SYSTEM_VERSION}")
+message(STATUS "KERNEL_DIR: ${KERNEL_DIR}")
+
+
+function(lkm_add_driver)
+    cmake_parse_arguments(LKM "" "NAME" "" ${ARGN})
+
+    # validate the module name
+    if(NOT LKM_NAME)
+        message(FATAL_ERROR "You should give a name to the module")
+        return()
+    else()
+        string(TOLOWER ${LKM_NAME} MODULE_NAME)
+    endif()
+
+    # set the Kbuild command and file path
+    set(KBUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C ${KERNEL_DIR} M=${CMAKE_BINARY_DIR} src=${CMAKE_SOURCE_DIR}/HEVD/${CMAKE_SYSTEM_NAME})
+    
+    set(KBUILD_FILE_PATH "${CMAKE_SOURCE_DIR}/HEVD/${CMAKE_SYSTEM_NAME}/Kbuild")
+
+    # delete the obsolete Kbuild file if exists
+    if(EXISTS ${KBUILD_FILE_PATH})
+        message(STATUS "Deleting obsolete Kbuild: ${KBUILD_FILE_PATH}")
+        file(REMOVE ${KBUILD_FILE_PATH})
+    endif()
+
+    # add the source object files to the Kbuild file
+    foreach(MODULE_SOURCE_FILE ${LKM_UNPARSED_ARGUMENTS})
+        get_filename_component(SOURCE_FILE ${MODULE_SOURCE_FILE} NAME_WE)
+        file(APPEND ${KBUILD_FILE_PATH} "${MODULE_NAME}-m += ${SOURCE_FILE}.o\n")
+    endforeach()
+
+    file(APPEND ${KBUILD_FILE_PATH} "obj-m += ${MODULE_NAME}.o\n")
+
+    # disable -Wframe-larger-than= warning in GCC
+    file(APPEND ${KBUILD_FILE_PATH} "ccflags-y := -Wframe-larger-than=65535\n")
+
+    # if we are building secure version, then set the flag
+    if(SECURE)
+        file(APPEND ${KBUILD_FILE_PATH} "ccflags-y += -DSECURE\n")
+    endif()
+
+    message(STATUS "Wrote new Kbuild: ${KBUILD_FILE_PATH}")
+
+    # set the output module path
+    set(MODULE_BIN_FILE "${CMAKE_BINARY_DIR}/${MODULE_NAME}.ko")
+    
+    add_custom_target(
+        ${MODULE_NAME}
+        ALL COMMAND ${KBUILD_COMMAND} modules
+        COMMENT "Compiling Linux Kernel Module: ${MODULE_BIN_FILE}"
+    )
+
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${KBUILD_FILE_PATH} ${CMAKE_BINARY_DIR})
+    
+endfunction()

--- a/cmake/TestSigning.txt
+++ b/cmake/TestSigning.txt
@@ -1,0 +1,9 @@
+References:
+- https://learn.microsoft.com/en-us/windows-hardware/drivers/install/creating-test-certificates
+- https://stackoverflow.com/questions/9506671/why-do-i-keep-getting-a-failed-when-trying-to-make-a-cer-for-testing
+
+Commands:
+
+makecert -sv TestSigning.pvk -n "CN=TestSigning" TestSigning.cer -b 01/01/2023 -e 01/01/2050 -eku 1.3.6.1.5.5.7.3.3 -r
+pvk2pfx -pvk TestSigning.pvk -spc TestSigning.cer -pfx TestSigning.pfx
+del TestSigning.pvk TestSigning.cer

--- a/cmake/msvc-configurations.cmake
+++ b/cmake/msvc-configurations.cmake
@@ -1,0 +1,8 @@
+# Set up a more familiar Visual Studio configuration
+# Override these options with -DCMAKE_OPTION=Value
+#
+# See: https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG:FULL /INCREMENTAL:NO" CACHE STRING "")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "/DEBUG:FULL /INCREMENTAL:NO" CACHE STRING "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")


### PR DESCRIPTION
1. support kmd and umd lib, unitest building
2. support X86 native building and cross compile building
3. support both ewdk and ddk

extra components:
1. cmake module (https://cmake.org/)
2. ninja module (https://ninja-build.org/)
Please put these two modules be searchable under PATH env
