### PR TITLE
Fixed warning C4100

### DIFF
--- a/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
+++ b/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
@@ -914,6 +914,10 @@ Return Value:
                                                                                                                                         MobileBroadbandTransmissionStateChangedEventArgs args)
     {
         NTSTATUS ntStatus;
+
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(args);
+
         // Bug inside C++/WinRT SarManager. This event can still be called even if modem is gone.
         // Need to use DMF_ModuleReference() to protect.
         //
@@ -1035,6 +1039,10 @@ Return Value:
                                                                                                                          MobileBroadbandSlotInfoChangedEventArgs args)
     {
         NTSTATUS ntStatus;
+
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(args);
+
         ntStatus = DMF_ModuleReference(DmfModule);
         if (!NT_SUCCESS(ntStatus))
         {


### PR DESCRIPTION
Current master doesn't build due to leftover warnings:

```text
1>D:\Development\GitHub\dshidmini\DMF\Dmf\Modules.Library\Dmf_MobileBroadband.cpp(918,5): error C2220: the following warning is treated as an error
1>D:\Development\GitHub\dshidmini\DMF\Dmf\Modules.Library\Dmf_MobileBroadband.cpp(918,5): warning C4100: 'sender': unreferenced parameter
```

This PR fixes those issues.