### PR TITLE
Merge20250522

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.152
+// DMF Release: v1.1.153
 //
 
-#define DMF_VERSION 0x01010098
+#define DMF_VERSION 0x01010099
 
 // eof: DmfVersion.h
 //

--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.149
+// DMF Release: v1.1.150
 //
 
-#define DMF_VERSION 0x01010095
+#define DMF_VERSION 0x01010096
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_IoctlHandler.c
@@ -599,6 +599,9 @@ Return Value:
             sleepRequestBufferInput = (Tests_IoctlHandler_Sleep*)InputBuffer;
             sleepRequestBufferOutput = (Tests_IoctlHandler_Sleep*)OutputBuffer;
 
+            // ' Using uninitialized memory '*OutputBuffer''
+            //
+            #pragma warning(suppress: 6001)
             RtlCopyMemory(sleepRequestBufferInput,
                           sleepRequestBufferOutput,
                           sizeof(Tests_IoctlHandler_Sleep));

--- a/Dmf/Modules.Library/Dmf_BufferPool.c
+++ b/Dmf/Modules.Library/Dmf_BufferPool.c
@@ -1294,8 +1294,8 @@ Return Value:
     {
         DmfAssert(moduleConfig->Mode.SourceSettings.BufferSize > 0);
 
-        // Each buffer allocated in the look aside list and contains components that are asigned
-        // in the bffer as described below.
+        // Each buffer allocated in the look aside list and contains components that are assigned
+        // in the buffer as described below.
         // 
         // +----------------+---------------+---------------+----------------+------------------+
         // | Entry Metadata | Client Buffer | Data Sentinel | Buffer Context | Context Sentinel |
@@ -1316,7 +1316,7 @@ Return Value:
                                               MEMORY_ALLOCATION_ALIGNMENT);
         sentinelSizeAligned = WDF_ALIGN_SIZE_UP(BufferPool_SentinelSize,
                                                 MEMORY_ALLOCATION_ALIGNMENT);
-        bufferContextSizeAligned = WDF_ALIGN_SIZE_UP(moduleConfig->Mode.SourceSettings.BufferSize,
+        bufferContextSizeAligned = WDF_ALIGN_SIZE_UP(moduleConfig->Mode.SourceSettings.BufferContextSize,
                                                      MEMORY_ALLOCATION_ALIGNMENT);
 
         sizeOfEachAllocation = bufferPoolEntrySizeAligned +

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.c
@@ -884,7 +884,7 @@ DeviceInterfaceTarget_Target_ReuseCreate(
 
     DmfAssert(! moduleContext->OpenedInStreamMode);
 
-    ntStatus = DMF_RequestTarget_ReuseCreate(moduleContext->DmfModuleContinuousRequestTarget,
+    ntStatus = DMF_RequestTarget_ReuseCreate(moduleContext->DmfModuleRequestTarget,
                                              DmfRequestIdReuse);
 
     return ntStatus;

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.h
@@ -71,6 +71,19 @@ EVT_DMF_DeviceInterfaceTarget_OnPnpNotification(_In_ DMFMODULE DmfModule,
                                                 _In_ PUNICODE_STRING SymbolicLinkName,
                                                 _Out_ BOOLEAN* IoTargetOpen);
 
+#if defined(DMF_USER_MODE)
+// Client callback for custom device handle notifications user mode.
+//
+typedef
+_Function_class_(EVT_DMF_DeviceInterfaceTarget_OnPnpCustomNotificationUser)
+_IRQL_requires_max_(PASSIVE_LEVEL)
+DWORD
+EVT_DMF_DeviceInterfaceTarget_OnPnpCustomNotificationUser(_In_ DMFMODULE DmfModule,
+                                                          _In_ CM_NOTIFY_ACTION Action,
+                                                          _In_reads_bytes_(EventDataSize) PCM_NOTIFY_EVENT_DATA EventData,
+                                                          _In_ DWORD EventDataSize);
+#endif // defined(DMF_USER_MODE)
+
 // Client uses this structure to configure the Module specific parameters.
 //
 typedef struct
@@ -98,6 +111,11 @@ typedef struct
     // Callback to notify Interface arrival.
     //
     EVT_DMF_DeviceInterfaceTarget_OnPnpNotification* EvtDeviceInterfaceTargetOnPnpNotification;
+#if defined(DMF_USER_MODE)
+    // Callback to notify pnp custom event for user mode.
+    //
+    EVT_DMF_DeviceInterfaceTarget_OnPnpCustomNotificationUser* EvtPnpCustomNotificationCallbackUser;
+#endif // defined(DMF_USER_MODE)
 } DMF_CONFIG_DeviceInterfaceTarget;
 
 // This macro declares the following functions:

--- a/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
+++ b/Dmf/Modules.Library/Dmf_DeviceInterfaceTarget.md
@@ -47,6 +47,7 @@ ShareAccess | The Share Access mask used when opening the underlying WDFIOTARGET
 ContinuousRequestTargetModuleConfig | Contains the settings for the underlying RequesetStream.
 EvtDeviceInterfaceTargetOnStateChange | Callback to the Client that indicates the state of the target has changed.
 EvtDeviceInterfaceTargetOnPnpNotification | Callback to the Client that allows the Client to indicate if the target should open.
+EvtPnpCustomNotificationCallbackUser | Callback to the Client for user mode that allows the Client to be notify of pnp custom event.
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
@@ -160,6 +161,34 @@ IoTargetOpen | The address where the Client writes TRUE to indicate that the WDF
 ##### Remarks
 
 * See DMF_ContinuousRequestTarget.
+
+##### EVT_DMF_DeviceInterfaceTarget_OnPnpCustomNotificationUser
+````
+_IRQL_requires_max_(PASSIVE_LEVEL)
+_IRQL_requires_same_
+VOID
+EVT_DMF_DeviceInterfaceTarget_OnPnpCustomNotificationUser(
+    _In_ DMFMODULE DmfModule,
+    _In_ CM_NOTIFY_ACTION Action,
+    _In_reads_bytes_(EventDataSize) PCM_NOTIFY_EVENT_DATA EventData,
+    _In_ DWORD EventDataSize
+    );
+````
+
+ Callback to the Client for user mode that allows the Client to be notify of pnp custom event.
+
+##### Parameters
+Parameter | Description
+----|----
+DmfModule | An open DMF_DeviceInterfaceTarget Module handle.
+Action | IType of CM_NOTIFY_ACTION.
+EventData | Custom event data associated with the event.
+EventDataSize | Size of EventData.
+
+##### Remarks
+
+* This only available in user mode.
+
 
 -----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
+++ b/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
@@ -1039,6 +1039,10 @@ Return Value:
                                                                                                                          MobileBroadbandSlotInfoChangedEventArgs args)
     {
         NTSTATUS ntStatus;
+
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(args);
+
         ntStatus = DMF_ModuleReference(DmfModule);
         if (!NT_SUCCESS(ntStatus))
         {

--- a/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
+++ b/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
@@ -914,6 +914,10 @@ Return Value:
                                                                                                                                         MobileBroadbandTransmissionStateChangedEventArgs args)
     {
         NTSTATUS ntStatus;
+
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(args);
+
         // Bug inside C++/WinRT SarManager. This event can still be called even if modem is gone.
         // Need to use DMF_ModuleReference() to protect.
         //


### PR DESCRIPTION
Merge20250522
1. Fix BufferContextSize issue. Wrong size was used. This is potentially a serious issue if buffer context is used. However, it is rarely used.
2. Fix compilation errors due to SAL.
3. Add Custom Device Notification support to DMF_DeviceInterfaceTarget.
4. Fix additional SAL issues.