### PR TITLE
Merge20241212

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.147
+// DMF Release: v1.1.148
 //
 
-#define DMF_VERSION 0x01010093
+#define DMF_VERSION 0x01010094
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
+++ b/Dmf/Framework/DmfIncludes_KERNEL_MODE.h
@@ -133,6 +133,22 @@ Environment:
 //
 #define IS_WIN10_21H2_OR_LATER (NTDDI_WIN10_CO && (NTDDI_VERSION >= NTDDI_WIN10_CO))
 
+// Check that the Windows version is 22H2 or EARLIER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_22H2_OR_EARLIER (!(NTDDI_WIN10_NI && (NTDDI_VERSION > NTDDI_WIN10_NI)))
+
+// Check that the Windows version is 22H2 or LATER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN10_22H2_OR_LATER (NTDDI_WIN10_NI && (NTDDI_VERSION >= NTDDI_WIN10_NI))
+
+// Check that the Windows version is 24H2 or EARLIER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN11_24H2_OR_EARLIER (!(NTDDI_WIN11_GE && (NTDDI_VERSION > NTDDI_WIN11_GE)))
+
+// Check that the Windows version is 24H2 or LATER. The supported versions are defined in sdkddkver.h.
+//
+#define IS_WIN11_24H2_OR_LATER (NTDDI_WIN11_GE && (NTDDI_VERSION >= NTDDI_WIN11_GE))
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // All include files needed by all Modules and the Framework.

