### PR TITLE
Merge20251121

### DIFF
--- a/Dmf/DmfVersion.h
+++ b/Dmf/DmfVersion.h
@@ -4,10 +4,10 @@
 // built using DMF.
 //
 
-// DMF Release: v1.1.155
+// DMF Release: v1.1.156
 //
 
-#define DMF_VERSION 0x0101009B
+#define DMF_VERSION 0x0101009C
 
 // eof: DmfVersion.h
 //

--- a/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
+++ b/Dmf/Modules.Library.Tests/Dmf_Tests_DeviceInterfaceMultipleTarget.c
@@ -430,7 +430,7 @@ Return Value:
                                                                    0,
                                                                    &bytesWritten);
     TraceEvents(TRACE_LEVEL_INFORMATION, DMF_TRACE, "MT01:dmfModule=0x%p sleepIoctlBuffer->TimeToSleepMilliseconds=%ld SyncComplete", InstanceToSendTo, sleepIoctlBuffer.TimeToSleepMilliseconds);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     // TODO: Get time and compare with send time.
     //
 }
@@ -798,7 +798,7 @@ Return Value:
                                                       timeoutMs,
                                                       Tests_DeviceInterfaceMultipleTarget_SendCompletion,
                                                       sleepIoctlBuffer);
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
 }
 #pragma code_seg()
 
@@ -1032,7 +1032,7 @@ Return Value:
                                                         sleepIoctlBuffer,
                                                         &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1096,7 +1096,7 @@ Return Value:
                                                         sleepIoctlBuffer,
                                                         &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1157,7 +1157,7 @@ Return Value:
                                                         sleepIoctlBuffer,
                                                         &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1200,7 +1200,7 @@ Return Value:
                                                         sleepIoctlBuffer,
                                                         &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1259,7 +1259,7 @@ Return Value:
                                                         sleepIoctlBuffer,
                                                         &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1385,7 +1385,7 @@ Return Value:
                                                            sleepIoctlBuffer,
                                                            &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1455,7 +1455,7 @@ Return Value:
                                                            sleepIoctlBuffer,
                                                            &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1522,7 +1522,7 @@ Return Value:
                                                            sleepIoctlBuffer,
                                                            &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1571,7 +1571,7 @@ Return Value:
                                                            sleepIoctlBuffer,
                                                            &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;
@@ -1636,7 +1636,7 @@ Return Value:
                                                            sleepIoctlBuffer,
                                                            &dmfRequestIdCancel);
 
-    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE));
+    DmfAssert(NT_SUCCESS(ntStatus) || (ntStatus == STATUS_CANCELLED) || (ntStatus == STATUS_INVALID_DEVICE_STATE) || (ntStatus == STATUS_DEVICE_DOES_NOT_EXIST));
     if (!NT_SUCCESS(ntStatus))
     {
         goto Exit;

--- a/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
+++ b/Dmf/Modules.Library/Dmf_MobileBroadband.cpp
@@ -217,6 +217,16 @@ Return Value:
 {
     DWORD result = 0;
     int currentPosition = 0;
+
+    if (ProviderId.empty() ||
+        StartPosition < 0 ||
+        CodeLength <= 0 ||
+        StartPosition + CodeLength > (int)ProviderId.size() ||
+        Result == nullptr)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     for (int providerIdIndex = 0; providerIdIndex < CodeLength; providerIdIndex++) 
     {
         currentPosition = providerIdIndex + StartPosition;


### PR DESCRIPTION
Merge20251121
1. Make it easier for clients to use DMF_DeviceInterfaceMultipleTarget. a) Remove callback is called prior to rundown. b) DmfIoTargets are always checked for validity prior to use in Methods. 3) Update tests for new error codes.
2. Clean up DMF_Rundown logging so that IFR log does not fill up in cases where wait is not satisfied. It helps debug since it is possible to see what happened prior to wait starting.
3. Improve DMF_MobileBroadband error checking.