### PR TITLE
Merge20250305

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.149
+// DMF Release: v1.1.150
 //
 
-#define DMF_VERSION 0x01010095
+#define DMF_VERSION 0x01010096
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -884,7 +884,7 @@ DeviceInterfaceTarget_Target_ReuseCreate(
 
     DmfAssert(! moduleContext->OpenedInStreamMode);
 
-    ntStatus = DMF_RequestTarget_ReuseCreate(moduleContext->DmfModuleContinuousRequestTarget,
+    ntStatus = DMF_RequestTarget_ReuseCreate(moduleContext->DmfModuleRequestTarget,
                                              DmfRequestIdReuse);
 
     return ntStatus;


### PR DESCRIPTION
Merge20250305
1. Fix incorrect handle passed by DMF_DeviceInterfaceTarget_ReuseCreate(). Add test for that family of APIs.
2. Add missing unit tests for DeviceInterfaceTarget.