--- a/Dmf/Modules.Library/Dmf_BufferQueue.h
+++ b/Dmf/Modules.Library/Dmf_BufferQueue.h
@@ -132,6 +132,16 @@ DMF_BufferQueue_EnqueueAtHead(
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_BufferQueue_EnqueueWithTimer(
+    _In_ DMFMODULE DmfModule,
+    _In_ VOID* ClientBuffer,
+    _In_ ULONGLONG TimerExpirationMilliseconds,
+    _In_ EVT_DMF_BufferPool_TimerCallback* TimerExpirationCallback,
+    _In_opt_ VOID* TimerExpirationCallbackContext
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DMF_BufferQueue_Enumerate(
     _In_ DMFMODULE DmfModule,

--- a/Dmf/Modules.Library/Dmf_BufferQueue.md
+++ b/Dmf/Modules.Library/Dmf_BufferQueue.md
@@ -247,6 +247,39 @@ ClientBuffer | The given DMF_BufferQueue buffer to add to the list.
 
 * ClientBuffer *must* have been previously retrieved from the same instance of DMF_BufferQueue because the buffer must have the appropriate metadata which is stored with ClientBuffer. Buffers allocated by the Client using ExAllocatePool() or WdfMemoryCreate() may not be added Module's list using this API.
 
+* ##### DMF_BufferQueue_EnqueueWithTimer
+
+Adds a given DMF_BufferQueue buffer to an instance of DMF_BufferQueue's Consumer (at the end). A given timer value specifies that if the buffer is still in the list after the timeout expires, the buffer should be removed, and a given callback called so that the Client knows that the given buffer is being removed.
+```
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS
+DMF_BufferQueue_EnqueueWithTimer(
+  _In_ DMFMODULE DmfModule,
+  _In_ VOID* ClientBuffer,
+  _In_ ULONGLONG TimerExpirationMilliseconds,
+  _In_ EVT_DMF_BufferPool_TimerCallback* TimerExpirationCallback,
+  _In_opt_ VOID* TimerExpirationCallbackContext
+  );
+```
+
+##### Parameters
+Parameter | Description.
+----|----
+DmfModule | An open DMF_BufferQueue Module handle.
+ClientBuffer | The given DMF_BufferQueue buffer to add to the list.
+TimerExpirationMilliseconds | The given timeout value which indicates how long the buffer will remain in the list before being automatically removed.
+TimerExpirationCallback | The given callback that is called when the given buffer is automatically removed from the list. Race conditions associated with the removal are properly handled.
+TimerExpirationCallbackContext | The context that is sent to TimerExpirationCallback so the Client can perform Client specific operations due to the automatic removal of the given buffer from DMF_BufferPool.
+
+##### Returns
+
+NTSTATUS
+
+##### Remarks
+
+* ClientBuffer *must* have been previously retrieved from the same instance of DMF_BufferQueue because the buffer must have the appropriate metadata which is stored with ClientBuffer. Buffers allocated by the Client using ExAllocatePool() or WdfMemoryCreate() may not be added Module's list using this API.
+* TimerExpirationCallback must be assigned otherwise the function will fail.
+
 ##### DMF_BufferQueue_Enumerate
 
 ````

--- a/Dmf/Modules.Library/Dmf_IoctlHandler.h
+++ b/Dmf/Modules.Library/Dmf_IoctlHandler.h
@@ -167,6 +167,20 @@ DECLARE_DMF_MODULE(IoctlHandler)
 //
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_IoctlHandler_IoctlChain(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFQUEUE Queue,
+    _In_ WDFREQUEST Request,
+    _In_ ULONG IoctlCode,
+    _In_reads_(InputBufferSize) VOID* InputBuffer,
+    _In_ size_t InputBufferSize,
+    _Out_writes_(OutputBufferSize) VOID* OutputBuffer,
+    _In_ size_t OutputBufferSize,
+    _Out_ size_t* BytesReturned
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 DMF_IoctlHandler_IoctlStateSet(
     _In_ DMFMODULE DmfModule,

--- a/Dmf/Modules.Library/Dmf_IoctlHandler.md
+++ b/Dmf/Modules.Library/Dmf_IoctlHandler.md
@@ -173,7 +173,7 @@ InputBuffer | The Request's input buffer, if any.
 InputBufferSize | The size of the Request's input buffer.
 OutputBuffer | The Request's output buffer, if any.
 OutputBufferSize | The size of the Request's output buffer.
-BytesReturned | The number of bytes returned to the caller. Indicates the number of bytes transferred usually. __IMPORTANT: Set *BytesReturned to zero when the Request is NOT completed by this callback. If the callback returns STATUS_PENDING, the number of bytes returned can be set when the Client completes the Request using `WdfRequestCompleteWithInformation()`. If STATUS_PENDING is returned, do not store BytesReturned and write to it when Request is completed.__
+BytesReturned | The number of bytes returned to the caller. Indicates the number of bytes transferred usually. **IMPORTANT**: Set *BytesReturned to zero when the Request is NOT completed by this callback. If the callback returns STATUS_PENDING, the number of bytes returned can be set when the Client completes the Request using `WdfRequestCompleteWithInformation()`. If STATUS_PENDING is returned, do not store BytesReturned and write to it when Request is completed.__
 
 ##### Remarks
 
@@ -236,7 +236,50 @@ ReferenceStringUnicodePointer | Indicates the Reference String corresponding to 
 
 #### Module Methods
 
-##### DMF_IoctlHandler_IoctlsEnable
+##### DMF_IoctlHandler_IoctlChain
+
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+NTSTATUS
+DMF_IoctlHandler_IoctlChain(
+    _In_ DMFMODULE DmfModule,
+    _In_ WDFQUEUE Queue,
+    _In_ WDFREQUEST Request,
+    _In_ ULONG IoctlCode,
+    _In_reads_(InputBufferSize) VOID* InputBuffer,
+    _In_ size_t InputBufferSize,
+    _Out_writes_(OutputBufferSize) VOID* OutputBuffer,
+    _In_ size_t OutputBufferSize,
+    _Out_ size_t* BytesReturned
+    )
+````
+Allows Client to send an IOCTL to a Dynamic Module. Dynamic Modules do not receive WDF calls directly. In rare cases, a Dynamic Module may have a child IoctlHandler. In that case,
+this Method is used to route calls from a Parent Module to the Child Module.
+
+##### Returns
+
+None
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_IoctlHandler Module handle.
+Queue | Parameter passed to this Method's caller that must be passed to target Module.
+Request |  Parameter passed to this Method's caller that must be passed to target Module.
+IoctlCode | Parameter passed to this Method's caller that must be passed to target Module.
+InputBuffer | Parameter passed to this Method's caller that must be passed to target Module.
+InputBufferSize | Parameter passed to this Method's caller that must be passed to target Module.
+OutputBuffer | Parameter passed to this Method's caller that must be passed to target Module.
+OutputBufferSize | Parameter passed to this Method's caller that must be passed to target Module.
+BytesReturned | Parameter passed to this Method's caller that must be passed to target Module.
+
+##### Remarks
+
+* **IMPORTANT:** Table entries for Child Module must be in Parent Module for buffer size validation. Use the exact same entries but with a different callback to the Parent Module which then calls this Method.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+##### DMF_IoctlHandler_IoctlStateSet
 
 ````
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -250,7 +293,7 @@ Allows Client to enable / disable the device interface set in the Module's Confi
 
 ##### Returns
 
-None
+NTSTATUS
 
 ##### Parameters
 Parameter | Description

--- a/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.h
+++ b/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.h
@@ -57,6 +57,10 @@ typedef struct
     // Use automatic time stamping.
     //
     BOOLEAN TimeStamping;
+    // Allows more buffers for pending data to be automatically allocated
+    // if buffers run out too fast.
+    //
+    BOOLEAN EnableLookAside;
 } DMF_CONFIG_NotifyUserWithRequest;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.md
+++ b/Dmf/Modules.Library/Dmf_NotifyUserWithRequest.md
@@ -39,6 +39,10 @@ typedef struct
     // Use automatic time stamping.
     //
     BOOLEAN TimeStamping;
+    // Allows more buffers for pending data to be automatically allocated
+    // if buffers run out too fast.
+    //
+    BOOLEAN EnableLookAside;
 } DMF_CONFIG_NotifyUserWithRequest;
 ````
 Member | Description
@@ -50,6 +54,7 @@ EvtPendingRequestsCancel | The callback that is called Requests are canceled.
 ClientDriverProviderName | Used for Event Logging purposes if the Client has this capability.
 EvtDataCleanup | Callback to process queued data before it is flushed.
 TimeStamping | If TRUE, this Module timestamps enqueued requests and data buffers.
+EnableLookAside | Set to TRUE to allow more data buffers than pending requests. **Important: See Remarks.**
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -348,6 +353,7 @@ Request | The given request passed in the callback.
 * The Producer contains empty buffers that can be retrieved and written to.
 * After the buffers from Producer are written to, they are put in the Consumer. The Consumer is, essentially, a list of pending work.
 * After buffers are removed from Producer and the corresponding work is done, they are added back to the Producer.
+* **Important:** Use caution with EnableLookAside. If the consumer of data buffers does not run, and data buffers are generated indefinitely, all the memory can be used up. Use this option only when relatively few data buffers can ever be added.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Merge20241212
1. Correct a race condidition in NotifyUserWithRequest. (If a single Request is available but it is completed after it is has started to be populated, the data that could not be put in the request is lost.) It is hard to hit this race condition, but it is possible under stress conditions or when there are very few requests available for incomming data.
1. Add support for loading IoctlHandler dynamically. Now any Module that does not support plug and play WDF callbacks can be loaded dynamically. Previously any Module that supported any WDF callbacks was prevented from loading dynamically.
3. Add DMF_BufferQueue_EnqueueWithTimer() and update unit tests to support it.